### PR TITLE
ci(deploy): MVP gate, complete env, rename container

### DIFF
--- a/.github/workflows/ec2-deploy.yml
+++ b/.github/workflows/ec2-deploy.yml
@@ -123,7 +123,7 @@ jobs:
           chmod 600 .env
 
       - name: Stop and remove old container
-        run: docker rm -f scrapper-revolico-api 2>/dev/null || true
+        run: docker rm -f scrapper-bazaarsentinel-api 2>/dev/null || true
 
       - name: Pull new image
         run: docker pull quay.io/gsi_cesar/scrappers/main:${{ inputs.image_tag || 'latest' }}
@@ -143,7 +143,7 @@ jobs:
             --network scrappers \
             --env-file .env \
             --restart unless-stopped \
-            --name scrapper-revolico-api \
+            --name scrapper-bazaarsentinel-api \
             quay.io/gsi_cesar/scrappers/main:${{ inputs.image_tag || 'latest' }}
 
       - name: Smoke test
@@ -159,5 +159,5 @@ jobs:
           done
           echo "Smoke test FAILED: /api-docs never returned 2xx/3xx"
           echo "--- container logs ---"
-          docker logs scrapper-revolico-api
+          docker logs scrapper-bazaarsentinel-api
           exit 1

--- a/.github/workflows/ec2-deploy.yml
+++ b/.github/workflows/ec2-deploy.yml
@@ -7,6 +7,11 @@ name: Deploy Scrapers API
 #                              Quay.io convention for robot accounts)
 #   DOCKER_PASSWORD            Quay.io robot account token
 #   DB_URI                     MongoDB connection string
+#   TENANT_DB_URL              PostgreSQL connection string (Prisma)
+#   JWT_SECRET                 JWT signing secret — app throws at boot if unset
+#   JWT_EXPIRATION             Token lifetime (e.g. "1d"). Defaults to "1d".
+#   SUPER_ADMIN_EMAIL          Seeded admin email
+#   SUPER_ADMIN_PASSWORD       Seeded admin password
 #   PORT                       App internal port the container listens on
 #                              (host port 80 is mapped to this; the docker
 #                              run uses `-p 80:$PORT`)
@@ -101,6 +106,11 @@ jobs:
         run: |
           {
             echo "DB_URI=${{ secrets.DB_URI }}"
+            echo "TENANT_DB_URL=${{ secrets.TENANT_DB_URL }}"
+            echo "JWT_SECRET=${{ secrets.JWT_SECRET }}"
+            echo "JWT_EXPIRATION=${{ secrets.JWT_EXPIRATION }}"
+            echo "SUPER_ADMIN_EMAIL=${{ secrets.SUPER_ADMIN_EMAIL }}"
+            echo "SUPER_ADMIN_PASSWORD=${{ secrets.SUPER_ADMIN_PASSWORD }}"
             echo "PORT=${{ secrets.PORT }}"
             echo "TIME_OUT=${{ secrets.TIME_OUT }}"
             echo "REDIS_URL=${{ secrets.REDIS_URL }}"

--- a/.github/workflows/ec2-deploy.yml
+++ b/.github/workflows/ec2-deploy.yml
@@ -29,6 +29,21 @@ name: Deploy Scrapers API
 # Create one at https://quay.io/organization/gsi_cesar/robots (or your
 # org's robots page), grant it write access to the `scrappers/main`
 # repository, and paste the token into DOCKER_PASSWORD.
+#
+# Enabling production deploys (MVP gate)
+# --------------------------------------
+# Both build and deploy jobs are gated on the repository variable
+# `DEPLOY_ENABLED`. While the project is an MVP without a production host,
+# leave it unset (or set to anything other than `true`) and both jobs skip
+# themselves — the workflow still runs (so CI is green) but does no work.
+#
+# To enable production deploys later:
+#   1. Add the secrets listed above (Settings > Secrets and variables).
+#   2. Set repository variable `DEPLOY_ENABLED=true`
+#      (Settings > Secrets and variables > Actions > Variables tab).
+#   3. Register the self-hosted runner on the production EC2 host so the
+#      `runs-on: self-hosted` job has somewhere to land.
+# No code change is required at that point.
 
 on:
   push:
@@ -54,8 +69,10 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-    # Only build on push. On workflow_dispatch we redeploy an existing image.
-    if: github.event_name == 'push'
+    # MVP gate: skip while DEPLOY_ENABLED is not 'true'. See workflow header.
+    # On workflow_dispatch we redeploy an existing image, so the build step
+    # is also skipped (only the deploy job runs).
+    if: github.event_name == 'push' && vars.DEPLOY_ENABLED == 'true'
     steps:
       - name: Checkout source
         uses: actions/checkout@v7
@@ -72,7 +89,8 @@ jobs:
   deploy:
     needs: build
     runs-on: self-hosted
-    if: github.event_name != 'pull_request'
+    # MVP gate: skip while DEPLOY_ENABLED is not 'true'. See workflow header.
+    if: github.event_name != 'pull_request' && vars.DEPLOY_ENABLED == 'true'
     steps:
       - name: Login to Quay.io
         run: docker login quay.io -u "${{ secrets.DOCKER_USERNAME }}" -p "${{ secrets.DOCKER_PASSWORD }}"


### PR DESCRIPTION
## Summary

Three changes to \`.github/workflows/ec2-deploy.yml\`, all preparing the workflow for production deploys without breaking the MVP while no production host exists.

1. **\`a2cc5eb\` — MVP gate.** Build and deploy jobs now require the repository variable \`DEPLOY_ENABLED=true\` to run. While unset (the default), both jobs skip themselves — CI stays green, no work is performed.

2. **\`49f4cb6\` — Runtime env vars.** Add five env vars the app reads at boot but the deploy was not writing to the on-host \`.env\`: \`TENANT_DB_URL\`, \`JWT_SECRET\`, \`JWT_EXPIRATION\`, \`SUPER_ADMIN_EMAIL\`, \`SUPER_ADMIN_PASSWORD\`. Without \`JWT_SECRET\` the app throws on boot, so the smoke test would fail even when the image builds correctly.

3. **\`7126629\` — Container rename.** \`scrapper-revolico-api\` → \`scrapper-bazaarsentinel-api\` so the host-side name reflects \`package.json#name\` (\`bazaarsentinel\`). The Quay.io image repo (\`gsi_cesar/scrappers/main\`) is unchanged.

## How to enable production deploys (when ready)

1. Add the secrets listed in the workflow header.
2. Set repository variable \`DEPLOY_ENABLED=true\`.
3. Register the self-hosted runner on the production EC2.

No code change is required at that point.

## Test plan

- [ ] Push to develop → CI green
- [ ] Push to main → deploy workflow runs, both jobs skipped with status "skipped"
- [ ] \`gh run rerun\` with \`DEPLOY_ENABLED=true\` (after secrets + runner are wired up) → builds, deploys, smoke test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)