### PR TITLE
build: upgrade Node runtime from 20 to 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ── Stage 1: build ──────────────────────────────────────────────────────
-FROM node:20-bookworm-slim AS build
+FROM node:24-bookworm-slim AS build
 WORKDIR /app
 
 # Skip Puppeteer's postinstall Chrome download (Chromium is installed in the
@@ -15,7 +15,7 @@ COPY . .
 RUN npm run build
 
 # ── Stage 2: production runtime ─────────────────────────────────────────
-FROM node:20-bookworm-slim AS production
+FROM node:24-bookworm-slim AS production
 WORKDIR /app
 
 # System deps for Chromium and the Node runtime.

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "@types/cors": "^2.8.17",
         "@types/express": "^4.17.21",
         "@types/jest": "^29.5.12",
-        "@types/node": "^22.5.2",
+        "@types/node": "^24.13.2",
         "@types/supertest": "^6.0.2",
         "@types/swagger-ui-express": "^4.1.8",
         "@types/uuid": "^10.0.0",
@@ -3732,11 +3732,12 @@
       "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g=="
     },
     "node_modules/@types/node": {
-      "version": "22.5.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.2.tgz",
-      "integrity": "sha512-acJsPTEqYqulZS/Yp/S3GgeE6GZ0qYODUR8aVr/DkhHQ8l9nd4j5x1/ZJy9/gHrRlFMqkO6i0I3E27Alu4jjPg==",
+      "version": "24.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
+      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.19.2"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/node-fetch": {
@@ -13264,9 +13265,10 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "license": "MIT"
     },
     "node_modules/universalify": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
     "@types/jest": "^29.5.12",
-    "@types/node": "^22.5.2",
+    "@types/node": "^24.13.2",
     "@types/supertest": "^6.0.2",
     "@types/swagger-ui-express": "^4.1.8",
     "@types/uuid": "^10.0.0",


### PR DESCRIPTION
## Summary

Upgrades the Node runtime from 20 to 24 across the three places it
appears: CI (`actions/setup-node`), the Docker base image
(`node:20-bookworm-slim` in both build and production stages),
and `@types/node` (`^22.5.2` → `^24.13.2`).

## Why

- **Node 20 reached EOL in April 2026** — no more security fixes.
- **GitHub Actions now warns** on every CI run that runs Node 20:
  > Node 20 is being deprecated. This workflow is running with
  > Node 24 by default.
- Node 24 is the current **active LTS** (support until April 2028).
  Node 22 is in maintenance LTS and would be a downgrade in support
  window.

## Changes

| File | Before | After |
|---|---|---|
| `.github/workflows/ci.yml` | `node-version: '20'` | `node-version: '24'` |
| `Dockerfile` (build stage) | `node:20-bookworm-slim` | `node:24-bookworm-slim` |
| `Dockerfile` (production stage) | `node:20-bookworm-slim` | `node:24-bookworm-slim` |
| `package.json` | `"@types/node": "^22.5.2"` | `"@types/node": "^24.13.2"` |
| `package-lock.json` | (regenerated) | (regenerated via `npm install`) |

## Compatibility

All runtime deps support Node 24 — verified before opening:

- `puppeteer-core@^23.11.1` ✓
- `prisma@^6.10.1` / `@prisma/client@^6.10.1` ✓
- `mongoose@^8.6.0` ✓
- `bullmq@^5.78.1` ✓
- `inversify-express-utils@^6.5.0`, `express@^4.20.0`, `jose@^6.1.0` ✓

No native module rebuilds expected — Prisma is the only native
dependency and 6.x ships prebuilt binaries for Node 24.

## Verification

Run locally on Node 24.14.1 (same major as target):

- `npm run lint` — no issues
- `npm run test` — 143/143 pass in 62s, clean exit (no Jest hang)
- `npm run build` — succeeds, no swagger drift

## Out of scope

This PR does **not** change the deploy workflow. PR #5 (just merged
to develop) added `workflow_dispatch` and the env-file-based runtime
fix. They are separate concerns, merged separately so each can be
reverted independently if needed.

## Follow-up

After this lands in `develop` and gets merged to `main`, the next
push to `main` will:
1. Pull `node:24-bookworm-slim` instead of node 20
2. Trigger the same Docker build + deploy pipeline
3. Deploy a Node 24 runtime to production

Rollback path is straightforward: revert this single commit and the
runtime goes back to Node 20.