### PR TITLE
fix(ci): stop baking secrets into deploy image

### DIFF
--- a/.github/workflows/ec2-deploy.yml
+++ b/.github/workflows/ec2-deploy.yml
@@ -1,5 +1,35 @@
 name: Deploy Scrapers API
 
+# Required GitHub secrets (Settings > Secrets and variables > Actions):
+#
+#   DOCKER_USERNAME            Quay.io robot account username
+#                              (e.g. gsi_cesar+ci — the "+" suffix is the
+#                              Quay.io convention for robot accounts)
+#   DOCKER_PASSWORD            Quay.io robot account token
+#   DB_URI                     MongoDB connection string
+#   PORT                       App internal port the container listens on
+#                              (host port 80 is mapped to this; the docker
+#                              run uses `-p 80:$PORT`)
+#   TIME_OUT                   Request timeout
+#   REDIS_URL                  Redis connection string
+#   BULL_BOARD_USER            Bull board basic-auth user
+#   BULL_BOARD_PASSWORD        Bull board basic-auth password
+#   BULL_ARENA_URL             Bull board mount path
+#   PRODUCT_URLS_BATCHSIZE     Scraper config
+#   PRODUCT_STORAGE_BATCHSIZE  Scraper config
+#
+# Security model
+# --------------
+# Runtime env vars are NOT baked into the Docker image. They are written
+# to a 0600 .env file on the self-hosted runner (which IS the production
+# host) and passed to the container via `--env-file`. Anyone with pull
+# access to quay.io/gsi_cesar/scrappers/main cannot extract secrets.
+#
+# Credentials: use a Quay.io robot account, not a personal password.
+# Create one at https://quay.io/organization/gsi_cesar/robots (or your
+# org's robots page), grant it write access to the `scrappers/main`
+# repository, and paste the token into DOCKER_PASSWORD.
+
 on:
   push:
     branches:
@@ -7,28 +37,20 @@ on:
     tags:
       - 'v*.*.*'
 
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: false  # never kill a deploy that is already running
+
 jobs:
   build:
-    runs-on: ubuntu-latest    
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request'
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
-
-      - name: Create .env file
-        run: |
-          echo "DB_URI=${{ secrets.DB_URI }}" >> .env
-          echo "PORT=${{ secrets.PORT }}" >> .env
-          echo "TIME_OUT=${{ secrets.TIME_OUT }}" >> .env
-          echo "REDIS_URL=${{ secrets.REDIS_URL }}" >> .env
-          echo "BULL_BOARD_USER=${{ secrets.BULL_BOARD_USER }}" >> .env
-          echo "BULL_BOARD_PASSWORD=${{ secrets.BULL_BOARD_PASSWORD }}" >> .env
-          echo "BULL_ARENA_URL=${{ secrets.BULL_ARENA_URL }}" >> .env
-          echo "PRODUCT_URLS_BATCHSIZE=${{ secrets.PRODUCT_URLS_BATCHSIZE }}" >> .env
-          echo "PRODUCT_STORAGE_BATCHSIZE=${{ secrets.PRODUCT_STORAGE_BATCHSIZE }}" >> .env  
+        uses: actions/checkout@v7
 
       - name: Build & push Docker image to Quay.io
-        if: github.event_name != 'pull_request'
-        uses: mr-smithers-excellent/docker-build-push@v6
+        uses: mr-smithers-excellent/docker-build-push@v7
         with:
           image: gsi_cesar/scrappers/main
           addLatest: true
@@ -42,21 +64,61 @@ jobs:
     if: github.event_name != 'pull_request'
     steps:
       - name: Login to Quay.io
-        run: docker login quay.io -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
+        run: docker login quay.io -u "${{ secrets.DOCKER_USERNAME }}" -p "${{ secrets.DOCKER_PASSWORD }}"
 
-      - name: Pull image from Qua.io
-        run: docker pull quay.io/gsi_cesar/scrappers/main
-
-      - name: Delete old container
-        run: docker rm -f scrapper-revolico-api || true
-
-      - name: Delete old image
+      - name: Write runtime env file
+        # Lives only on the self-hosted runner / prod host. Never copied
+        # into the image. Mode 0600 = owner read/write only.
         run: |
-            docker images --filter "reference=quay.io/gsi_cesar/scrappers/main" --format "{{.ID}}" | xargs -r docker rmi -f
+          {
+            echo "DB_URI=${{ secrets.DB_URI }}"
+            echo "PORT=${{ secrets.PORT }}"
+            echo "TIME_OUT=${{ secrets.TIME_OUT }}"
+            echo "REDIS_URL=${{ secrets.REDIS_URL }}"
+            echo "BULL_BOARD_USER=${{ secrets.BULL_BOARD_USER }}"
+            echo "BULL_BOARD_PASSWORD=${{ secrets.BULL_BOARD_PASSWORD }}"
+            echo "BULL_ARENA_URL=${{ secrets.BULL_ARENA_URL }}"
+            echo "PRODUCT_URLS_BATCHSIZE=${{ secrets.PRODUCT_URLS_BATCHSIZE }}"
+            echo "PRODUCT_STORAGE_BATCHSIZE=${{ secrets.PRODUCT_STORAGE_BATCHSIZE }}"
+          } > .env
+          chmod 600 .env
 
+      - name: Stop and remove old container
+        run: docker rm -f scrapper-revolico-api 2>/dev/null || true
 
-      - name: Run docker container
+      - name: Pull new image
+        run: docker pull quay.io/gsi_cesar/scrappers/main:latest
+
+      - name: Remove old images (keep last 2 for rollback)
         run: |
-          docker run -d -p 80:${{ secrets.PORT }} \
+          docker images --filter "reference=quay.io/gsi_cesar/scrappers/main" --format "{{.ID}} {{.CreatedAt}}" \
+            | sort -k2 -r \
+            | tail -n +4 \
+            | awk '{print $1}' \
+            | xargs -r docker rmi -f
+
+      - name: Run new container
+        run: |
+          docker run -d \
+            -p 80:${{ secrets.PORT }} \
             --network scrappers \
-            --name scrapper-revolico-api quay.io/gsi_cesar/scrappers/main
+            --env-file .env \
+            --restart unless-stopped \
+            --name scrapper-revolico-api \
+            quay.io/gsi_cesar/scrappers/main:latest
+
+      - name: Smoke test
+        # Hit /api-docs — it should return 2xx/3xx once the app is up.
+        # 60s budget covers Puppeteer warm-up, queue init, etc.
+        run: |
+          for i in $(seq 1 30); do
+            if curl -fsS -o /dev/null -w "%{http_code}" http://localhost/api-docs | grep -qE '^[23]'; then
+              echo "Smoke test passed on attempt $i"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "Smoke test FAILED: /api-docs never returned 2xx/3xx"
+          echo "--- container logs ---"
+          docker logs scrapper-revolico-api
+          exit 1

--- a/.github/workflows/ec2-deploy.yml
+++ b/.github/workflows/ec2-deploy.yml
@@ -36,6 +36,16 @@ on:
       - main
     tags:
       - 'v*.*.*'
+  # Manual deploy trigger — useful for verifying Quay.io credentials and
+  # for redeploying a specific tag without rebuilding (e.g. rollback).
+  # The image must already exist in quay.io/gsi_cesar/scrappers/main.
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: 'Docker image tag to deploy (default: latest)'
+        required: false
+        default: 'latest'
+        type: string
 
 concurrency:
   group: deploy-${{ github.ref }}
@@ -44,7 +54,8 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request'
+    # Only build on push. On workflow_dispatch we redeploy an existing image.
+    if: github.event_name == 'push'
     steps:
       - name: Checkout source
         uses: actions/checkout@v7
@@ -87,7 +98,7 @@ jobs:
         run: docker rm -f scrapper-revolico-api 2>/dev/null || true
 
       - name: Pull new image
-        run: docker pull quay.io/gsi_cesar/scrappers/main:latest
+        run: docker pull quay.io/gsi_cesar/scrappers/main:${{ inputs.image_tag || 'latest' }}
 
       - name: Remove old images (keep last 2 for rollback)
         run: |
@@ -105,7 +116,7 @@ jobs:
             --env-file .env \
             --restart unless-stopped \
             --name scrapper-revolico-api \
-            quay.io/gsi_cesar/scrappers/main:latest
+            quay.io/gsi_cesar/scrappers/main:${{ inputs.image_tag || 'latest' }}
 
       - name: Smoke test
         # Hit /api-docs — it should return 2xx/3xx once the app is up.

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,6 @@ COPY package*.json ./
 RUN npm ci --omit=dev && npm cache clean --force
 COPY --from=build /app/dist/main ./dist/main
 COPY --from=build /app/node_modules/.prisma ./node_modules/.prisma
-COPY .env ./
 
 EXPOSE 80
 


### PR DESCRIPTION
## Summary

Refactors `.github/workflows/ec2-deploy.yml` and `Dockerfile` so
runtime secrets are no longer baked into the published Docker
image. The build job no longer touches any secret; the deploy
job writes `.env` (mode 0600) on the self-hosted runner and
passes it to the container via `--env-file`.

Also adds `workflow_dispatch` so the deploy job can be triggered
manually from the Actions UI (with an optional `image_tag`
input for rollback). This makes it possible to verify the
Quay.io credentials and the new env-file-based runtime before
the first real push-to-main deploy.

## Context

The previous workflow created `.env` from GitHub secrets in the
build job, then the Dockerfile (`COPY .env ./`) baked that file
into the image at `quay.io/gsi_cesar/scrappers/main`. Anyone
with `docker pull` access could extract every secret with:

```bash
docker run --rm --entrypoint cat <image> /app/.env
```

That includes `DB_URI`, `REDIS_URL`, `BULL_BOARD_PASSWORD`,
`BULL_BOARD_USER`, etc. — a full leak of all non-`DOCKER_*`
secrets. The `DOCKER_*` secrets were safe only because they
weren't in the `.env` file (they were used during build, not
runtime).

## Changes

**`.github/workflows/ec2-deploy.yml`** (~130 lines, mostly rewritten):

- **Removed** the "Create .env file" step from the build job
- **Added** "Write runtime env file" step in the deploy job,
  output to a `0600` file on the self-hosted runner
- **Added** `--env-file .env` to the `docker run` command
- **Added** `workflow_dispatch` trigger with optional
  `image_tag` input (default `latest`) — for credential
  verification and rollback; build job is skipped on dispatch
- Bumped `actions/checkout` v4 → **v7**
- Bumped `mr-smithers-excellent/docker-build-push` v6 → **v7**
- Added `concurrency: deploy-${{ github.ref }}` with
  `cancel-in-progress: false` to prevent overlapping deploys
- Container now runs with `--restart unless-stopped`
- Image cleanup keeps the last 2 images for rollback (was:
  deleted all old images)
- Added a 60s smoke test that curls `/api-docs`; dumps
  container logs on failure
- Top-of-file comments document the required secrets and
  the Quay.io robot-account setup

**`Dockerfile`** (1 line removed):

- Dropped `COPY .env ./` — the env file is no longer baked in

## Why a self-hosted runner

The deploy job runs on `self-hosted` because the runner is the
production host — the `.env` file written from secrets stays on
the prod host, never leaves the trust boundary. A GitHub-hosted
runner would not work here (no persistent host to mount `/var`
on, plus secrets should not be written to ephemeral runners).

## How to test the PR

The CI workflow (`ci.yml`) doesn't exercise this deploy
workflow — they target different branches. The deploy
workflow runs on `main` push, `v*` tags, and `workflow_dispatch`.

### Option A — verify with `workflow_dispatch` (no push needed)

Once `DOCKER_USERNAME` / `DOCKER_PASSWORD` are updated in
GitHub UI to a Quay.io robot account:

1. Merge this PR to `develop`
2. Actions → Deploy Scrapers API → Run workflow
3. Leave `image_tag` empty (= `latest`) — uses the image
   already on Quay.io, **does not rebuild**
4. Watch the logs:
   - `docker login` must succeed
   - `docker pull quay.io/gsi_cesar/scrappers/main:latest`
     must succeed
   - Container must come up
   - Smoke test must hit `/api-docs` with 2xx/3xx

If any step fails, re-run the failed job after fixing the
underlying problem — no new commit needed.

### Option B — full push-to-main deploy

1. Update secrets in GitHub UI (Quay.io robot account)
2. Merge this PR
3. Push to `main` (or a `v0.0.0` tag) → full build + deploy
4. Verify the new image on Quay.io has no `app/.env`:
   ```bash
   docker pull quay.io/gsi_cesar/scrappers/main:latest
   docker run --rm --entrypoint ls <image> /app/.env
   # should print: ls: /app/.env: No such file or directory
   ```
5. Verify the smoke test passes in the Actions UI

## Required secret update (independent of this PR)

The 401/403 the previous deploy was throwing is a separate
problem: the stored `DOCKER_USERNAME` / `DOCKER_PASSWORD` are
a personal account. Replace them with a Quay.io robot account:

- Create robot at
  https://quay.io/organization/gsi_cesar/robots → name `ci`
  (becomes `gsi_cesar+ci`) → grant Write to `scrappers/main`
- Copy the token
- Settings → Secrets and variables → Actions →
  `DOCKER_USERNAME` = `gsi_cesar+ci`,
  `DOCKER_PASSWORD` = the token

## Related

- This PR does NOT change which secrets the workflow consumes
- The two orphan secrets (`MONGO_USER`, `MONGO_PASSWORD`) are
  not touched — they're unused by any workflow and can be
  cleaned up separately