### PR TITLE
feat(admin): Super Admin API expansion — products, dashboard, queues, accounts, roles

### DIFF
--- a/src/__tests__/integration/productServiceIT.test.ts
+++ b/src/__tests__/integration/productServiceIT.test.ts
@@ -70,7 +70,10 @@ describe('ProductService Integration Test', () => {
     const insertedProducts = await productRepository.find(0, 2);
     expect(insertedProducts).toHaveLength(2);
 
-    expect(insertedProducts[0]).toEqual(
+    // sort by ID for deterministic order across CI environments
+    const sorted = [...insertedProducts].sort((a, b) => (a.ID ?? '').localeCompare(b.ID ?? ''));
+
+    expect(sorted[0]).toEqual(
       expect.objectContaining({
         _id: expect.anything(),
         ID: productData[0].ID,

--- a/src/__tests__/unit/admin/account-admin.controller.test.ts
+++ b/src/__tests__/unit/admin/account-admin.controller.test.ts
@@ -1,0 +1,151 @@
+import { Request, Response } from 'express';
+import { AccountAdminController } from '@admin/controllers/account-admin.controller';
+import { AccountAdminService } from '@admin/services/account-admin.service';
+import { ILogger } from '@shared/logger.interface';
+
+describe('AccountAdminController', () => {
+  let controller: AccountAdminController;
+  let serviceMock: Record<string, jest.Mock>;
+  let loggerMock: ILogger;
+  let req: Partial<Request>;
+  let res: Partial<Response>;
+
+  beforeEach(() => {
+    serviceMock = {
+      getAll: jest.fn(),
+      getById: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    };
+
+    loggerMock = {
+      set context(_value: string) {},
+      info: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn(),
+      log: jest.fn(),
+    } as unknown as ILogger;
+
+    controller = new AccountAdminController(serviceMock as unknown as AccountAdminService, loggerMock);
+
+    res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    };
+  });
+
+  // =========================================================================
+  // list
+  // =========================================================================
+  describe('list', () => {
+    it('should return paginated accounts', async () => {
+      req = { query: { skip: '0', limit: '10' } };
+      const result = { accounts: [{ id: 'acc-1', name: 'Test' }], total: 1, skip: 0, limit: 10 };
+      serviceMock.getAll.mockResolvedValue(result);
+
+      await controller.list(req as Request, res as Response);
+
+      expect(serviceMock.getAll).toHaveBeenCalledWith(0, 10);
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'success',
+          data: result,
+        }),
+      );
+    });
+
+    it('should use defaults when query params are missing', async () => {
+      req = { query: {} };
+      serviceMock.getAll.mockResolvedValue({ accounts: [], total: 0, skip: 0, limit: 10 });
+
+      await controller.list(req as Request, res as Response);
+
+      expect(serviceMock.getAll).toHaveBeenCalledWith(0, 10);
+    });
+
+    it('should handle errors', async () => {
+      req = { query: {} };
+      serviceMock.getAll.mockRejectedValue(new Error('DB error'));
+
+      await controller.list(req as Request, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+    });
+  });
+
+  // =========================================================================
+  // getById
+  // =========================================================================
+  describe('getById', () => {
+    it('should return account when found', async () => {
+      req = { params: { id: 'acc-1' } };
+      const account = { id: 'acc-1', name: 'Test Account', userCount: 2, subscriptionCount: 3, alarmCount: 5 };
+      serviceMock.getById.mockResolvedValue(account);
+
+      await controller.getById(req as Request, res as Response);
+
+      expect(serviceMock.getById).toHaveBeenCalledWith('acc-1');
+      expect(res.status).toHaveBeenCalledWith(200);
+    });
+
+    it('should return 404 when account not found', async () => {
+      req = { params: { id: 'bad-id' } };
+      serviceMock.getById.mockResolvedValue(null);
+
+      await controller.getById(req as Request, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+    });
+  });
+
+  // =========================================================================
+  // update
+  // =========================================================================
+  describe('update', () => {
+    it('should update and return the account', async () => {
+      req = { params: { id: 'acc-1' }, body: { name: 'Updated' } };
+      const updated = { id: 'acc-1', name: 'Updated', settings: null, createdAt: new Date(), updatedAt: new Date() };
+      serviceMock.update.mockResolvedValue(updated);
+
+      await controller.update(req as Request, res as Response);
+
+      expect(serviceMock.update).toHaveBeenCalledWith('acc-1', { name: 'Updated' });
+      expect(res.status).toHaveBeenCalledWith(200);
+    });
+
+    it('should handle errors', async () => {
+      req = { params: { id: 'acc-1' }, body: {} };
+      serviceMock.update.mockRejectedValue(new Error('Update failed'));
+
+      await controller.update(req as Request, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+    });
+  });
+
+  // =========================================================================
+  // delete
+  // =========================================================================
+  describe('delete', () => {
+    it('should delete and return 200', async () => {
+      req = { params: { id: 'acc-1' } };
+      serviceMock.delete.mockResolvedValue(undefined);
+
+      await controller.delete(req as Request, res as Response);
+
+      expect(serviceMock.delete).toHaveBeenCalledWith('acc-1');
+      expect(res.status).toHaveBeenCalledWith(200);
+    });
+
+    it('should handle errors', async () => {
+      req = { params: { id: 'bad-id' } };
+      serviceMock.delete.mockRejectedValue(new Error('Delete failed'));
+
+      await controller.delete(req as Request, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+    });
+  });
+});

--- a/src/__tests__/unit/admin/account-admin.service.test.ts
+++ b/src/__tests__/unit/admin/account-admin.service.test.ts
@@ -1,0 +1,166 @@
+import { AccountAdminService } from '@admin/services/account-admin.service';
+import { ILogger } from '@shared/logger.interface';
+
+describe('AccountAdminService', () => {
+  let service: AccountAdminService;
+  let accountRepoMock: Record<string, jest.Mock>;
+  let prismaMock: Record<string, Record<string, jest.Mock>>;
+  let loggerMock: ILogger;
+
+  const mockAccount = {
+    id: 'acc-1',
+    name: 'Test Account',
+    settings: null,
+    createdAt: new Date('2024-01-01'),
+    updatedAt: new Date('2024-01-01'),
+    users: [{ id: 'user-1' }, { id: 'user-2' }],
+  };
+
+  beforeEach(() => {
+    accountRepoMock = {
+      findAll: jest.fn(),
+      findById: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    };
+
+    prismaMock = {
+      accountSubscription: {
+        groupBy: jest.fn(),
+        count: jest.fn(),
+      },
+      alarm: {
+        groupBy: jest.fn(),
+        count: jest.fn(),
+      },
+    };
+
+    loggerMock = {
+      set context(_value: string) {},
+      info: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn(),
+      log: jest.fn(),
+    } as unknown as ILogger;
+
+    service = new AccountAdminService(accountRepoMock as never, prismaMock as never, loggerMock);
+  });
+
+  // =========================================================================
+  // getAll
+  // =========================================================================
+  describe('getAll', () => {
+    it('should return paginated accounts with counts', async () => {
+      accountRepoMock.findAll.mockResolvedValue([mockAccount]);
+      prismaMock.accountSubscription.groupBy.mockResolvedValue([{ accountId: 'acc-1', _count: { id: 3 } }]);
+      prismaMock.alarm.groupBy.mockResolvedValue([{ accountId: 'acc-1', _count: { id: 5 } }]);
+
+      const result = await service.getAll(0, 10);
+
+      expect(result.total).toBe(1);
+      expect(result.skip).toBe(0);
+      expect(result.limit).toBe(10);
+      expect(result.accounts).toHaveLength(1);
+      expect(result.accounts[0].id).toBe('acc-1');
+      expect(result.accounts[0].userCount).toBe(2);
+      expect(result.accounts[0].subscriptionCount).toBe(3);
+      expect(result.accounts[0].alarmCount).toBe(5);
+    });
+
+    it('should return empty accounts when no accounts exist', async () => {
+      accountRepoMock.findAll.mockResolvedValue([]);
+
+      const result = await service.getAll(0, 10);
+
+      expect(result.accounts).toEqual([]);
+      expect(result.total).toBe(0);
+    });
+
+    it('should handle pagination correctly', async () => {
+      const accounts = Array.from({ length: 5 }, (_, i) => ({
+        ...mockAccount,
+        id: `acc-${i + 1}`,
+        users: [{ id: `user-${i + 1}` }],
+      }));
+      accountRepoMock.findAll.mockResolvedValue(accounts);
+      prismaMock.accountSubscription.groupBy.mockResolvedValue([]);
+      prismaMock.alarm.groupBy.mockResolvedValue([]);
+
+      const result = await service.getAll(1, 2);
+
+      expect(result.total).toBe(5);
+      expect(result.accounts).toHaveLength(2);
+      expect(result.accounts[0].id).toBe('acc-2');
+      expect(result.accounts[1].id).toBe('acc-3');
+    });
+  });
+
+  // =========================================================================
+  // getById
+  // =========================================================================
+  describe('getById', () => {
+    it('should return account with counts when found', async () => {
+      accountRepoMock.findById.mockResolvedValue(mockAccount);
+      prismaMock.accountSubscription.count.mockResolvedValue(3);
+      prismaMock.alarm.count.mockResolvedValue(5);
+
+      const result = await service.getById('acc-1');
+
+      expect(result).not.toBeNull();
+      expect(result!.id).toBe('acc-1');
+      expect(result!.name).toBe('Test Account');
+      expect(result!.userCount).toBe(2);
+      expect(result!.subscriptionCount).toBe(3);
+      expect(result!.alarmCount).toBe(5);
+      expect(prismaMock.accountSubscription.count).toHaveBeenCalledWith({ where: { accountId: 'acc-1' } });
+      expect(prismaMock.alarm.count).toHaveBeenCalledWith({ where: { accountId: 'acc-1' } });
+    });
+
+    it('should return null when account not found', async () => {
+      accountRepoMock.findById.mockResolvedValue(null);
+
+      const result = await service.getById('bad-id');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  // =========================================================================
+  // update
+  // =========================================================================
+  describe('update', () => {
+    it('should update an account and return updated data', async () => {
+      const updatedAccount = {
+        ...mockAccount,
+        name: 'Updated Name',
+      };
+      accountRepoMock.update.mockResolvedValue(updatedAccount);
+
+      const result = await service.update('acc-1', { name: 'Updated Name' });
+
+      expect(result.name).toBe('Updated Name');
+      expect(accountRepoMock.update).toHaveBeenCalledWith('acc-1', { name: 'Updated Name' });
+    });
+  });
+
+  // =========================================================================
+  // delete
+  // =========================================================================
+  describe('delete', () => {
+    it('should delete an account by id', async () => {
+      accountRepoMock.delete.mockResolvedValue(undefined);
+
+      await service.delete('acc-1');
+
+      expect(accountRepoMock.delete).toHaveBeenCalledWith('acc-1');
+    });
+
+    it('should propagate errors', async () => {
+      const error = new Error('Delete failed');
+      accountRepoMock.delete.mockRejectedValue(error);
+
+      await expect(service.delete('bad-id')).rejects.toThrow('Delete failed');
+    });
+  });
+});

--- a/src/__tests__/unit/admin/admin.controller.test.ts
+++ b/src/__tests__/unit/admin/admin.controller.test.ts
@@ -1,0 +1,90 @@
+import { Request, Response } from 'express';
+
+const userServiceMock = {
+  getAll: jest.fn(),
+  delete: jest.fn(),
+};
+
+jest.mock('@users/services/user.service', () => ({
+  UserService: jest.fn().mockImplementation(() => userServiceMock),
+}));
+
+import { AdminController } from '@admin/controllers/admin.controller';
+import { ResponseHandler } from '@shared/response-handler';
+import { ILogger } from '@shared/logger.interface';
+import { UserService } from '@users/services/user.service';
+
+describe('AdminController', () => {
+  let controller: AdminController;
+  let loggerMock: ILogger;
+  let mockRes: Response;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    loggerMock = {
+      context: '',
+      info: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn(),
+      log: jest.fn(),
+    } as unknown as ILogger;
+
+    mockRes = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    } as unknown as Response;
+
+    const userServiceInstance = new (UserService as jest.Mock)() as UserService;
+
+    controller = new AdminController(userServiceInstance, loggerMock) as unknown as AdminController;
+
+    jest.spyOn(ResponseHandler, 'ok');
+    jest.spyOn(ResponseHandler, 'deleted');
+    jest.spyOn(ResponseHandler, 'notFound');
+  });
+
+  describe('structural', () => {
+    it('should be decorated with @injectable()', () => {
+      const hasParamTypes = Reflect.hasOwnMetadata('inversify:paramtypes', AdminController);
+      expect(hasParamTypes).toBe(true);
+    });
+  });
+
+  describe('list', () => {
+    it('should return users via ResponseHandler.ok', async () => {
+      const users = [{ id: '1', email: 'a@b.c' }];
+      userServiceMock.getAll.mockResolvedValue(users);
+
+      const req = {} as Request;
+
+      await controller.list(req, mockRes);
+
+      expect(ResponseHandler.ok).toHaveBeenCalledWith(mockRes, { users });
+    });
+  });
+
+  describe('delete', () => {
+    it('should call ResponseHandler.deleted on success', async () => {
+      userServiceMock.delete.mockResolvedValue(undefined);
+
+      const req = { params: { id: 'valid-id' } } as unknown as Request;
+
+      await controller.delete(req, mockRes);
+
+      expect(userServiceMock.delete).toHaveBeenCalledWith('valid-id');
+      expect(ResponseHandler.deleted).toHaveBeenCalledWith(mockRes);
+    });
+
+    it('should call ResponseHandler.notFound when UserService.delete throws', async () => {
+      userServiceMock.delete.mockRejectedValue(new Error('not found'));
+
+      const req = { params: { id: 'bad-id' } } as unknown as Request;
+
+      await controller.delete(req, mockRes);
+
+      expect(ResponseHandler.notFound).toHaveBeenCalledWith(mockRes);
+    });
+  });
+});

--- a/src/__tests__/unit/admin/dashboard-metrics.dto.test.ts
+++ b/src/__tests__/unit/admin/dashboard-metrics.dto.test.ts
@@ -1,0 +1,116 @@
+import { DashboardMetricsDTO, HealthResponseDTO } from '@admin/services/dto/dashboard-metrics.dto';
+
+describe('DashboardMetricsDTO', () => {
+  describe('structural', () => {
+    it('should have a static from method', () => {
+      expect(typeof DashboardMetricsDTO.from).toBe('function');
+    });
+  });
+
+  describe('from', () => {
+    it('should parse valid metrics data', () => {
+      const dto = DashboardMetricsDTO.from({
+        productCount: 150,
+        categoriesBreakdown: [
+          { category: 'Electronics', count: 50 },
+          { category: 'Vehicles', count: 100 },
+        ],
+        totalAccounts: 12,
+        totalUsers: 45,
+        activeSubscriptions: 8,
+        recentProducts: [{ _id: 'p1', description: 'iPhone 15', price: 500 }],
+      });
+
+      expect(dto.productCount).toBe(150);
+      expect(dto.categoriesBreakdown).toHaveLength(2);
+      expect(dto.categoriesBreakdown[0]).toEqual({ category: 'Electronics', count: 50 });
+      expect(dto.totalAccounts).toBe(12);
+      expect(dto.totalUsers).toBe(45);
+      expect(dto.activeSubscriptions).toBe(8);
+      expect(dto.recentProducts).toHaveLength(1);
+      expect(dto.recentProducts[0].description).toBe('iPhone 15');
+    });
+
+    it('should parse with empty arrays', () => {
+      const dto = DashboardMetricsDTO.from({
+        productCount: 0,
+        categoriesBreakdown: [],
+        totalAccounts: 0,
+        totalUsers: 0,
+        activeSubscriptions: 0,
+        recentProducts: [],
+      });
+
+      expect(dto.productCount).toBe(0);
+      expect(dto.categoriesBreakdown).toEqual([]);
+      expect(dto.recentProducts).toEqual([]);
+    });
+
+    it('should throw for missing required fields', () => {
+      expect(() => DashboardMetricsDTO.from({})).toThrow();
+    });
+
+    it('should throw for wrong types', () => {
+      expect(() =>
+        DashboardMetricsDTO.from({
+          productCount: 'not-a-number',
+          categoriesBreakdown: [],
+          totalAccounts: 0,
+          totalUsers: 0,
+          activeSubscriptions: 0,
+          recentProducts: [],
+        }),
+      ).toThrow();
+    });
+
+    it('should throw for non-object input', () => {
+      expect(() => DashboardMetricsDTO.from(null)).toThrow();
+      expect(() => DashboardMetricsDTO.from(undefined)).toThrow();
+      expect(() => DashboardMetricsDTO.from('string')).toThrow();
+    });
+  });
+});
+
+describe('HealthResponseDTO', () => {
+  describe('structural', () => {
+    it('should have a static from method', () => {
+      expect(typeof HealthResponseDTO.from).toBe('function');
+    });
+  });
+
+  describe('from', () => {
+    it('should parse a valid health response', () => {
+      const dto = HealthResponseDTO.from({
+        services: [
+          { service: 'mongodb', status: 'connected' },
+          { service: 'postgres', status: 'connected' },
+          { service: 'redis', status: 'error', error: 'ECONNREFUSED' },
+        ],
+        timestamp: '2025-01-01T00:00:00.000Z',
+      });
+
+      expect(dto.services).toHaveLength(3);
+      expect(dto.services[0]).toEqual({ service: 'mongodb', status: 'connected' });
+      expect(dto.services[2]).toEqual({ service: 'redis', status: 'error', error: 'ECONNREFUSED' });
+      expect(dto.timestamp).toBe('2025-01-01T00:00:00.000Z');
+    });
+
+    it('should throw for invalid status', () => {
+      expect(() =>
+        HealthResponseDTO.from({
+          services: [{ service: 'test', status: 'unknown' }],
+          timestamp: '2025-01-01T00:00:00.000Z',
+        }),
+      ).toThrow();
+    });
+
+    it('should throw for missing services', () => {
+      expect(() => HealthResponseDTO.from({ timestamp: '2025-01-01T00:00:00.000Z' })).toThrow();
+    });
+
+    it('should throw for non-object input', () => {
+      expect(() => HealthResponseDTO.from(null)).toThrow();
+      expect(() => HealthResponseDTO.from(undefined)).toThrow();
+    });
+  });
+});

--- a/src/__tests__/unit/admin/dashboard.controller.test.ts
+++ b/src/__tests__/unit/admin/dashboard.controller.test.ts
@@ -1,0 +1,127 @@
+import { Request, Response } from 'express';
+
+const dashboardServiceMock = {
+  getMetrics: jest.fn(),
+  getHealth: jest.fn(),
+};
+
+jest.mock('@admin/services/dashboard.service', () => ({
+  DashboardService: jest.fn().mockImplementation(() => dashboardServiceMock),
+}));
+
+import { DashboardController } from '@admin/controllers/dashboard.controller';
+import { ResponseHandler } from '@shared/response-handler';
+import { ILogger } from '@shared/logger.interface';
+import { DashboardService } from '@admin/services/dashboard.service';
+
+describe('DashboardController', () => {
+  let controller: DashboardController;
+  let loggerMock: ILogger;
+  let mockRes: Response;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    loggerMock = {
+      context: '',
+      info: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn(),
+      log: jest.fn(),
+    } as unknown as ILogger;
+
+    mockRes = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    } as unknown as Response;
+
+    const serviceInstance = new (DashboardService as jest.Mock)() as DashboardService;
+
+    controller = new DashboardController(serviceInstance, loggerMock);
+
+    jest.spyOn(ResponseHandler, 'ok');
+    jest.spyOn(ResponseHandler, 'error');
+  });
+
+  describe('structural', () => {
+    it('should be decorated with @injectable()', () => {
+      const hasParamTypes = Reflect.hasOwnMetadata('inversify:paramtypes', DashboardController);
+      expect(hasParamTypes).toBe(true);
+    });
+  });
+
+  describe('getMetrics', () => {
+    it('should return dashboard metrics via ResponseHandler.ok', async () => {
+      const metrics = {
+        productCount: 100,
+        categoriesBreakdown: [{ category: 'Electronics', count: 50 }],
+        totalAccounts: 5,
+        totalUsers: 20,
+        activeSubscriptions: 3,
+        recentProducts: [{ _id: 'p1', description: 'Test' }],
+      };
+      dashboardServiceMock.getMetrics.mockResolvedValue(metrics);
+
+      const req = {} as Request;
+      await controller.getMetrics(req, mockRes);
+
+      expect(ResponseHandler.ok).toHaveBeenCalledWith(mockRes, metrics);
+    });
+
+    it('should handle service errors', async () => {
+      dashboardServiceMock.getMetrics.mockRejectedValue(new Error('DB down'));
+
+      const req = {} as Request;
+      await controller.getMetrics(req, mockRes);
+
+      expect(ResponseHandler.error).toHaveBeenCalledWith(mockRes, 'Failed to get dashboard metrics', 500);
+      expect(loggerMock.error).toHaveBeenCalled();
+    });
+  });
+
+  describe('getHealth', () => {
+    it('should return health status via ResponseHandler.ok', async () => {
+      const health = {
+        services: [
+          { service: 'mongodb', status: 'connected' },
+          { service: 'postgres', status: 'connected' },
+          { service: 'redis', status: 'connected' },
+        ],
+        timestamp: '2025-01-01T00:00:00.000Z',
+      };
+      dashboardServiceMock.getHealth.mockResolvedValue(health);
+
+      const req = {} as Request;
+      await controller.getHealth(req, mockRes);
+
+      expect(ResponseHandler.ok).toHaveBeenCalledWith(mockRes, health);
+    });
+
+    it('should return health with errors when services are down', async () => {
+      const health = {
+        services: [
+          { service: 'mongodb', status: 'error', error: 'timeout' },
+          { service: 'postgres', status: 'connected' },
+          { service: 'redis', status: 'connected' },
+        ],
+        timestamp: '2025-01-01T00:00:00.000Z',
+      };
+      dashboardServiceMock.getHealth.mockResolvedValue(health);
+
+      const req = {} as Request;
+      await controller.getHealth(req, mockRes);
+
+      expect(ResponseHandler.ok).toHaveBeenCalledWith(mockRes, health);
+    });
+
+    it('should handle service errors', async () => {
+      dashboardServiceMock.getHealth.mockRejectedValue(new Error('Unexpected error'));
+
+      const req = {} as Request;
+      await controller.getHealth(req, mockRes);
+
+      expect(ResponseHandler.error).toHaveBeenCalledWith(mockRes, 'Failed to get health status', 500);
+    });
+  });
+});

--- a/src/__tests__/unit/admin/dashboard.service.test.ts
+++ b/src/__tests__/unit/admin/dashboard.service.test.ts
@@ -1,0 +1,213 @@
+import { DashboardService } from '@admin/services/dashboard.service';
+import { IQueueAdapterRegistry } from '@shared/queue/port/queue-adapter-registry.interfaces';
+import { IQueueAdapter } from '@shared/queue/port/queue-adapter.interfaces';
+import { ILogger } from '@shared/logger.interface';
+import { ProductRepository } from '@scrapers/revolico/repositories/product.repository';
+import { PrismaClient } from '@prisma/client';
+
+describe('DashboardService', () => {
+  let service: DashboardService;
+  let productRepoMock: jest.Mocked<ProductRepository>;
+  let prismaMock: jest.Mocked<PrismaClient>;
+  let registryMock: IQueueAdapterRegistry;
+  let adapterMock: IQueueAdapter;
+  let loggerMock: ILogger;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    loggerMock = {
+      context: '',
+      info: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn(),
+      log: jest.fn(),
+    } as unknown as ILogger;
+
+    productRepoMock = {
+      count: jest.fn(),
+      aggregate: jest.fn(),
+      find: jest.fn(),
+      findOne: jest.fn(),
+      clearAll: jest.fn(),
+      update: jest.fn(),
+      deleteById: jest.fn(),
+      bulkInsertOrUpdate: jest.fn(),
+    } as unknown as jest.Mocked<ProductRepository>;
+
+    prismaMock = {
+      account: { count: jest.fn() },
+      user: { count: jest.fn() },
+      accountSubscription: { count: jest.fn() },
+      $queryRaw: jest.fn(),
+    } as unknown as jest.Mocked<PrismaClient>;
+
+    adapterMock = {
+      backend: 'bullmq',
+      getDashboardQueues: jest.fn().mockReturnValue([]),
+      enqueue: jest.fn(),
+      registerWorker: jest.fn(),
+      onCompleted: jest.fn(),
+      onFailed: jest.fn(),
+      onProgress: jest.fn(),
+      describe: jest.fn(),
+      shutdown: jest.fn(),
+    } as unknown as IQueueAdapter;
+
+    registryMock = {
+      getCurrent: jest.fn().mockReturnValue(adapterMock),
+      get: jest.fn().mockReturnValue(adapterMock),
+    };
+
+    service = new DashboardService(productRepoMock, prismaMock, registryMock, loggerMock);
+  });
+
+  describe('structural', () => {
+    it('should set logger context to DashboardService', () => {
+      expect(loggerMock.context).toBe('DashboardService');
+    });
+  });
+
+  describe('getMetrics', () => {
+    it('should aggregate metrics from all data sources', async () => {
+      productRepoMock.count.mockResolvedValue(150);
+      productRepoMock.aggregate.mockResolvedValue([
+        { _id: 'Electronics', count: 50 },
+        { _id: 'Vehicles', count: 100 },
+      ]);
+      productRepoMock.find.mockResolvedValue([
+        {
+          _id: 'p1',
+          ID: 'id1',
+          category: 'Electronics',
+          url: 'http://ex.com/1',
+          description: 'iPhone',
+          price: 500,
+          currency: 'USD',
+          isOutstanding: false,
+          createdAt: new Date('2025-01-01'),
+          updatedAt: new Date('2025-01-02'),
+        } as any,
+      ]);
+      (prismaMock.account.count as jest.Mock).mockResolvedValue(12);
+      (prismaMock.user.count as jest.Mock).mockResolvedValue(45);
+      (prismaMock.accountSubscription.count as jest.Mock).mockResolvedValue(8);
+
+      const metrics = await service.getMetrics();
+
+      expect(metrics.productCount).toBe(150);
+      expect(metrics.categoriesBreakdown).toEqual([
+        { category: 'Electronics', count: 50 },
+        { category: 'Vehicles', count: 100 },
+      ]);
+      expect(metrics.totalAccounts).toBe(12);
+      expect(metrics.totalUsers).toBe(45);
+      expect(metrics.activeSubscriptions).toBe(8);
+      expect(metrics.recentProducts).toHaveLength(1);
+    });
+
+    it('should handle empty data gracefully', async () => {
+      productRepoMock.count.mockResolvedValue(0);
+      productRepoMock.aggregate.mockResolvedValue([]);
+      productRepoMock.find.mockResolvedValue([]);
+      (prismaMock.account.count as jest.Mock).mockResolvedValue(0);
+      (prismaMock.user.count as jest.Mock).mockResolvedValue(0);
+      (prismaMock.accountSubscription.count as jest.Mock).mockResolvedValue(0);
+
+      const metrics = await service.getMetrics();
+
+      expect(metrics.productCount).toBe(0);
+      expect(metrics.categoriesBreakdown).toEqual([]);
+      expect(metrics.totalAccounts).toBe(0);
+      expect(metrics.totalUsers).toBe(0);
+      expect(metrics.activeSubscriptions).toBe(0);
+      expect(metrics.recentProducts).toEqual([]);
+    });
+
+    it('should filter active subscriptions correctly', async () => {
+      productRepoMock.count.mockResolvedValue(10);
+      productRepoMock.aggregate.mockResolvedValue([]);
+      productRepoMock.find.mockResolvedValue([]);
+      (prismaMock.account.count as jest.Mock).mockResolvedValue(3);
+      (prismaMock.user.count as jest.Mock).mockResolvedValue(10);
+      (prismaMock.accountSubscription.count as jest.Mock).mockResolvedValue(3);
+
+      const metrics = await service.getMetrics();
+
+      expect(prismaMock.accountSubscription.count).toHaveBeenCalledWith(expect.objectContaining({ where: { status: 'ACTIVE' } }));
+      expect(metrics.activeSubscriptions).toBe(3);
+    });
+  });
+
+  describe('getHealth', () => {
+    it('should report connected for all services when healthy', async () => {
+      productRepoMock.count.mockResolvedValue(10);
+      (prismaMock.$queryRaw as jest.Mock).mockResolvedValue([{ result: 1 }]);
+      (adapterMock.getDashboardQueues as jest.Mock).mockReturnValue([{ name: 'test', queue: {} }]);
+
+      const health = await service.getHealth();
+
+      expect(health.services).toHaveLength(3);
+      expect(health.services[0]).toEqual({ service: 'mongodb', status: 'connected' });
+      expect(health.services[1]).toEqual({ service: 'postgres', status: 'connected' });
+      expect(health.services[2]).toEqual({ service: 'redis', status: 'connected' });
+      expect(health.timestamp).toBeDefined();
+    });
+
+    it('should report error for mongodb when count fails', async () => {
+      productRepoMock.count.mockRejectedValue(new Error('Connection refused'));
+      (prismaMock.$queryRaw as jest.Mock).mockResolvedValue([{ result: 1 }]);
+      (adapterMock.getDashboardQueues as jest.Mock).mockReturnValue([{ name: 'test', queue: {} }]);
+
+      const health = await service.getHealth();
+
+      const mongoService = health.services.find(s => s.service === 'mongodb');
+      expect(mongoService).toBeDefined();
+      expect(mongoService!.status).toBe('error');
+      expect(mongoService!.error).toBeDefined();
+      expect(mongoService!.error).toContain('Connection refused');
+    });
+
+    it('should report error for postgres when query fails', async () => {
+      productRepoMock.count.mockResolvedValue(10);
+      (prismaMock.$queryRaw as jest.Mock).mockRejectedValue(new Error('Connection refused'));
+      (adapterMock.getDashboardQueues as jest.Mock).mockReturnValue([{ name: 'test', queue: {} }]);
+
+      const health = await service.getHealth();
+
+      const pgService = health.services.find(s => s.service === 'postgres');
+      expect(pgService).toBeDefined();
+      expect(pgService!.status).toBe('error');
+      expect(pgService!.error).toBeDefined();
+    });
+
+    it('should report error for redis when adapter call fails', async () => {
+      productRepoMock.count.mockResolvedValue(10);
+      (prismaMock.$queryRaw as jest.Mock).mockResolvedValue([{ result: 1 }]);
+      (adapterMock.getDashboardQueues as jest.Mock).mockImplementation(() => {
+        throw new Error('Redis unavailable');
+      });
+
+      const health = await service.getHealth();
+
+      const redisService = health.services.find(s => s.service === 'redis');
+      expect(redisService).toBeDefined();
+      expect(redisService!.status).toBe('error');
+      expect(redisService!.error).toBeDefined();
+      expect(redisService!.error).toContain('Redis unavailable');
+    });
+
+    it('should include a timestamp in the response', async () => {
+      productRepoMock.count.mockResolvedValue(10);
+      (prismaMock.$queryRaw as jest.Mock).mockResolvedValue([{ result: 1 }]);
+      (adapterMock.getDashboardQueues as jest.Mock).mockReturnValue([{ name: 'test', queue: {} }]);
+
+      const health = await service.getHealth();
+
+      expect(health.timestamp).toBeDefined();
+      // Should be a valid ISO date string
+      expect(() => new Date(health.timestamp)).not.toThrow();
+    });
+  });
+});

--- a/src/__tests__/unit/admin/product-admin.controller.test.ts
+++ b/src/__tests__/unit/admin/product-admin.controller.test.ts
@@ -1,0 +1,291 @@
+import { Request, Response } from 'express';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const serviceMock = {
+  list: jest.fn(),
+  getById: jest.fn(),
+  getPriceHistory: jest.fn(),
+  getViewsHistory: jest.fn(),
+  getLocationHistory: jest.fn(),
+  getOutstandingHistory: jest.fn(),
+  getPromotedHistory: jest.fn(),
+  getStats: jest.fn(),
+  delete: jest.fn(),
+};
+
+jest.mock('@admin/services/product-admin.service', () => ({
+  ProductAdminService: jest.fn().mockImplementation(() => serviceMock),
+}));
+
+import { ProductAdminController } from '@admin/controllers/product-admin.controller';
+import { ProductAdminService } from '@admin/services/product-admin.service';
+import { ResponseHandler } from '@shared/response-handler';
+import { ILogger } from '@shared/logger.interface';
+
+describe('ProductAdminController', () => {
+  let controller: ProductAdminController;
+  let loggerMock: ILogger;
+  let mockRes: Response;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    loggerMock = {
+      context: '',
+      info: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn(),
+      log: jest.fn(),
+    } as unknown as ILogger;
+
+    mockRes = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    } as unknown as Response;
+
+    const serviceInstance = new (ProductAdminService as jest.Mock)() as ProductAdminService;
+
+    controller = new ProductAdminController(serviceInstance, loggerMock);
+
+    jest.spyOn(ResponseHandler, 'ok');
+    jest.spyOn(ResponseHandler, 'success');
+    jest.spyOn(ResponseHandler, 'error');
+    jest.spyOn(ResponseHandler, 'notFound');
+    jest.spyOn(ResponseHandler, 'deleted');
+  });
+
+  // -------------------------------------------------------------------------
+  // Structural
+  // -------------------------------------------------------------------------
+  describe('structural', () => {
+    it('should have inversify param types metadata', () => {
+      const hasParamTypes = Reflect.hasOwnMetadata('inversify:paramtypes', ProductAdminController);
+      expect(hasParamTypes).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // GET / — list
+  // -------------------------------------------------------------------------
+  describe('list', () => {
+    it('should return paginated products via ResponseHandler.ok', async () => {
+      const paginated = {
+        data: [{ _id: 'abc' }],
+        meta: { total: 1, skip: 0, limit: 20, hasMore: false },
+      };
+      serviceMock.list.mockResolvedValue(paginated);
+
+      const req = { query: { skip: '0', limit: '20' } } as unknown as Request;
+      await controller.list(req, mockRes);
+
+      expect(ResponseHandler.ok).toHaveBeenCalledWith(mockRes, paginated);
+    });
+
+    it('should handle service errors', async () => {
+      serviceMock.list.mockRejectedValue(new Error('DB error'));
+
+      const req = { query: {} } as unknown as Request;
+      await controller.list(req, mockRes);
+
+      expect(ResponseHandler.error).toHaveBeenCalledWith(mockRes, 'Failed to list products', 500);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // GET /stats — getStats
+  // -------------------------------------------------------------------------
+  describe('getStats', () => {
+    it('should return stats via ResponseHandler.ok', async () => {
+      const stats = {
+        totalProducts: 100,
+        byCategory: [{ category: 'inmuebles', count: 50 }],
+        byState: [{ state: 'La Habana', count: 80 }],
+        outstandingCount: 10,
+        promotedCount: 5,
+        lastScrapedAt: '2025-01-15T00:00:00.000Z',
+        priceRange: { min: 100, max: 50000 },
+      };
+      serviceMock.getStats.mockResolvedValue(stats);
+
+      const req = {} as Request;
+      await controller.getStats(req, mockRes);
+
+      expect(ResponseHandler.ok).toHaveBeenCalledWith(mockRes, stats);
+    });
+
+    it('should handle service errors', async () => {
+      serviceMock.getStats.mockRejectedValue(new Error('Aggregation error'));
+
+      const req = {} as Request;
+      await controller.getStats(req, mockRes);
+
+      expect(ResponseHandler.error).toHaveBeenCalledWith(mockRes, 'Failed to get product stats', 500);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // GET /:id — getById
+  // -------------------------------------------------------------------------
+  describe('getById', () => {
+    it('should return product detail when found', async () => {
+      const product = { _id: 'abc', url: 'https://x.com/item', currency: 'USD', price: 10, isOutstanding: false };
+      serviceMock.getById.mockResolvedValue(product);
+
+      const req = { params: { id: 'abc' } } as unknown as Request;
+      await controller.getById(req, mockRes);
+
+      expect(ResponseHandler.ok).toHaveBeenCalledWith(mockRes, product);
+    });
+
+    it('should return 404 when product not found', async () => {
+      serviceMock.getById.mockResolvedValue(null);
+
+      const req = { params: { id: 'nonexistent' } } as unknown as Request;
+      await controller.getById(req, mockRes);
+
+      expect(ResponseHandler.notFound).toHaveBeenCalledWith(mockRes, 'Product not found');
+    });
+
+    it('should handle service errors', async () => {
+      serviceMock.getById.mockRejectedValue(new Error('DB error'));
+
+      const req = { params: { id: 'abc' } } as unknown as Request;
+      await controller.getById(req, mockRes);
+
+      expect(ResponseHandler.error).toHaveBeenCalledWith(mockRes, 'Failed to get product', 500);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // GET /:id/history/price
+  // -------------------------------------------------------------------------
+  describe('getPriceHistory', () => {
+    it('should return price history', async () => {
+      const history = { data: [{ value: 50000, updatedAt: '2025-01-10T00:00:00.000Z' }], total: 1 };
+      serviceMock.getPriceHistory.mockResolvedValue(history);
+
+      const req = { params: { id: 'abc' } } as unknown as Request;
+      await controller.getPriceHistory(req, mockRes);
+
+      expect(ResponseHandler.ok).toHaveBeenCalledWith(mockRes, history);
+    });
+
+    it('should return 404 when product not found', async () => {
+      serviceMock.getPriceHistory.mockResolvedValue(null);
+
+      const req = { params: { id: 'nonexistent' } } as unknown as Request;
+      await controller.getPriceHistory(req, mockRes);
+
+      expect(ResponseHandler.notFound).toHaveBeenCalledWith(mockRes, 'Product not found');
+    });
+
+    it('should handle service errors', async () => {
+      serviceMock.getPriceHistory.mockRejectedValue(new Error('DB error'));
+
+      const req = { params: { id: 'abc' } } as unknown as Request;
+      await controller.getPriceHistory(req, mockRes);
+
+      expect(ResponseHandler.error).toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // GET /:id/history/views
+  // -------------------------------------------------------------------------
+  describe('getViewsHistory', () => {
+    it('should return views history', async () => {
+      const history = { data: [{ value: 150, updatedAt: '2025-01-10T00:00:00.000Z' }], total: 1 };
+      serviceMock.getViewsHistory.mockResolvedValue(history);
+
+      const req = { params: { id: 'abc' } } as unknown as Request;
+      await controller.getViewsHistory(req, mockRes);
+
+      expect(ResponseHandler.ok).toHaveBeenCalledWith(mockRes, history);
+    });
+
+    it('should return 404 when product not found', async () => {
+      serviceMock.getViewsHistory.mockResolvedValue(null);
+
+      const req = { params: { id: 'nonexistent' } } as unknown as Request;
+      await controller.getViewsHistory(req, mockRes);
+
+      expect(ResponseHandler.notFound).toHaveBeenCalledWith(mockRes, 'Product not found');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // GET /:id/history/location
+  // -------------------------------------------------------------------------
+  describe('getLocationHistory', () => {
+    it('should return location history', async () => {
+      const history = {
+        data: [{ location: { state: 'La Habana', municipality: 'Plaza' }, updatedAt: '2025-01-10T00:00:00.000Z' }],
+        total: 1,
+      };
+      serviceMock.getLocationHistory.mockResolvedValue(history);
+
+      const req = { params: { id: 'abc' } } as unknown as Request;
+      await controller.getLocationHistory(req, mockRes);
+
+      expect(ResponseHandler.ok).toHaveBeenCalledWith(mockRes, history);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // GET /:id/history/outstanding
+  // -------------------------------------------------------------------------
+  describe('getOutstandingHistory', () => {
+    it('should return outstanding history', async () => {
+      const history = { data: [{ value: 1, updatedAt: '2025-01-10T00:00:00.000Z' }], total: 1 };
+      serviceMock.getOutstandingHistory.mockResolvedValue(history);
+
+      const req = { params: { id: 'abc' } } as unknown as Request;
+      await controller.getOutstandingHistory(req, mockRes);
+
+      expect(ResponseHandler.ok).toHaveBeenCalledWith(mockRes, history);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // GET /:id/history/promoted
+  // -------------------------------------------------------------------------
+  describe('getPromotedHistory', () => {
+    it('should return promoted history', async () => {
+      const history = { data: [{ value: 1, updatedAt: '2025-01-10T00:00:00.000Z' }], total: 1 };
+      serviceMock.getPromotedHistory.mockResolvedValue(history);
+
+      const req = { params: { id: 'abc' } } as unknown as Request;
+      await controller.getPromotedHistory(req, mockRes);
+
+      expect(ResponseHandler.ok).toHaveBeenCalledWith(mockRes, history);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // DELETE /:id — delete
+  // -------------------------------------------------------------------------
+  describe('delete', () => {
+    it('should call ResponseHandler.deleted on success', async () => {
+      serviceMock.delete.mockResolvedValue(undefined);
+
+      const req = { params: { id: 'abc' } } as unknown as Request;
+      await controller.delete(req, mockRes);
+
+      expect(serviceMock.delete).toHaveBeenCalledWith('abc');
+      expect(ResponseHandler.deleted).toHaveBeenCalledWith(mockRes);
+    });
+
+    it('should handle service errors', async () => {
+      serviceMock.delete.mockRejectedValue(new Error('DB error'));
+
+      const req = { params: { id: 'abc' } } as unknown as Request;
+      await controller.delete(req, mockRes);
+
+      expect(ResponseHandler.error).toHaveBeenCalledWith(mockRes, 'Failed to delete product', 500);
+    });
+  });
+});

--- a/src/__tests__/unit/admin/product-admin.service.test.ts
+++ b/src/__tests__/unit/admin/product-admin.service.test.ts
@@ -1,0 +1,65 @@
+import { ProductRepository } from '@scrapers/revolico/repositories/product.repository';
+
+// Mock ProductRepository with both existing and new methods.
+// This confirms the deleteById and aggregate method shapes before they exist.
+jest.mock('@scrapers/revolico/repositories/product.repository', () => ({
+  __esModule: true,
+  ProductRepository: jest.fn().mockImplementation(() => ({
+    clearAll: jest.fn(),
+    findOne: jest.fn(),
+    update: jest.fn(),
+    find: jest.fn(),
+    count: jest.fn(),
+    bulkInsertOrUpdate: jest.fn(),
+    deleteById: jest.fn(),
+    aggregate: jest.fn(),
+  })),
+}));
+
+describe('ProductAdminService — Repository shape verification', () => {
+  let mockRepo: jest.Mocked<ProductRepository>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRepo = new (ProductRepository as jest.Mock)() as jest.Mocked<ProductRepository>;
+  });
+
+  describe('deleteById', () => {
+    it('should be defined and accept a string _id', async () => {
+      expect(mockRepo.deleteById).toBeDefined();
+      expect(typeof mockRepo.deleteById).toBe('function');
+
+      mockRepo.deleteById.mockResolvedValue({ acknowledged: true, deletedCount: 1 });
+      const result = await mockRepo.deleteById('abc123');
+
+      expect(mockRepo.deleteById).toHaveBeenCalledWith('abc123');
+      expect(result).toEqual({ acknowledged: true, deletedCount: 1 });
+    });
+
+    it('should return DeleteResult with deletedCount 0 when id does not match', async () => {
+      mockRepo.deleteById.mockResolvedValue({ acknowledged: true, deletedCount: 0 });
+      const result = await mockRepo.deleteById('nonexistent-id');
+      expect(result.deletedCount).toBe(0);
+    });
+  });
+
+  describe('aggregate', () => {
+    it('should be defined and accept a PipelineStage array', async () => {
+      expect(mockRepo.aggregate).toBeDefined();
+      expect(typeof mockRepo.aggregate).toBe('function');
+
+      const pipeline = [{ $match: { category: 'inmuebles' } }];
+      mockRepo.aggregate.mockResolvedValue([{ _id: 'cat-1', count: 42 }]);
+      const result = await mockRepo.aggregate(pipeline as never[]);
+
+      expect(mockRepo.aggregate).toHaveBeenCalledWith(pipeline);
+      expect(result).toEqual([{ _id: 'cat-1', count: 42 }]);
+    });
+
+    it('should return an empty array when no documents match', async () => {
+      mockRepo.aggregate.mockResolvedValue([]);
+      const result = await mockRepo.aggregate([{ $match: { nonExistent: true } }] as never[]);
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/src/__tests__/unit/admin/product-admin.service.test.ts
+++ b/src/__tests__/unit/admin/product-admin.service.test.ts
@@ -1,4 +1,5 @@
 import { ProductRepository } from '@scrapers/revolico/repositories/product.repository';
+import { ILogger } from '@shared/logger.interface';
 
 // Mock ProductRepository with both existing and new methods.
 // This confirms the deleteById and aggregate method shapes before they exist.
@@ -15,6 +16,9 @@ jest.mock('@scrapers/revolico/repositories/product.repository', () => ({
     aggregate: jest.fn(),
   })),
 }));
+
+import { ProductAdminService } from '@admin/services/product-admin.service';
+import { ProductListQueryDTO } from '@admin/services/dto/product-list-query.dto';
 
 describe('ProductAdminService — Repository shape verification', () => {
   let mockRepo: jest.Mocked<ProductRepository>;
@@ -60,6 +64,365 @@ describe('ProductAdminService — Repository shape verification', () => {
       mockRepo.aggregate.mockResolvedValue([]);
       const result = await mockRepo.aggregate([{ $match: { nonExistent: true } }] as never[]);
       expect(result).toEqual([]);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ProductAdminService tests
+// ---------------------------------------------------------------------------
+describe('ProductAdminService', () => {
+  let service: ProductAdminService;
+  let mockRepo: jest.Mocked<ProductRepository>;
+  let loggerMock: ILogger;
+
+  // Reusable mock product returned from repo
+  const mockProduct = {
+    _id: '507f191e810c19729de860ea',
+    ID: 'REV-123',
+    category: 'inmuebles',
+    subcategory: 'apartamentos',
+    url: 'https://revolico.com/item/123',
+    description: 'Hermoso apartamento',
+    cost: '50000',
+    currency: 'USD',
+    price: 50000,
+    imageURL: 'https://img.revolico.com/123.jpg',
+    isOutstanding: true,
+    isPromoted: true,
+    location: { state: 'La Habana', municipality: 'Plaza' },
+    views: 150,
+    seller: { name: 'Juan', phone: '+5355555555' },
+    priceHistory: [
+      { value: 50000, updatedAt: new Date('2025-01-10') },
+      { value: 52000, updatedAt: new Date('2025-01-01') },
+    ],
+    viewsHistory: [{ value: 150, updatedAt: new Date('2025-01-10') }],
+    locationHistory: [{ value: { state: 'La Habana', municipality: 'Plaza' }, updatedAt: new Date('2025-01-10') }],
+    isOutstandingHistory: [{ value: true, updatedAt: new Date('2025-01-10') }],
+    isPromotedHistory: [{ value: true, updatedAt: new Date('2025-01-10') }],
+    metadata: { scrapedAt: new Date('2025-01-15') },
+    tags: ['vedado'],
+    attributes: {},
+    analytics: {},
+    createdAt: new Date('2025-01-01'),
+    updatedAt: new Date('2025-01-15'),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    loggerMock = {
+      context: '',
+      info: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn(),
+      log: jest.fn(),
+    } as unknown as ILogger;
+
+    mockRepo = new (ProductRepository as jest.Mock)() as jest.Mocked<ProductRepository>;
+    service = new ProductAdminService(mockRepo, loggerMock);
+  });
+
+  // -------------------------------------------------------------------------
+  // list
+  // -------------------------------------------------------------------------
+  describe('list', () => {
+    it('should return paginated products', async () => {
+      mockRepo.find.mockResolvedValue([mockProduct] as never[]);
+      mockRepo.count.mockResolvedValue(1);
+
+      const query = ProductListQueryDTO.from({ skip: 0, limit: 20 });
+      const result = await service.list(query);
+
+      expect(result.data).toHaveLength(1);
+      expect(result.meta.total).toBe(1);
+      expect(result.meta.skip).toBe(0);
+      expect(result.meta.limit).toBe(20);
+      expect(mockRepo.find).toHaveBeenCalled();
+      expect(mockRepo.count).toHaveBeenCalled();
+    });
+
+    it('should pass search as regex to filter', async () => {
+      mockRepo.find.mockResolvedValue([]);
+      mockRepo.count.mockResolvedValue(0);
+
+      const query = ProductListQueryDTO.from({ search: 'apartamento', skip: 0, limit: 10 });
+      await service.list(query);
+
+      // The filter passed to find should include a regex on description
+      const findCall = mockRepo.find.mock.calls[0] as unknown[];
+      expect(findCall[3]).toEqual(
+        expect.objectContaining({
+          description: expect.objectContaining({ $regex: 'apartamento', $options: 'i' }),
+        }),
+      );
+    });
+
+    it('should build filter from category and subcategory', async () => {
+      mockRepo.find.mockResolvedValue([]);
+      mockRepo.count.mockResolvedValue(0);
+
+      const query = ProductListQueryDTO.from({ category: 'inmuebles', subcategory: 'apartamentos', skip: 0, limit: 10 });
+      await service.list(query);
+
+      const findCall = mockRepo.find.mock.calls[0] as unknown[];
+      expect(findCall[3]).toEqual(
+        expect.objectContaining({
+          category: 'inmuebles',
+          subcategory: 'apartamentos',
+        }),
+      );
+    });
+
+    it('should build filter from price range', async () => {
+      mockRepo.find.mockResolvedValue([]);
+      mockRepo.count.mockResolvedValue(0);
+
+      const query = ProductListQueryDTO.from({ minPrice: 100, maxPrice: 1000, skip: 0, limit: 10 });
+      await service.list(query);
+
+      const findCall = mockRepo.find.mock.calls[0] as unknown[];
+      expect(findCall[3]).toEqual(
+        expect.objectContaining({
+          price: { $gte: 100, $lte: 1000 },
+        }),
+      );
+    });
+
+    it('should build filter from boolean flags', async () => {
+      mockRepo.find.mockResolvedValue([]);
+      mockRepo.count.mockResolvedValue(0);
+
+      const query = ProductListQueryDTO.from({ isOutstanding: true, isPromoted: true, skip: 0, limit: 10 });
+      await service.list(query);
+
+      const findCall = mockRepo.find.mock.calls[0] as unknown[];
+      expect(findCall[3]).toEqual(
+        expect.objectContaining({
+          isOutstanding: true,
+          isPromoted: true,
+        }),
+      );
+    });
+
+    it('should build nested location filter', async () => {
+      mockRepo.find.mockResolvedValue([]);
+      mockRepo.count.mockResolvedValue(0);
+
+      const query = ProductListQueryDTO.from({ 'location.state': 'La Habana', skip: 0, limit: 10 });
+      await service.list(query);
+
+      const findCall = mockRepo.find.mock.calls[0] as unknown[];
+      expect(findCall[3]).toEqual(
+        expect.objectContaining({
+          'location.state': 'La Habana',
+        }),
+      );
+    });
+
+    it('should pass projection to exclude history arrays', async () => {
+      mockRepo.find.mockResolvedValue([mockProduct] as never[]);
+      mockRepo.count.mockResolvedValue(1);
+
+      const query = ProductListQueryDTO.from({ skip: 0, limit: 20 });
+      await service.list(query);
+
+      const findCall = mockRepo.find.mock.calls[0] as unknown[];
+      expect(findCall[4]).toEqual(
+        expect.objectContaining({
+          priceHistory: 0,
+          viewsHistory: 0,
+          locationHistory: 0,
+          isOutstandingHistory: 0,
+          isPromotedHistory: 0,
+        }),
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getById
+  // -------------------------------------------------------------------------
+  describe('getById', () => {
+    it('should return product detail when found', async () => {
+      mockRepo.findOne.mockResolvedValue(mockProduct);
+
+      const result = await service.getById('507f191e810c19729de860ea');
+
+      expect(result).not.toBeNull();
+      expect(result?._id).toBe('507f191e810c19729de860ea');
+      expect(mockRepo.findOne).toHaveBeenCalledWith(
+        { _id: '507f191e810c19729de860ea' },
+        expect.objectContaining({
+          priceHistory: 0,
+          viewsHistory: 0,
+          locationHistory: 0,
+        }),
+      );
+    });
+
+    it('should return null when product not found', async () => {
+      mockRepo.findOne.mockResolvedValue(null);
+
+      const result = await service.getById('nonexistent');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getPriceHistory
+  // -------------------------------------------------------------------------
+  describe('getPriceHistory', () => {
+    it('should return sorted price history', async () => {
+      mockRepo.findOne.mockResolvedValue(mockProduct);
+
+      const result = await service.getPriceHistory('507f191e810c19729de860ea');
+
+      expect(result).not.toBeNull();
+      expect(result?.data).toHaveLength(2);
+      expect(result?.total).toBe(2);
+      // Sorted desc: newest first
+      expect(result?.data[0].value).toBe(50000);
+    });
+
+    it('should return null when product not found', async () => {
+      mockRepo.findOne.mockResolvedValue(null);
+
+      const result = await service.getPriceHistory('nonexistent');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getViewsHistory
+  // -------------------------------------------------------------------------
+  describe('getViewsHistory', () => {
+    it('should return views history', async () => {
+      mockRepo.findOne.mockResolvedValue(mockProduct);
+
+      const result = await service.getViewsHistory('507f191e810c19729de860ea');
+
+      expect(result).not.toBeNull();
+      expect(result?.data).toHaveLength(1);
+      expect(result?.data[0].value).toBe(150);
+    });
+
+    it('should return null when product not found', async () => {
+      mockRepo.findOne.mockResolvedValue(null);
+      expect(await service.getViewsHistory('nonexistent')).toBeNull();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getLocationHistory
+  // -------------------------------------------------------------------------
+  describe('getLocationHistory', () => {
+    it('should return location history', async () => {
+      mockRepo.findOne.mockResolvedValue(mockProduct);
+
+      const result = await service.getLocationHistory('507f191e810c19729de860ea');
+
+      expect(result).not.toBeNull();
+      expect(result?.data).toHaveLength(1);
+      expect(result?.data[0].location.state).toBe('La Habana');
+    });
+
+    it('should return null when product not found', async () => {
+      mockRepo.findOne.mockResolvedValue(null);
+      expect(await service.getLocationHistory('nonexistent')).toBeNull();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getOutstandingHistory
+  // -------------------------------------------------------------------------
+  describe('getOutstandingHistory', () => {
+    it('should return outstanding history', async () => {
+      mockRepo.findOne.mockResolvedValue(mockProduct);
+
+      const result = await service.getOutstandingHistory('507f191e810c19729de860ea');
+
+      expect(result).not.toBeNull();
+      expect(result?.data).toHaveLength(1);
+    });
+
+    it('should return null when product not found', async () => {
+      mockRepo.findOne.mockResolvedValue(null);
+      expect(await service.getOutstandingHistory('nonexistent')).toBeNull();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getPromotedHistory
+  // -------------------------------------------------------------------------
+  describe('getPromotedHistory', () => {
+    it('should return promoted history', async () => {
+      mockRepo.findOne.mockResolvedValue(mockProduct);
+
+      const result = await service.getPromotedHistory('507f191e810c19729de860ea');
+
+      expect(result).not.toBeNull();
+      expect(result?.data).toHaveLength(1);
+    });
+
+    it('should return null when product not found', async () => {
+      mockRepo.findOne.mockResolvedValue(null);
+      expect(await service.getPromotedHistory('nonexistent')).toBeNull();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getStats
+  // -------------------------------------------------------------------------
+  describe('getStats', () => {
+    it('should return product statistics from aggregation', async () => {
+      // Mock aggregate to return results for each pipeline stage
+      mockRepo.aggregate
+        .mockResolvedValueOnce([{ _id: 'inmuebles', count: 10 }]) // byCategory
+        .mockResolvedValueOnce([{ _id: 'La Habana', count: 8 }]) // byState
+        .mockResolvedValueOnce([{ total: 20, outstanding: 5, promoted: 3 }]) // counts
+        .mockResolvedValueOnce([{ lastScrapedAt: new Date('2025-01-15'), minPrice: 100, maxPrice: 50000 }]); // price/meta
+
+      const result = await service.getStats();
+
+      expect(result.totalProducts).toBe(20);
+      expect(result.byCategory).toEqual([{ category: 'inmuebles', count: 10 }]);
+      expect(result.byState).toEqual([{ state: 'La Habana', count: 8 }]);
+      expect(result.outstandingCount).toBe(5);
+      expect(result.promotedCount).toBe(3);
+      expect(result.lastScrapedAt).toBe('2025-01-15T00:00:00.000Z');
+      expect(result.priceRange).toEqual({ min: 100, max: 50000 });
+    });
+
+    it('should handle empty aggregation results', async () => {
+      mockRepo.aggregate.mockResolvedValueOnce([]).mockResolvedValueOnce([]).mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+
+      const result = await service.getStats();
+
+      expect(result.totalProducts).toBe(0);
+      expect(result.byCategory).toEqual([]);
+      expect(result.byState).toEqual([]);
+      expect(result.outstandingCount).toBe(0);
+      expect(result.promotedCount).toBe(0);
+      expect(result.lastScrapedAt).toBeNull();
+      expect(result.priceRange).toEqual({ min: 0, max: 0 });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // delete
+  // -------------------------------------------------------------------------
+  describe('delete', () => {
+    it('should call repo.deleteById with the given id', async () => {
+      mockRepo.deleteById.mockResolvedValue({ acknowledged: true, deletedCount: 1 });
+
+      await service.delete('507f191e810c19729de860ea');
+
+      expect(mockRepo.deleteById).toHaveBeenCalledWith('507f191e810c19729de860ea');
     });
   });
 });

--- a/src/__tests__/unit/admin/product-list-query.dto.test.ts
+++ b/src/__tests__/unit/admin/product-list-query.dto.test.ts
@@ -1,0 +1,129 @@
+import { ProductListQueryDTO, ProductListQueryType } from '@admin/services/dto/product-list-query.dto';
+
+describe('ProductListQueryDTO', () => {
+  describe('defaults', () => {
+    it('should apply default values when called with empty object', () => {
+      const result = ProductListQueryDTO.from({});
+      expect(result.skip).toBe(0);
+      expect(result.limit).toBe(20);
+      expect(result.sort).toBe('createdAt');
+      expect(result.order).toBe('desc');
+    });
+
+    it('should apply defaults when called with null', () => {
+      const result = ProductListQueryDTO.from(null);
+      expect(result.skip).toBe(0);
+      expect(result.limit).toBe(20);
+    });
+
+    it('should apply defaults when called with undefined', () => {
+      const result = ProductListQueryDTO.from(undefined);
+      expect(result.skip).toBe(0);
+      expect(result.limit).toBe(20);
+    });
+  });
+
+  describe('skip / limit boundaries', () => {
+    it('should coerce string skip to number and accept valid values', () => {
+      const result = ProductListQueryDTO.from({ skip: '10', limit: '50' });
+      expect(result.skip).toBe(10);
+      expect(result.limit).toBe(50);
+    });
+
+    it('should reject negative skip', () => {
+      expect(() => ProductListQueryDTO.from({ skip: -5 })).toThrow();
+    });
+
+    it('should reject limit of 0', () => {
+      expect(() => ProductListQueryDTO.from({ limit: 0 })).toThrow();
+    });
+
+    it('should reject limit greater than 100', () => {
+      expect(() => ProductListQueryDTO.from({ limit: 101 })).toThrow();
+    });
+
+    it('should accept limit of 100 (max boundary)', () => {
+      const result = ProductListQueryDTO.from({ limit: 100 });
+      expect(result.limit).toBe(100);
+    });
+
+    it('should accept limit of 1 (min boundary)', () => {
+      const result = ProductListQueryDTO.from({ limit: 1 });
+      expect(result.limit).toBe(1);
+    });
+  });
+
+  describe('sort / order', () => {
+    it('should accept custom sort field', () => {
+      const result = ProductListQueryDTO.from({ sort: 'price' });
+      expect(result.sort).toBe('price');
+    });
+
+    it('should accept ascending order', () => {
+      const result = ProductListQueryDTO.from({ order: 'asc' });
+      expect(result.order).toBe('asc');
+    });
+
+    it('should reject invalid order value', () => {
+      expect(() => ProductListQueryDTO.from({ order: 'invalid' })).toThrow();
+    });
+  });
+
+  describe('optional filters', () => {
+    it('should accept category', () => {
+      const result = ProductListQueryDTO.from({ category: 'inmuebles' });
+      expect(result.category).toBe('inmuebles');
+    });
+
+    it('should accept subcategory', () => {
+      const result = ProductListQueryDTO.from({ subcategory: 'apartamentos' });
+      expect(result.subcategory).toBe('apartamentos');
+    });
+
+    it('should accept search string', () => {
+      const result = ProductListQueryDTO.from({ search: 'casa' });
+      expect(result.search).toBe('casa');
+    });
+
+    it('should accept minPrice and maxPrice', () => {
+      const result = ProductListQueryDTO.from({ minPrice: '100', maxPrice: '500' });
+      expect(result.minPrice).toBe(100);
+      expect(result.maxPrice).toBe(500);
+    });
+
+    it('should accept isOutstanding', () => {
+      const result = ProductListQueryDTO.from({ isOutstanding: 'true' });
+      expect(result.isOutstanding).toBe(true);
+    });
+
+    it('should accept isPromoted', () => {
+      const result = ProductListQueryDTO.from({ isPromoted: 'false' });
+      expect(result.isPromoted).toBe(false);
+    });
+
+    it('should accept location.state', () => {
+      const result = ProductListQueryDTO.from({ 'location.state': 'La Habana' });
+      expect(result['location.state']).toBe('La Habana');
+    });
+
+    it('should have all optional fields undefined when not provided', () => {
+      const result = ProductListQueryDTO.from({});
+      expect(result.category).toBeUndefined();
+      expect(result.subcategory).toBeUndefined();
+      expect(result.search).toBeUndefined();
+      expect(result.minPrice).toBeUndefined();
+      expect(result.maxPrice).toBeUndefined();
+      expect(result.isOutstanding).toBeUndefined();
+      expect(result.isPromoted).toBeUndefined();
+      expect(result['location.state']).toBeUndefined();
+    });
+  });
+
+  describe('type inference', () => {
+    it('should export ProductListQueryType', () => {
+      // Compile-time check: ensure the type is inferred from the schema
+      const _typeCheck: ProductListQueryType = {} as ProductListQueryType;
+      expect(_typeCheck).toBeDefined();
+    });
+  });
+});

--- a/src/__tests__/unit/admin/product-response.dto.test.ts
+++ b/src/__tests__/unit/admin/product-response.dto.test.ts
@@ -1,0 +1,154 @@
+import {
+  ProductListItemDTO,
+  ProductDetailDTO,
+  PriceHistoryEntrySchema,
+  LocationHistoryEntrySchema,
+  ProductHistorySchema,
+} from '@admin/services/dto/product-response.dto';
+
+describe('ProductListItemDTO', () => {
+  const validMinimal = {
+    _id: '64a1b2c3d4e5f6a7b8c9d0e1',
+    url: 'https://example.com/product-1',
+    currency: 'USD',
+    price: 100,
+    isOutstanding: false,
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-02T00:00:00.000Z',
+  };
+
+  it('should accept a minimal valid object', () => {
+    const result = ProductListItemDTO.from(validMinimal);
+    expect(result._id).toBe(validMinimal._id);
+    expect(result.url).toBe(validMinimal.url);
+    expect(result.price).toBe(100);
+  });
+
+  it('should accept all optional fields', () => {
+    const full = {
+      ...validMinimal,
+      ID: 'PROD-001',
+      category: 'inmuebles',
+      subcategory: 'apartamentos',
+      description: 'Nice apartment',
+      cost: '50000 USD',
+      imageURL: 'https://example.com/img.jpg',
+      isPromoted: true,
+      location: { state: 'La Habana', municipality: 'Playa' },
+      views: 150,
+      seller: { name: 'John Doe' },
+      metadata: { scrapedAt: '2024-01-01T00:00:00.000Z' },
+    };
+    const result = ProductListItemDTO.from(full);
+    expect(result.ID).toBe('PROD-001');
+    expect(result.category).toBe('inmuebles');
+    expect(result.location?.state).toBe('La Habana');
+    expect(result.seller?.name).toBe('John Doe');
+    expect(result.views).toBe(150);
+  });
+
+  it('should reject missing required fields (_id, url, currency, price)', () => {
+    expect(() => ProductListItemDTO.from({ url: 'x' })).toThrow();
+    expect(() => ProductListItemDTO.from({ _id: 'x' })).toThrow();
+    expect(() => ProductListItemDTO.from({})).toThrow();
+    expect(() => ProductListItemDTO.from(null)).toThrow();
+  });
+});
+
+describe('ProductDetailDTO', () => {
+  const validMinimal = {
+    _id: '64a1b2c3d4e5f6a7b8c9d0e1',
+    url: 'https://example.com/product-1',
+    currency: 'USD',
+    price: 100,
+    isOutstanding: false,
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-02T00:00:00.000Z',
+  };
+
+  it('should accept a minimal valid object', () => {
+    const result = ProductDetailDTO.from(validMinimal);
+    expect(result._id).toBe(validMinimal._id);
+  });
+
+  it('should accept full detail with all fields', () => {
+    const full = {
+      ...validMinimal,
+      ID: 'PROD-001',
+      category: 'inmuebles',
+      subcategory: 'apartamentos',
+      description: 'Nice apartment in Vedado',
+      cost: '50000 USD',
+      imageURL: 'https://example.com/img.jpg',
+      isPromoted: true,
+      location: { state: 'La Habana', municipality: 'Vedado' },
+      views: 250,
+      seller: { name: 'John Doe', phone: '+5355555555', email: 'john@example.com', whatsapp: '+5355555555' },
+      metadata: { source: 'revolico', schemaVersion: 1, scrapedAt: '2024-01-01T00:00:00.000Z' },
+      tags: ['urgent', 'sale'],
+      attributes: { condition: 'new' },
+      analytics: { viewsPerDay: 10 },
+    };
+    const result = ProductDetailDTO.from(full);
+    expect(result.seller?.phone).toBe('+5355555555');
+    expect(result.tags).toContain('urgent');
+    expect(result.metadata?.source).toBe('revolico');
+    expect(result.analytics).toEqual({ viewsPerDay: 10 });
+  });
+
+  it('should reject missing required fields', () => {
+    expect(() => ProductDetailDTO.from({})).toThrow();
+    expect(() => ProductDetailDTO.from(null)).toThrow();
+  });
+});
+
+describe('PriceHistoryEntrySchema', () => {
+  it('should accept valid price history entry', () => {
+    const result = PriceHistoryEntrySchema.parse({ value: 100, updatedAt: '2024-01-01T00:00:00.000Z' });
+    expect(result.value).toBe(100);
+    expect(result.updatedAt).toBe('2024-01-01T00:00:00.000Z');
+  });
+
+  it('should reject missing required fields', () => {
+    expect(() => PriceHistoryEntrySchema.parse({})).toThrow();
+    expect(() => PriceHistoryEntrySchema.parse({ value: 100 })).toThrow();
+  });
+});
+
+describe('LocationHistoryEntrySchema', () => {
+  it('should accept valid location history entry with municipality', () => {
+    const result = LocationHistoryEntrySchema.parse({
+      location: { state: 'La Habana', municipality: 'Playa' },
+      updatedAt: '2024-01-01T00:00:00.000Z',
+    });
+    expect(result.location.state).toBe('La Habana');
+    expect(result.location.municipality).toBe('Playa');
+  });
+
+  it('should accept location history entry without municipality', () => {
+    const result = LocationHistoryEntrySchema.parse({
+      location: { state: 'La Habana' },
+      updatedAt: '2024-01-01T00:00:00.000Z',
+    });
+    expect(result.location.municipality).toBeUndefined();
+  });
+});
+
+describe('ProductHistorySchema (generic wrapper)', () => {
+  it('should wrap items in { data, total } structure', () => {
+    const schema = ProductHistorySchema(PriceHistoryEntrySchema);
+    const result = schema.parse({
+      data: [{ value: 100, updatedAt: '2024-01-01T00:00:00.000Z' }],
+      total: 1,
+    });
+    expect(result.data).toHaveLength(1);
+    expect(result.total).toBe(1);
+  });
+
+  it('should accept empty data array', () => {
+    const schema = ProductHistorySchema(LocationHistoryEntrySchema);
+    const result = schema.parse({ data: [], total: 0 });
+    expect(result.data).toEqual([]);
+    expect(result.total).toBe(0);
+  });
+});

--- a/src/__tests__/unit/admin/product-response.dto.test.ts
+++ b/src/__tests__/unit/admin/product-response.dto.test.ts
@@ -10,6 +10,8 @@ describe('ProductListItemDTO', () => {
   const validMinimal = {
     _id: '64a1b2c3d4e5f6a7b8c9d0e1',
     url: 'https://example.com/product-1',
+    cost: '100',
+    category: 'electronica',
     currency: 'USD',
     price: 100,
     isOutstanding: false,
@@ -37,7 +39,6 @@ describe('ProductListItemDTO', () => {
       location: { state: 'La Habana', municipality: 'Playa' },
       views: 150,
       seller: { name: 'John Doe' },
-      metadata: { scrapedAt: '2024-01-01T00:00:00.000Z' },
     };
     const result = ProductListItemDTO.from(full);
     expect(result.ID).toBe('PROD-001');
@@ -47,7 +48,7 @@ describe('ProductListItemDTO', () => {
     expect(result.views).toBe(150);
   });
 
-  it('should reject missing required fields (_id, url, currency, price)', () => {
+  it('should reject missing required fields (_id, url, cost, category, currency, price)', () => {
     expect(() => ProductListItemDTO.from({ url: 'x' })).toThrow();
     expect(() => ProductListItemDTO.from({ _id: 'x' })).toThrow();
     expect(() => ProductListItemDTO.from({})).toThrow();
@@ -59,6 +60,8 @@ describe('ProductDetailDTO', () => {
   const validMinimal = {
     _id: '64a1b2c3d4e5f6a7b8c9d0e1',
     url: 'https://example.com/product-1',
+    cost: '100',
+    category: 'electronica',
     currency: 'USD',
     price: 100,
     isOutstanding: false,
@@ -84,16 +87,12 @@ describe('ProductDetailDTO', () => {
       location: { state: 'La Habana', municipality: 'Vedado' },
       views: 250,
       seller: { name: 'John Doe', phone: '+5355555555', email: 'john@example.com', whatsapp: '+5355555555' },
-      metadata: { source: 'revolico', schemaVersion: 1, scrapedAt: '2024-01-01T00:00:00.000Z' },
-      tags: ['urgent', 'sale'],
-      attributes: { condition: 'new' },
-      analytics: { viewsPerDay: 10 },
     };
     const result = ProductDetailDTO.from(full);
+    expect(result.cost).toBe('50000 USD');
+    expect(result.category).toBe('inmuebles');
     expect(result.seller?.phone).toBe('+5355555555');
-    expect(result.tags).toContain('urgent');
-    expect(result.metadata?.source).toBe('revolico');
-    expect(result.analytics).toEqual({ viewsPerDay: 10 });
+    expect(result.seller?.email).toBe('john@example.com');
   });
 
   it('should reject missing required fields', () => {

--- a/src/__tests__/unit/admin/product.mapper.test.ts
+++ b/src/__tests__/unit/admin/product.mapper.test.ts
@@ -1,0 +1,356 @@
+import { IRevolicoProduct } from '@scrapers/revolico/models/product.model';
+
+// ---------------------------------------------------------------------------
+// We'll test the mapper after it's created.
+// Import placeholders — will be resolved in GREEN phase.
+// ---------------------------------------------------------------------------
+
+import {
+  toProductListItemDTO,
+  toProductDetailDTO,
+  toProductListItemDTOs,
+  toPaginatedResponse,
+  toPriceHistoryEntries,
+  toViewsHistoryEntries,
+  toLocationHistoryEntries,
+  toOutstandingHistoryEntries,
+  toPromotedHistoryEntries,
+} from '@admin/mappers/product.mapper';
+
+describe('ProductMapper', () => {
+  // ---------------------------------------------------------------------------
+  // Fixtures
+  // ---------------------------------------------------------------------------
+
+  const baseProduct: IRevolicoProduct = {
+    _id: '507f191e810c19729de860ea',
+    ID: 'REV-123',
+    category: 'inmuebles',
+    subcategory: 'apartamentos',
+    url: 'https://revolico.com/item/123',
+    description: 'Hermoso apartamento en Vedado',
+    cost: '50000',
+    currency: 'USD',
+    price: 50000,
+    imageURL: 'https://img.revolico.com/123.jpg',
+    isOutstanding: true,
+    isPromoted: true,
+    location: { state: 'La Habana', municipality: 'Plaza' },
+    views: 150,
+    seller: { name: 'Juan', phone: '+5355555555', email: 'juan@email.cu', whatsapp: '+5355555555' },
+    metadata: { source: 'revolico', schemaVersion: 2, scrapedAt: new Date('2025-01-15') },
+    tags: ['vedado', '2cuartos'],
+    attributes: { rooms: 2, bathrooms: 1 },
+    analytics: { avgPrice: 48000 },
+    priceHistory: [
+      { value: 52000, updatedAt: new Date('2025-01-01') },
+      { value: 50000, updatedAt: new Date('2025-01-10') },
+      { value: 48000, updatedAt: new Date('2025-01-05') },
+    ],
+    viewsHistory: [
+      { value: 100, updatedAt: new Date('2025-01-05') },
+      { value: 150, updatedAt: new Date('2025-01-10') },
+    ],
+    locationHistory: [{ value: { state: 'La Habana', municipality: 'Plaza' }, updatedAt: new Date('2025-01-10') }],
+    isOutstandingHistory: [
+      { value: false, updatedAt: new Date('2025-01-01') },
+      { value: true, updatedAt: new Date('2025-01-10') },
+    ],
+    isPromotedHistory: [
+      { value: false, updatedAt: new Date('2025-01-01') },
+      { value: true, updatedAt: new Date('2025-01-10') },
+    ],
+    createdAt: '2025-01-01T00:00:00.000Z',
+    updatedAt: '2025-01-15T00:00:00.000Z',
+  } as IRevolicoProduct;
+
+  // ---------------------------------------------------------------------------
+  // toProductListItemDTO
+  // ---------------------------------------------------------------------------
+  describe('toProductListItemDTO', () => {
+    it('should map a product to a list item DTO with correct fields', () => {
+      const result = toProductListItemDTO(baseProduct);
+
+      expect(result._id).toBe('507f191e810c19729de860ea');
+      expect(result.ID).toBe('REV-123');
+      expect(result.category).toBe('inmuebles');
+      expect(result.subcategory).toBe('apartamentos');
+      expect(result.url).toBe('https://revolico.com/item/123');
+      expect(result.description).toBe('Hermoso apartamento en Vedado');
+      expect(result.cost).toBe('50000');
+      expect(result.currency).toBe('USD');
+      expect(result.price).toBe(50000);
+      expect(result.imageURL).toBe('https://img.revolico.com/123.jpg');
+      expect(result.isOutstanding).toBe(true);
+      expect(result.isPromoted).toBe(true);
+      expect(result.location).toEqual({ state: 'La Habana', municipality: 'Plaza' });
+      expect(result.views).toBe(150);
+      expect(result.seller).toEqual({ name: 'Juan' });
+      expect(result.createdAt).toBe('2025-01-01T00:00:00.000Z');
+      expect(result.updatedAt).toBe('2025-01-15T00:00:00.000Z');
+    });
+
+    it('should NOT include history arrays in list item DTO', () => {
+      const result = toProductListItemDTO(baseProduct);
+      expect((result as Record<string, unknown>).priceHistory).toBeUndefined();
+      expect((result as Record<string, unknown>).viewsHistory).toBeUndefined();
+      expect((result as Record<string, unknown>).locationHistory).toBeUndefined();
+      expect((result as Record<string, unknown>).isOutstandingHistory).toBeUndefined();
+      expect((result as Record<string, unknown>).isPromotedHistory).toBeUndefined();
+    });
+
+    it('should handle missing optional fields gracefully', () => {
+      const minimal: IRevolicoProduct = {
+        _id: '507f191e810c19729de860ea',
+        url: 'https://revolico.com/item/min',
+        currency: 'USD',
+        price: 10,
+        isOutstanding: false,
+        createdAt: '2025-01-01T00:00:00.000Z',
+        updatedAt: '2025-01-01T00:00:00.000Z',
+      } as IRevolicoProduct;
+
+      const result = toProductListItemDTO(minimal);
+
+      expect(result._id).toBe('507f191e810c19729de860ea');
+      expect(result.url).toBe('https://revolico.com/item/min');
+      expect(result.price).toBe(10);
+      expect(result.currency).toBe('USD');
+      expect(result.isOutstanding).toBe(false);
+      expect(result.category).toBeUndefined();
+      expect(result.subcategory).toBeUndefined();
+      expect(result.description).toBeUndefined();
+      expect(result.imageURL).toBeUndefined();
+      expect(result.isPromoted).toBeUndefined();
+      expect(result.views).toBeUndefined();
+      expect(result.seller).toBeUndefined();
+    });
+
+    it('should serialize _id from ObjectId to string', () => {
+      const productWithObjectId = {
+        ...baseProduct,
+        _id: { toString: () => '507f191e810c19729de860ea' } as unknown as string,
+      };
+      const result = toProductListItemDTO(productWithObjectId);
+      expect(result._id).toBe('507f191e810c19729de860ea');
+    });
+
+    it('should handle null location', () => {
+      const noLocation = { ...baseProduct, location: undefined };
+      const result = toProductListItemDTO(noLocation);
+      expect(result.location).toBeUndefined();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // toProductDetailDTO
+  // ---------------------------------------------------------------------------
+  describe('toProductDetailDTO', () => {
+    it('should map a product to a detail DTO with all fields', () => {
+      const result = toProductDetailDTO(baseProduct);
+
+      expect(result._id).toBe('507f191e810c19729de860ea');
+      expect(result.ID).toBe('REV-123');
+      expect(result.category).toBe('inmuebles');
+      expect(result.subcategory).toBe('apartamentos');
+      expect(result.url).toBe('https://revolico.com/item/123');
+      expect(result.description).toBe('Hermoso apartamento en Vedado');
+      expect(result.cost).toBe('50000');
+      expect(result.currency).toBe('USD');
+      expect(result.price).toBe(50000);
+      expect(result.imageURL).toBe('https://img.revolico.com/123.jpg');
+      expect(result.isOutstanding).toBe(true);
+      expect(result.isPromoted).toBe(true);
+      expect(result.location).toEqual({ state: 'La Habana', municipality: 'Plaza' });
+      expect(result.views).toBe(150);
+      expect(result.seller).toEqual({
+        name: 'Juan',
+        phone: '+5355555555',
+        email: 'juan@email.cu',
+        whatsapp: '+5355555555',
+      });
+      expect(result.tags).toEqual(['vedado', '2cuartos']);
+      expect(result.attributes).toEqual({ rooms: 2, bathrooms: 1 });
+      expect(result.analytics).toEqual({ avgPrice: 48000 });
+      expect(result.metadata).toEqual({ source: 'revolico', schemaVersion: 2, scrapedAt: new Date('2025-01-15') });
+    });
+
+    it('should NOT include history arrays in detail DTO', () => {
+      const result = toProductDetailDTO(baseProduct);
+      expect((result as Record<string, unknown>).priceHistory).toBeUndefined();
+      expect((result as Record<string, unknown>).viewsHistory).toBeUndefined();
+      expect((result as Record<string, unknown>).locationHistory).toBeUndefined();
+    });
+
+    it('should handle minimal product', () => {
+      const minimal: IRevolicoProduct = {
+        _id: 'abc',
+        url: 'https://revolico.com/item/min',
+        currency: 'USD',
+        price: 5,
+        isOutstanding: false,
+        createdAt: '2025-01-01T00:00:00.000Z',
+        updatedAt: '2025-01-01T00:00:00.000Z',
+      } as IRevolicoProduct;
+
+      const result = toProductDetailDTO(minimal);
+      expect(result._id).toBe('abc');
+      expect(result.tags).toBeUndefined();
+      expect(result.attributes).toBeUndefined();
+      expect(result.analytics).toBeUndefined();
+      expect(result.seller).toBeUndefined();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // toProductListItemDTOs
+  // ---------------------------------------------------------------------------
+  describe('toProductListItemDTOs', () => {
+    it('should map an array of products', () => {
+      const result = toProductListItemDTOs([baseProduct, baseProduct]);
+      expect(result).toHaveLength(2);
+      expect(result[0]._id).toBe('507f191e810c19729de860ea');
+    });
+
+    it('should return empty array for empty input', () => {
+      expect(toProductListItemDTOs([])).toEqual([]);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // toPaginatedResponse
+  // ---------------------------------------------------------------------------
+  describe('toPaginatedResponse', () => {
+    it('should create a paginated response with correct meta', () => {
+      const data = [{ id: 'a' }, { id: 'b' }];
+      const result = toPaginatedResponse(data, 10, 0, 2);
+
+      expect(result.data).toEqual(data);
+      expect(result.meta.total).toBe(10);
+      expect(result.meta.skip).toBe(0);
+      expect(result.meta.limit).toBe(2);
+      expect(result.meta.hasMore).toBe(true);
+    });
+
+    it('should set hasMore to false when no more pages', () => {
+      const result = toPaginatedResponse([{ id: 'a' }], 1, 0, 20);
+      expect(result.meta.hasMore).toBe(false);
+    });
+
+    it('should set hasMore to true when total exceeds skip+limit', () => {
+      const result = toPaginatedResponse([{ id: 'a' }], 100, 0, 20);
+      expect(result.meta.hasMore).toBe(true);
+    });
+
+    it('should handle empty data', () => {
+      const result = toPaginatedResponse([], 0, 0, 20);
+      expect(result.data).toEqual([]);
+      expect(result.meta.total).toBe(0);
+      expect(result.meta.hasMore).toBe(false);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // toPriceHistoryEntries
+  // ---------------------------------------------------------------------------
+  describe('toPriceHistoryEntries', () => {
+    it('should sort price history entries desc by updatedAt', () => {
+      const result = toPriceHistoryEntries(baseProduct.priceHistory ?? []);
+      expect(result.data).toHaveLength(3);
+      expect(result.total).toBe(3);
+      // Sorted desc: newest first
+      expect(result.data[0].value).toBe(50000); // Jan 10
+      expect(result.data[1].value).toBe(48000); // Jan 5
+      expect(result.data[2].value).toBe(52000); // Jan 1
+    });
+
+    it('should handle empty history', () => {
+      const result = toPriceHistoryEntries([]);
+      expect(result.data).toEqual([]);
+      expect(result.total).toBe(0);
+    });
+
+    it('should handle undefined history', () => {
+      const result = toPriceHistoryEntries(undefined);
+      expect(result.data).toEqual([]);
+      expect(result.total).toBe(0);
+    });
+
+    it('should serialize updatedAt to string', () => {
+      const result = toPriceHistoryEntries(baseProduct.priceHistory ?? []);
+      expect(typeof result.data[0].updatedAt).toBe('string');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // toViewsHistoryEntries
+  // ---------------------------------------------------------------------------
+  describe('toViewsHistoryEntries', () => {
+    it('should sort views history entries desc by updatedAt', () => {
+      const result = toViewsHistoryEntries(baseProduct.viewsHistory ?? []);
+      expect(result.data).toHaveLength(2);
+      expect(result.total).toBe(2);
+      expect(result.data[0].value).toBe(150); // Jan 10
+      expect(result.data[1].value).toBe(100); // Jan 5
+    });
+
+    it('should handle empty/undefined history', () => {
+      expect(toViewsHistoryEntries([]).data).toEqual([]);
+      expect(toViewsHistoryEntries(undefined).data).toEqual([]);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // toLocationHistoryEntries
+  // ---------------------------------------------------------------------------
+  describe('toLocationHistoryEntries', () => {
+    it('should return location history entries sorted desc by updatedAt', () => {
+      const history = [
+        { value: { state: 'Matanzas', municipality: 'Varadero' }, updatedAt: new Date('2025-01-05') },
+        { value: { state: 'La Habana', municipality: 'Plaza' }, updatedAt: new Date('2025-01-10') },
+      ];
+      const result = toLocationHistoryEntries(history);
+      expect(result.data).toHaveLength(2);
+      expect(result.data[0].location.state).toBe('La Habana'); // newest first
+    });
+
+    it('should handle empty/undefined history', () => {
+      expect(toLocationHistoryEntries([]).data).toEqual([]);
+      expect(toLocationHistoryEntries(undefined).data).toEqual([]);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // toOutstandingHistoryEntries
+  // ---------------------------------------------------------------------------
+  describe('toOutstandingHistoryEntries', () => {
+    it('should return outstanding history entries sorted desc by updatedAt', () => {
+      const result = toOutstandingHistoryEntries(baseProduct.isOutstandingHistory ?? []);
+      expect(result.data).toHaveLength(2);
+      expect(result.data[0].value).toBe(1); // newest — true → 1
+      expect(result.data[1].value).toBe(0); // false → 0
+    });
+
+    it('should handle empty/undefined history', () => {
+      expect(toOutstandingHistoryEntries([]).data).toEqual([]);
+      expect(toOutstandingHistoryEntries(undefined).data).toEqual([]);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // toPromotedHistoryEntries
+  // ---------------------------------------------------------------------------
+  describe('toPromotedHistoryEntries', () => {
+    it('should return promoted history entries sorted desc by updatedAt', () => {
+      const result = toPromotedHistoryEntries(baseProduct.isPromotedHistory ?? []);
+      expect(result.data).toHaveLength(2);
+      expect(result.data[0].value).toBe(1); // newest — true → 1
+      expect(result.data[1].value).toBe(0); // false → 0
+    });
+
+    it('should handle empty/undefined history', () => {
+      expect(toPromotedHistoryEntries([]).data).toEqual([]);
+      expect(toPromotedHistoryEntries(undefined).data).toEqual([]);
+    });
+  });
+});

--- a/src/__tests__/unit/admin/product.mapper.test.ts
+++ b/src/__tests__/unit/admin/product.mapper.test.ts
@@ -38,10 +38,6 @@ describe('ProductMapper', () => {
     location: { state: 'La Habana', municipality: 'Plaza' },
     views: 150,
     seller: { name: 'Juan', phone: '+5355555555', email: 'juan@email.cu', whatsapp: '+5355555555' },
-    metadata: { source: 'revolico', schemaVersion: 2, scrapedAt: new Date('2025-01-15') },
-    tags: ['vedado', '2cuartos'],
-    attributes: { rooms: 2, bathrooms: 1 },
-    analytics: { avgPrice: 48000 },
     priceHistory: [
       { value: 52000, updatedAt: new Date('2025-01-01') },
       { value: 50000, updatedAt: new Date('2025-01-10') },
@@ -103,6 +99,8 @@ describe('ProductMapper', () => {
       const minimal: IRevolicoProduct = {
         _id: '507f191e810c19729de860ea',
         url: 'https://revolico.com/item/min',
+        cost: '10',
+        category: 'electronica',
         currency: 'USD',
         price: 10,
         isOutstanding: false,
@@ -117,7 +115,8 @@ describe('ProductMapper', () => {
       expect(result.price).toBe(10);
       expect(result.currency).toBe('USD');
       expect(result.isOutstanding).toBe(false);
-      expect(result.category).toBeUndefined();
+      expect(result.cost).toBe('10');
+      expect(result.category).toBe('electronica');
       expect(result.subcategory).toBeUndefined();
       expect(result.description).toBeUndefined();
       expect(result.imageURL).toBeUndefined();
@@ -169,10 +168,6 @@ describe('ProductMapper', () => {
         email: 'juan@email.cu',
         whatsapp: '+5355555555',
       });
-      expect(result.tags).toEqual(['vedado', '2cuartos']);
-      expect(result.attributes).toEqual({ rooms: 2, bathrooms: 1 });
-      expect(result.analytics).toEqual({ avgPrice: 48000 });
-      expect(result.metadata).toEqual({ source: 'revolico', schemaVersion: 2, scrapedAt: new Date('2025-01-15') });
     });
 
     it('should NOT include history arrays in detail DTO', () => {
@@ -186,6 +181,8 @@ describe('ProductMapper', () => {
       const minimal: IRevolicoProduct = {
         _id: 'abc',
         url: 'https://revolico.com/item/min',
+        cost: '5',
+        category: 'inmuebles',
         currency: 'USD',
         price: 5,
         isOutstanding: false,
@@ -195,9 +192,8 @@ describe('ProductMapper', () => {
 
       const result = toProductDetailDTO(minimal);
       expect(result._id).toBe('abc');
-      expect(result.tags).toBeUndefined();
-      expect(result.attributes).toBeUndefined();
-      expect(result.analytics).toBeUndefined();
+      expect(result.cost).toBe('5');
+      expect(result.category).toBe('inmuebles');
       expect(result.seller).toBeUndefined();
     });
   });

--- a/src/__tests__/unit/admin/queue-admin.controller.test.ts
+++ b/src/__tests__/unit/admin/queue-admin.controller.test.ts
@@ -1,0 +1,192 @@
+import { Request, Response } from 'express';
+
+const queueAdminServiceMock = {
+  getAllQueueStats: jest.fn(),
+  getQueueStats: jest.fn(),
+  getRecentJobs: jest.fn(),
+  getJobDetail: jest.fn(),
+};
+
+jest.mock('@admin/services/queue-admin.service', () => ({
+  QueueAdminService: jest.fn().mockImplementation(() => queueAdminServiceMock),
+}));
+
+import { QueueAdminController } from '@admin/controllers/queue-admin.controller';
+import { ResponseHandler } from '@shared/response-handler';
+import { ILogger } from '@shared/logger.interface';
+import { QueueAdminService } from '@admin/services/queue-admin.service';
+
+describe('QueueAdminController', () => {
+  let controller: QueueAdminController;
+  let loggerMock: ILogger;
+  let mockRes: Response;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    loggerMock = {
+      context: '',
+      info: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn(),
+      log: jest.fn(),
+    } as unknown as ILogger;
+
+    mockRes = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    } as unknown as Response;
+
+    const serviceInstance = new (QueueAdminService as jest.Mock)() as QueueAdminService;
+
+    controller = new QueueAdminController(serviceInstance, loggerMock);
+
+    jest.spyOn(ResponseHandler, 'ok');
+    jest.spyOn(ResponseHandler, 'notFound');
+    jest.spyOn(ResponseHandler, 'error');
+  });
+
+  describe('structural', () => {
+    it('should be decorated with @injectable()', () => {
+      const hasParamTypes = Reflect.hasOwnMetadata('inversify:paramtypes', QueueAdminController);
+      expect(hasParamTypes).toBe(true);
+    });
+  });
+
+  describe('getAllStats', () => {
+    it('should return queue stats via ResponseHandler.ok', async () => {
+      const stats = [{ queueName: 'scraping', counts: { waiting: 5, completed: 10 } }];
+      queueAdminServiceMock.getAllQueueStats.mockResolvedValue(stats);
+
+      const req = {} as Request;
+      await controller.getAllStats(req, mockRes);
+
+      expect(ResponseHandler.ok).toHaveBeenCalledWith(mockRes, { queues: stats });
+    });
+
+    it('should handle empty stats', async () => {
+      queueAdminServiceMock.getAllQueueStats.mockResolvedValue([]);
+
+      const req = {} as Request;
+      await controller.getAllStats(req, mockRes);
+
+      expect(ResponseHandler.ok).toHaveBeenCalledWith(mockRes, { queues: [] });
+    });
+
+    it('should handle errors', async () => {
+      queueAdminServiceMock.getAllQueueStats.mockRejectedValue(new Error('Failed'));
+
+      const req = {} as Request;
+      await controller.getAllStats(req, mockRes);
+
+      expect(ResponseHandler.error).toHaveBeenCalledWith(mockRes, 'Failed to get queue stats', 500);
+      expect(loggerMock.error).toHaveBeenCalled();
+    });
+  });
+
+  describe('getStats', () => {
+    it('should return stats for a specific queue', async () => {
+      const stats = { queueName: 'scraping', counts: { waiting: 3 } };
+      queueAdminServiceMock.getQueueStats.mockResolvedValue(stats);
+
+      const req = { params: { name: 'scraping' } } as unknown as Request;
+      await controller.getStats(req, mockRes);
+
+      expect(queueAdminServiceMock.getQueueStats).toHaveBeenCalledWith('scraping');
+      expect(ResponseHandler.ok).toHaveBeenCalledWith(mockRes, stats);
+    });
+
+    it('should return 404 when queue not found', async () => {
+      queueAdminServiceMock.getQueueStats.mockResolvedValue(null);
+
+      const req = { params: { name: 'nonexistent' } } as unknown as Request;
+      await controller.getStats(req, mockRes);
+
+      expect(ResponseHandler.notFound).toHaveBeenCalledWith(mockRes, 'Queue not found');
+    });
+
+    it('should handle errors', async () => {
+      queueAdminServiceMock.getQueueStats.mockRejectedValue(new Error('Failed'));
+
+      const req = { params: { name: 'scraping' } } as unknown as Request;
+      await controller.getStats(req, mockRes);
+
+      expect(ResponseHandler.error).toHaveBeenCalledWith(mockRes, 'Failed to get queue stats', 500);
+    });
+  });
+
+  describe('getRecentJobs', () => {
+    it('should return recent jobs', async () => {
+      const jobs = [{ id: '1', name: 'job-a' }];
+      queueAdminServiceMock.getRecentJobs.mockResolvedValue(jobs);
+
+      const req = { params: { name: 'scraping' }, query: {} } as unknown as Request;
+      await controller.getRecentJobs(req, mockRes);
+
+      expect(queueAdminServiceMock.getRecentJobs).toHaveBeenCalledWith('scraping', 20, undefined);
+      expect(ResponseHandler.ok).toHaveBeenCalledWith(mockRes, { jobs });
+    });
+
+    it('should pass query params for limit and status', async () => {
+      queueAdminServiceMock.getRecentJobs.mockResolvedValue([]);
+
+      const req = {
+        params: { name: 'scraping' },
+        query: { limit: '5', status: 'failed' },
+      } as unknown as Request;
+      await controller.getRecentJobs(req, mockRes);
+
+      expect(queueAdminServiceMock.getRecentJobs).toHaveBeenCalledWith('scraping', 5, 'failed');
+    });
+
+    it('should handle empty jobs', async () => {
+      queueAdminServiceMock.getRecentJobs.mockResolvedValue([]);
+
+      const req = { params: { name: 'scraping' }, query: {} } as unknown as Request;
+      await controller.getRecentJobs(req, mockRes);
+
+      expect(ResponseHandler.ok).toHaveBeenCalledWith(mockRes, { jobs: [] });
+    });
+
+    it('should handle errors', async () => {
+      queueAdminServiceMock.getRecentJobs.mockRejectedValue(new Error('Failed'));
+
+      const req = { params: { name: 'scraping' }, query: {} } as unknown as Request;
+      await controller.getRecentJobs(req, mockRes);
+
+      expect(ResponseHandler.error).toHaveBeenCalledWith(mockRes, 'Failed to get recent jobs', 500);
+    });
+  });
+
+  describe('getJobDetail', () => {
+    it('should return job detail', async () => {
+      const job = { id: 'job-123', name: 'scrape-product' };
+      queueAdminServiceMock.getJobDetail.mockResolvedValue(job);
+
+      const req = { params: { name: 'scraping', id: 'job-123' } } as unknown as Request;
+      await controller.getJobDetail(req, mockRes);
+
+      expect(queueAdminServiceMock.getJobDetail).toHaveBeenCalledWith('scraping', 'job-123');
+      expect(ResponseHandler.ok).toHaveBeenCalledWith(mockRes, job);
+    });
+
+    it('should return 404 when job not found', async () => {
+      queueAdminServiceMock.getJobDetail.mockResolvedValue(null);
+
+      const req = { params: { name: 'scraping', id: 'job-123' } } as unknown as Request;
+      await controller.getJobDetail(req, mockRes);
+
+      expect(ResponseHandler.notFound).toHaveBeenCalledWith(mockRes, 'Job not found');
+    });
+
+    it('should handle errors', async () => {
+      queueAdminServiceMock.getJobDetail.mockRejectedValue(new Error('Failed'));
+
+      const req = { params: { name: 'scraping', id: 'job-123' } } as unknown as Request;
+      await controller.getJobDetail(req, mockRes);
+
+      expect(ResponseHandler.error).toHaveBeenCalledWith(mockRes, 'Failed to get job detail', 500);
+    });
+  });
+});

--- a/src/__tests__/unit/admin/queue-admin.service.test.ts
+++ b/src/__tests__/unit/admin/queue-admin.service.test.ts
@@ -1,0 +1,245 @@
+import { QueueAdminService } from '@admin/services/queue-admin.service';
+import { IQueueAdapterRegistry } from '@shared/queue/port/queue-adapter-registry.interfaces';
+import { IQueueAdapter } from '@shared/queue/port/queue-adapter.interfaces';
+import { ILogger } from '@shared/logger.interface';
+
+describe('QueueAdminService', () => {
+  let service: QueueAdminService;
+  let registryMock: IQueueAdapterRegistry;
+  let adapterMock: IQueueAdapter;
+  let loggerMock: ILogger;
+
+  const createMockQueue = (name: string, overrides: Record<string, any> = {}): Record<string, any> => ({
+    name,
+    getJobCounts: jest.fn().mockResolvedValue({}),
+    getJobs: jest.fn().mockResolvedValue([]),
+    getJob: jest.fn().mockResolvedValue(null),
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    loggerMock = {
+      context: '',
+      info: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn(),
+      log: jest.fn(),
+    } as unknown as ILogger;
+
+    adapterMock = {
+      backend: 'bullmq',
+      getDashboardQueues: jest.fn().mockReturnValue([]),
+      enqueue: jest.fn(),
+      registerWorker: jest.fn(),
+      onCompleted: jest.fn(),
+      onFailed: jest.fn(),
+      onProgress: jest.fn(),
+      describe: jest.fn(),
+      shutdown: jest.fn(),
+    } as unknown as IQueueAdapter;
+
+    registryMock = {
+      getCurrent: jest.fn().mockReturnValue(adapterMock),
+      get: jest.fn().mockReturnValue(adapterMock),
+    } as unknown as IQueueAdapterRegistry;
+
+    service = new QueueAdminService(registryMock, loggerMock);
+  });
+
+  describe('structural', () => {
+    it('should set logger context to QueueAdminService', () => {
+      expect(loggerMock.context).toBe('QueueAdminService');
+    });
+  });
+
+  describe('getAllQueueStats', () => {
+    it('should return empty array when no dashboard queues exist (Mock backend)', async () => {
+      (adapterMock.getDashboardQueues as jest.Mock).mockReturnValue([]);
+
+      const result = await service.getAllQueueStats();
+
+      expect(result).toEqual([]);
+      expect(loggerMock.warn).toHaveBeenCalledWith(
+        'getAllQueueStats: no dashboard queues available (non-BullMQ backend or no queues registered)',
+      );
+    });
+
+    it('should return stats for each registered queue', async () => {
+      const mockQueue1 = createMockQueue('scraping', {
+        getJobCounts: jest.fn().mockResolvedValue({ waiting: 5, active: 2, completed: 100, failed: 3 }),
+      });
+      const mockQueue2 = createMockQueue('notifications', {
+        getJobCounts: jest.fn().mockResolvedValue({ waiting: 0, completed: 50 }),
+      });
+
+      (adapterMock.getDashboardQueues as jest.Mock).mockReturnValue([
+        { name: 'scraping', queue: mockQueue1 },
+        { name: 'notifications', queue: mockQueue2 },
+      ]);
+
+      const result = await service.getAllQueueStats();
+
+      expect(result).toHaveLength(2);
+      expect(result[0].queueName).toBe('scraping');
+      expect(result[0].counts).toEqual({ waiting: 5, active: 2, completed: 100, failed: 3 });
+      expect(result[1].queueName).toBe('notifications');
+      expect(result[1].counts).toEqual({ waiting: 0, completed: 50 });
+    });
+
+    it('should use the current adapter from registry', async () => {
+      (adapterMock.getDashboardQueues as jest.Mock).mockReturnValue([]);
+
+      await service.getAllQueueStats();
+
+      expect(registryMock.getCurrent).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('getQueueStats', () => {
+    it('should return null when queue not found', async () => {
+      (adapterMock.getDashboardQueues as jest.Mock).mockReturnValue([]);
+
+      const result = await service.getQueueStats('nonexistent');
+
+      expect(result).toBeNull();
+      expect(loggerMock.warn).toHaveBeenCalledWith('Queue "nonexistent" not found');
+    });
+
+    it('should return stats for a specific queue', async () => {
+      const mockQueue = createMockQueue('scraping', {
+        getJobCounts: jest.fn().mockResolvedValue({ waiting: 10, active: 3, completed: 42 }),
+      });
+
+      (adapterMock.getDashboardQueues as jest.Mock).mockReturnValue([
+        { name: 'scraping', queue: mockQueue },
+        { name: 'other', queue: createMockQueue('other') },
+      ]);
+
+      const result = await service.getQueueStats('scraping');
+
+      expect(result).not.toBeNull();
+      expect(result!.queueName).toBe('scraping');
+      expect(result!.counts).toEqual({ waiting: 10, active: 3, completed: 42 });
+    });
+  });
+
+  describe('getRecentJobs', () => {
+    it('should return empty array when queue not found', async () => {
+      (adapterMock.getDashboardQueues as jest.Mock).mockReturnValue([]);
+
+      const result = await service.getRecentJobs('nonexistent');
+
+      expect(result).toEqual([]);
+      expect(loggerMock.warn).toHaveBeenCalledWith('Queue "nonexistent" not found');
+    });
+
+    it('should return recent jobs for a queue with default params', async () => {
+      const mockJobs = [
+        { id: '1', name: 'job-a', data: { url: '/a' }, attemptsMade: 0, progress: 100, timestamp: 1000 },
+        { id: '2', name: 'job-b', data: { url: '/b' }, attemptsMade: 1, progress: 50, timestamp: 2000 },
+      ];
+      const mockQueue = createMockQueue('scraping', {
+        getJobs: jest.fn().mockResolvedValue(mockJobs),
+      });
+
+      (adapterMock.getDashboardQueues as jest.Mock).mockReturnValue([{ name: 'scraping', queue: mockQueue }]);
+
+      const result = await service.getRecentJobs('scraping');
+
+      expect(result).toHaveLength(2);
+      expect(result[0].id).toBe('1');
+      expect(result[1].id).toBe('2');
+      // getJobs called with default: limit 20, asc=false (newest first)
+      expect(mockQueue.getJobs).toHaveBeenCalled();
+    });
+
+    it('should pass status filter to getJobs when provided', async () => {
+      const mockQueue = createMockQueue('scraping');
+      (adapterMock.getDashboardQueues as jest.Mock).mockReturnValue([{ name: 'scraping', queue: mockQueue }]);
+
+      await service.getRecentJobs('scraping', 10, 'failed');
+
+      const calledArgs = mockQueue.getJobs.mock.calls[0];
+      // First argument should be ['failed'] (the types array with the status)
+      expect(calledArgs).toBeDefined();
+    });
+
+    it('should limit results to provided limit', async () => {
+      const mockJobs = Array.from({ length: 5 }, (_, i) => ({
+        id: String(i),
+        name: `job-${i}`,
+        data: {},
+        attemptsMade: 0,
+        timestamp: 1000 + i,
+      }));
+      const mockQueue = createMockQueue('scraping', {
+        getJobs: jest.fn().mockResolvedValue(mockJobs),
+      });
+      (adapterMock.getDashboardQueues as jest.Mock).mockReturnValue([{ name: 'scraping', queue: mockQueue }]);
+
+      const result = await service.getRecentJobs('scraping', 5);
+
+      expect(result).toHaveLength(5);
+    });
+  });
+
+  describe('getJobDetail', () => {
+    it('should return null when queue not found', async () => {
+      (adapterMock.getDashboardQueues as jest.Mock).mockReturnValue([]);
+
+      const result = await service.getJobDetail('nonexistent', 'job-123');
+
+      expect(result).toBeNull();
+      expect(loggerMock.warn).toHaveBeenCalledWith('Queue "nonexistent" not found');
+    });
+
+    it('should return null when job not found', async () => {
+      const mockQueue = createMockQueue('scraping', {
+        getJob: jest.fn().mockResolvedValue(null),
+      });
+      (adapterMock.getDashboardQueues as jest.Mock).mockReturnValue([{ name: 'scraping', queue: mockQueue }]);
+
+      const result = await service.getJobDetail('scraping', 'job-123');
+
+      expect(result).toBeNull();
+    });
+
+    it('should return job detail for a found job', async () => {
+      const mockJob = {
+        id: 'job-123',
+        name: 'scrape-product',
+        data: { url: 'https://example.com' },
+        progress: 100,
+        attemptsMade: 0,
+        timestamp: 1700000000000,
+        processedOn: 1700000001000,
+        finishedOn: 1700000005000,
+        returnvalue: { success: true },
+      };
+      const mockQueue = createMockQueue('scraping', {
+        getJob: jest.fn().mockResolvedValue(mockJob),
+      });
+      (adapterMock.getDashboardQueues as jest.Mock).mockReturnValue([{ name: 'scraping', queue: mockQueue }]);
+
+      const result = await service.getJobDetail('scraping', 'job-123');
+
+      expect(result).not.toBeNull();
+      expect(result!.id).toBe('job-123');
+      expect(result!.name).toBe('scrape-product');
+    });
+
+    it('should call getJob on the correct queue with correct jobId', async () => {
+      const mockQueue = createMockQueue('scraping', {
+        getJob: jest.fn().mockResolvedValue(null),
+      });
+      (adapterMock.getDashboardQueues as jest.Mock).mockReturnValue([{ name: 'scraping', queue: mockQueue }]);
+
+      await service.getJobDetail('scraping', 'job-abc');
+
+      expect(mockQueue.getJob).toHaveBeenCalledWith('job-abc');
+    });
+  });
+});

--- a/src/__tests__/unit/admin/queue-stats.dto.test.ts
+++ b/src/__tests__/unit/admin/queue-stats.dto.test.ts
@@ -1,0 +1,139 @@
+import { QueueStatsDTO, JobDetailDTO } from '@admin/services/dto/queue-stats.dto';
+
+describe('QueueStatsDTO', () => {
+  describe('structural', () => {
+    it('should have a static from method', () => {
+      expect(typeof QueueStatsDTO.from).toBe('function');
+    });
+  });
+
+  describe('from', () => {
+    it('should parse valid queue stats data', () => {
+      const dto = QueueStatsDTO.from({
+        queueName: 'scraping-queue',
+        counts: { waiting: 5, active: 2, completed: 100, failed: 3, delayed: 1 },
+      });
+
+      expect(dto.queueName).toBe('scraping-queue');
+      expect(dto.counts).toEqual({ waiting: 5, active: 2, completed: 100, failed: 3, delayed: 1 });
+    });
+
+    it('should parse empty counts', () => {
+      const dto = QueueStatsDTO.from({ queueName: 'test', counts: {} });
+      expect(dto.queueName).toBe('test');
+      expect(dto.counts).toEqual({});
+    });
+
+    it('should throw for missing queueName', () => {
+      expect(() => QueueStatsDTO.from({ counts: { waiting: 1 } })).toThrow();
+    });
+
+    it('should throw for missing counts', () => {
+      expect(() => QueueStatsDTO.from({ queueName: 'test' })).toThrow();
+    });
+
+    it('should throw for non-object input', () => {
+      expect(() => QueueStatsDTO.from(null)).toThrow();
+      expect(() => QueueStatsDTO.from(undefined)).toThrow();
+      expect(() => QueueStatsDTO.from('string')).toThrow();
+    });
+
+    it('should throw when counts values are not numbers', () => {
+      expect(() => QueueStatsDTO.from({ queueName: 'test', counts: { waiting: 'five' } })).toThrow();
+    });
+  });
+});
+
+describe('JobDetailDTO', () => {
+  describe('structural', () => {
+    it('should have a static from method', () => {
+      expect(typeof JobDetailDTO.from).toBe('function');
+    });
+  });
+
+  describe('from', () => {
+    it('should parse a valid job detail', () => {
+      const dto = JobDetailDTO.from({
+        id: 'job-123',
+        name: 'scrape-product',
+        data: { url: 'https://example.com' },
+        progress: 50,
+        attemptsMade: 0,
+        timestamp: 1700000000000,
+        processedOn: 1700000001000,
+        finishedOn: null,
+        returnValue: { success: true },
+        status: 'completed',
+      });
+
+      expect(dto.id).toBe('job-123');
+      expect(dto.name).toBe('scrape-product');
+      expect(dto.data).toEqual({ url: 'https://example.com' });
+      expect(dto.progress).toBe(50);
+      expect(dto.attemptsMade).toBe(0);
+      expect(dto.timestamp).toBe(1700000000000);
+      expect(dto.processedOn).toBe(1700000001000);
+      expect(dto.finishedOn).toBeNull();
+      expect(dto.returnValue).toEqual({ success: true });
+      expect(dto.status).toBe('completed');
+    });
+
+    it('should parse a minimal job detail with only required fields', () => {
+      const dto = JobDetailDTO.from({ id: 'job-min', name: 'minimal' });
+      expect(dto.id).toBe('job-min');
+      expect(dto.name).toBe('minimal');
+      expect(dto.data).toBeUndefined();
+      expect(dto.progress).toBeUndefined();
+      expect(dto.attemptsMade).toBeUndefined();
+      expect(dto.failedReason).toBeUndefined();
+      expect(dto.timestamp).toBeUndefined();
+      expect(dto.processedOn).toBeUndefined();
+      expect(dto.finishedOn).toBeUndefined();
+      expect(dto.returnValue).toBeUndefined();
+      expect(dto.status).toBeUndefined();
+    });
+
+    it('should parse a failed job with failedReason', () => {
+      const dto = JobDetailDTO.from({
+        id: 'job-fail',
+        name: 'failed-job',
+        attemptsMade: 3,
+        failedReason: 'Connection timeout',
+        status: 'failed',
+      });
+
+      expect(dto.id).toBe('job-fail');
+      expect(dto.failedReason).toBe('Connection timeout');
+      expect(dto.attemptsMade).toBe(3);
+      expect(dto.status).toBe('failed');
+    });
+
+    it('should parse progress as object', () => {
+      const dto = JobDetailDTO.from({
+        id: 'job-progress-obj',
+        name: 'batch-scrape',
+        progress: { current: 10, total: 100 },
+      });
+
+      expect(dto.progress).toEqual({ current: 10, total: 100 });
+    });
+
+    it('should throw for missing id', () => {
+      expect(() => JobDetailDTO.from({ name: 'test' })).toThrow();
+    });
+
+    it('should throw for missing name', () => {
+      expect(() => JobDetailDTO.from({ id: 'test' })).toThrow();
+    });
+
+    it('should throw for non-object input', () => {
+      expect(() => JobDetailDTO.from(null)).toThrow();
+      expect(() => JobDetailDTO.from(undefined)).toThrow();
+      expect(() => JobDetailDTO.from('string')).toThrow();
+    });
+
+    it('should throw for wrong type on attemptsMade', () => {
+      expect(() => JobDetailDTO.from({ id: 'test', name: 'test', attemptsMade: 'three' })).toThrow();
+    });
+  });
+});

--- a/src/__tests__/unit/admin/role.controller.test.ts
+++ b/src/__tests__/unit/admin/role.controller.test.ts
@@ -1,0 +1,185 @@
+import { Request, Response } from 'express';
+import { RoleController } from '@admin/controllers/role.controller';
+import { RoleService } from '@admin/services/role.service';
+import { ILogger } from '@shared/logger.interface';
+
+describe('RoleController', () => {
+  let controller: RoleController;
+  let serviceMock: Record<string, jest.Mock>;
+  let loggerMock: ILogger;
+  let req: Partial<Request>;
+  let res: Partial<Response>;
+
+  beforeEach(() => {
+    serviceMock = {
+      getAll: jest.fn(),
+      create: jest.fn(),
+      delete: jest.fn(),
+      assignRole: jest.fn(),
+      unassignRole: jest.fn(),
+    };
+
+    loggerMock = {
+      set context(_value: string) {},
+      info: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn(),
+      log: jest.fn(),
+    } as unknown as ILogger;
+
+    controller = new RoleController(serviceMock as unknown as RoleService, loggerMock);
+
+    res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    };
+  });
+
+  // =========================================================================
+  // list
+  // =========================================================================
+  describe('list', () => {
+    it('should return all roles', async () => {
+      req = {};
+      const roles = [{ id: 'role-1', name: 'SUPER_ADMIN', accountId: null, _count: { users: 1 } }];
+      serviceMock.getAll.mockResolvedValue(roles);
+
+      await controller.list(req as Request, res as Response);
+
+      expect(serviceMock.getAll).toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'success',
+          data: { roles },
+        }),
+      );
+    });
+
+    it('should handle errors', async () => {
+      req = {};
+      serviceMock.getAll.mockRejectedValue(new Error('DB error'));
+
+      await controller.list(req as Request, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+    });
+  });
+
+  // =========================================================================
+  // create
+  // =========================================================================
+  describe('create', () => {
+    it('should create a role from valid body', async () => {
+      req = { body: { name: 'MODERATOR' } };
+      const created = { id: 'role-3', name: 'MODERATOR', accountId: null };
+      serviceMock.create.mockResolvedValue(created);
+
+      await controller.create(req as Request, res as Response);
+
+      expect(serviceMock.create).toHaveBeenCalledWith('MODERATOR', undefined);
+      expect(res.status).toHaveBeenCalledWith(201);
+    });
+
+    it('should create a role with accountId', async () => {
+      req = { body: { name: 'TENANT_ROLE', accountId: 'acc-1' } };
+      const created = { id: 'role-4', name: 'TENANT_ROLE', accountId: 'acc-1' };
+      serviceMock.create.mockResolvedValue(created);
+
+      await controller.create(req as Request, res as Response);
+
+      expect(serviceMock.create).toHaveBeenCalledWith('TENANT_ROLE', 'acc-1');
+      expect(res.status).toHaveBeenCalledWith(201);
+    });
+
+    it('should handle validation errors', async () => {
+      req = { body: { name: '' } };
+
+      await controller.create(req as Request, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+    });
+
+    it('should handle service errors', async () => {
+      req = { body: { name: 'ADMIN' } };
+      serviceMock.create.mockRejectedValue(new Error('Unique constraint'));
+
+      await controller.create(req as Request, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+    });
+  });
+
+  // =========================================================================
+  // delete
+  // =========================================================================
+  describe('delete', () => {
+    it('should delete a role by id', async () => {
+      req = { params: { id: 'role-1' } };
+      serviceMock.delete.mockResolvedValue(undefined);
+
+      await controller.delete(req as Request, res as Response);
+
+      expect(serviceMock.delete).toHaveBeenCalledWith('role-1');
+      expect(res.status).toHaveBeenCalledWith(200);
+    });
+
+    it('should handle errors', async () => {
+      req = { params: { id: 'bad-id' } };
+      serviceMock.delete.mockRejectedValue(new Error('Not found'));
+
+      await controller.delete(req as Request, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+    });
+  });
+
+  // =========================================================================
+  // assignRole
+  // =========================================================================
+  describe('assignRole', () => {
+    it('should assign a role to a user', async () => {
+      req = { params: { userId: 'user-1', roleId: 'role-1' } };
+      serviceMock.assignRole.mockResolvedValue(undefined);
+
+      await controller.assignRole(req as Request, res as Response);
+
+      expect(serviceMock.assignRole).toHaveBeenCalledWith('user-1', 'role-1');
+      expect(res.status).toHaveBeenCalledWith(200);
+    });
+
+    it('should handle errors', async () => {
+      req = { params: { userId: 'bad-user', roleId: 'role-1' } };
+      serviceMock.assignRole.mockRejectedValue(new Error('User not found'));
+
+      await controller.assignRole(req as Request, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+    });
+  });
+
+  // =========================================================================
+  // unassignRole
+  // =========================================================================
+  describe('unassignRole', () => {
+    it('should unassign a role from a user', async () => {
+      req = { params: { userId: 'user-1', roleId: 'role-1' } };
+      serviceMock.unassignRole.mockResolvedValue(undefined);
+
+      await controller.unassignRole(req as Request, res as Response);
+
+      expect(serviceMock.unassignRole).toHaveBeenCalledWith('user-1', 'role-1');
+      expect(res.status).toHaveBeenCalledWith(200);
+    });
+
+    it('should handle errors', async () => {
+      req = { params: { userId: 'bad-user', roleId: 'role-1' } };
+      serviceMock.unassignRole.mockRejectedValue(new Error('User not found'));
+
+      await controller.unassignRole(req as Request, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+    });
+  });
+});

--- a/src/__tests__/unit/admin/role.dto.test.ts
+++ b/src/__tests__/unit/admin/role.dto.test.ts
@@ -1,0 +1,42 @@
+import { CreateRoleDTO, CreateRoleSchema } from '@admin/services/dto/role.dto';
+
+describe('CreateRoleDTO', () => {
+  describe('validation schema', () => {
+    it('should accept valid input with just name', () => {
+      const result = CreateRoleSchema.parse({ name: 'ADMIN' });
+      expect(result).toEqual({ name: 'ADMIN' });
+    });
+
+    it('should accept valid input with name and accountId', () => {
+      const result = CreateRoleSchema.parse({ name: 'CUSTOM_ROLE', accountId: 'acc-1' });
+      expect(result).toEqual({ name: 'CUSTOM_ROLE', accountId: 'acc-1' });
+    });
+
+    it('should reject empty name', () => {
+      expect(() => CreateRoleSchema.parse({ name: '' })).toThrow();
+    });
+
+    it('should reject missing name', () => {
+      expect(() => CreateRoleSchema.parse({})).toThrow();
+    });
+  });
+
+  describe('from', () => {
+    it('should create DTO from valid body', () => {
+      const dto = CreateRoleDTO.from({ name: 'MODERATOR' });
+      expect(dto).toBeInstanceOf(CreateRoleDTO);
+      expect(dto.name).toBe('MODERATOR');
+      expect(dto.accountId).toBeUndefined();
+    });
+
+    it('should create DTO with optional accountId', () => {
+      const dto = CreateRoleDTO.from({ name: 'TENANT_ROLE', accountId: 'acc-2' });
+      expect(dto.name).toBe('TENANT_ROLE');
+      expect(dto.accountId).toBe('acc-2');
+    });
+
+    it('should throw on invalid body', () => {
+      expect(() => CreateRoleDTO.from({ name: '' })).toThrow();
+    });
+  });
+});

--- a/src/__tests__/unit/admin/role.service.test.ts
+++ b/src/__tests__/unit/admin/role.service.test.ts
@@ -1,0 +1,169 @@
+import { RoleService } from '@admin/services/role.service';
+import { ILogger } from '@shared/logger.interface';
+
+describe('RoleService', () => {
+  let service: RoleService;
+  let prismaMock: Record<string, Record<string, jest.Mock>>;
+  let loggerMock: ILogger;
+
+  beforeEach(() => {
+    prismaMock = {
+      role: {
+        findMany: jest.fn(),
+        create: jest.fn(),
+        delete: jest.fn(),
+      },
+      user: {
+        update: jest.fn(),
+      },
+    };
+
+    loggerMock = {
+      set context(_value: string) {},
+      info: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn(),
+      log: jest.fn(),
+    } as unknown as ILogger;
+
+    service = new RoleService(prismaMock as never, loggerMock);
+  });
+
+  // =========================================================================
+  // getAll
+  // =========================================================================
+  describe('getAll', () => {
+    it('should return all roles with user count', async () => {
+      const roles = [
+        { id: 'role-1', name: 'SUPER_ADMIN', accountId: null, _count: { users: 1 } },
+        { id: 'role-2', name: 'ACCOUNT_OWNER', accountId: null, _count: { users: 5 } },
+      ];
+      prismaMock.role.findMany.mockResolvedValue(roles);
+
+      const result = await service.getAll();
+
+      expect(result).toEqual(roles);
+      expect(prismaMock.role.findMany).toHaveBeenCalledWith({
+        include: { _count: { select: { users: true } } },
+      });
+    });
+
+    it('should return empty array when no roles exist', async () => {
+      prismaMock.role.findMany.mockResolvedValue([]);
+
+      const result = await service.getAll();
+
+      expect(result).toEqual([]);
+    });
+
+    it('should propagate prisma errors', async () => {
+      const error = new Error('DB error');
+      prismaMock.role.findMany.mockRejectedValue(error);
+
+      await expect(service.getAll()).rejects.toThrow('DB error');
+    });
+  });
+
+  // =========================================================================
+  // create
+  // =========================================================================
+  describe('create', () => {
+    it('should create a role with only name', async () => {
+      const created = { id: 'role-3', name: 'MODERATOR', accountId: null };
+      prismaMock.role.create.mockResolvedValue(created);
+
+      const result = await service.create('MODERATOR');
+
+      expect(result).toEqual(created);
+      expect(prismaMock.role.create).toHaveBeenCalledWith({
+        data: { name: 'MODERATOR', accountId: null },
+      });
+    });
+
+    it('should create a role with name and accountId', async () => {
+      const created = { id: 'role-4', name: 'TENANT_ROLE', accountId: 'acc-1' };
+      prismaMock.role.create.mockResolvedValue(created);
+
+      const result = await service.create('TENANT_ROLE', 'acc-1');
+
+      expect(result).toEqual(created);
+      expect(prismaMock.role.create).toHaveBeenCalledWith({
+        data: { name: 'TENANT_ROLE', accountId: 'acc-1' },
+      });
+    });
+
+    it('should propagate prisma errors', async () => {
+      const error = new Error('Unique constraint');
+      prismaMock.role.create.mockRejectedValue(error);
+
+      await expect(service.create('DUPLICATE')).rejects.toThrow('Unique constraint');
+    });
+  });
+
+  // =========================================================================
+  // delete
+  // =========================================================================
+  describe('delete', () => {
+    it('should delete a role by id', async () => {
+      prismaMock.role.delete.mockResolvedValue({ id: 'role-1', name: 'TEST', accountId: null });
+
+      await service.delete('role-1');
+
+      expect(prismaMock.role.delete).toHaveBeenCalledWith({ where: { id: 'role-1' } });
+    });
+
+    it('should propagate prisma errors', async () => {
+      const error = new Error('Record not found');
+      prismaMock.role.delete.mockRejectedValue(error);
+
+      await expect(service.delete('bad-id')).rejects.toThrow('Record not found');
+    });
+  });
+
+  // =========================================================================
+  // assignRole
+  // =========================================================================
+  describe('assignRole', () => {
+    it('should connect role to user', async () => {
+      prismaMock.user.update.mockResolvedValue({ id: 'user-1' });
+
+      await service.assignRole('user-1', 'role-1');
+
+      expect(prismaMock.user.update).toHaveBeenCalledWith({
+        where: { id: 'user-1' },
+        data: { roles: { connect: { id: 'role-1' } } },
+      });
+    });
+
+    it('should propagate prisma errors', async () => {
+      const error = new Error('User not found');
+      prismaMock.user.update.mockRejectedValue(error);
+
+      await expect(service.assignRole('bad-user', 'role-1')).rejects.toThrow('User not found');
+    });
+  });
+
+  // =========================================================================
+  // unassignRole
+  // =========================================================================
+  describe('unassignRole', () => {
+    it('should disconnect role from user', async () => {
+      prismaMock.user.update.mockResolvedValue({ id: 'user-1' });
+
+      await service.unassignRole('user-1', 'role-1');
+
+      expect(prismaMock.user.update).toHaveBeenCalledWith({
+        where: { id: 'user-1' },
+        data: { roles: { disconnect: { id: 'role-1' } } },
+      });
+    });
+
+    it('should propagate prisma errors', async () => {
+      const error = new Error('User not found');
+      prismaMock.user.update.mockRejectedValue(error);
+
+      await expect(service.unassignRole('bad-user', 'role-1')).rejects.toThrow('User not found');
+    });
+  });
+});

--- a/src/main/admin/controllers/account-admin.controller.ts
+++ b/src/main/admin/controllers/account-admin.controller.ts
@@ -1,0 +1,88 @@
+import { Request, Response } from 'express';
+import { controller, httpGet, httpPut, httpDelete, request, response } from 'inversify-express-utils';
+import { inject } from 'inversify';
+import { TYPES } from '@shared/types.container';
+import { AuthMiddleware } from '@shared/middleware/auth.middleware';
+import { ResponseHandler } from '@shared/response-handler';
+import { ILogger } from '@shared/logger.interface';
+import { AccountAdminService } from '@admin/services/account-admin.service';
+
+@controller('/api/admin/accounts')
+export class AccountAdminController {
+  public constructor(
+    @inject(TYPES.AccountAdminService) private readonly _service: AccountAdminService,
+    @inject(TYPES.Logger) private readonly _log: ILogger,
+  ) {
+    this._log.context = AccountAdminController.name;
+  }
+
+  /**
+   * Lists all accounts with pagination and related counts.
+   * @param req - Express request with query params (skip, limit).
+   * @param res - Express response.
+   */
+  @httpGet('/', AuthMiddleware.forRoles('SUPER_ADMIN'))
+  public async list(@request() req: Request, @response() res: Response): Promise<void> {
+    try {
+      const skip = parseInt(req.query.skip as string, 10) || 0;
+      const limit = parseInt(req.query.limit as string, 10) || 10;
+      const result = await this._service.getAll(skip, limit);
+      ResponseHandler.ok(res, result);
+    } catch (err) {
+      this._log.error('Failed to list accounts', { error: err });
+      ResponseHandler.error(res, 'Failed to list accounts', 500);
+    }
+  }
+
+  /**
+   * Retrieves a single account by ID with stats.
+   * @param req - Express request with account id in params.
+   * @param res - Express response.
+   */
+  @httpGet('/:id', AuthMiddleware.forRoles('SUPER_ADMIN'))
+  public async getById(@request() req: Request, @response() res: Response): Promise<void> {
+    try {
+      const account = await this._service.getById(req.params.id);
+      if (!account) {
+        ResponseHandler.notFound(res, 'Account not found');
+        return;
+      }
+      ResponseHandler.ok(res, account);
+    } catch (err) {
+      this._log.error('Failed to get account', { error: err, accountId: req.params.id });
+      ResponseHandler.error(res, 'Failed to get account', 500);
+    }
+  }
+
+  /**
+   * Updates an account by ID.
+   * @param req - Express request with account id in params and body data.
+   * @param res - Express response.
+   */
+  @httpPut('/:id', AuthMiddleware.forRoles('SUPER_ADMIN'))
+  public async update(@request() req: Request, @response() res: Response): Promise<void> {
+    try {
+      const account = await this._service.update(req.params.id, req.body);
+      ResponseHandler.updated(res, account);
+    } catch (err) {
+      this._log.error('Failed to update account', { error: err, accountId: req.params.id });
+      ResponseHandler.error(res, 'Failed to update account', 500);
+    }
+  }
+
+  /**
+   * Deletes an account by ID.
+   * @param req - Express request with account id in params.
+   * @param res - Express response.
+   */
+  @httpDelete('/:id', AuthMiddleware.forRoles('SUPER_ADMIN'))
+  public async delete(@request() req: Request, @response() res: Response): Promise<void> {
+    try {
+      await this._service.delete(req.params.id);
+      ResponseHandler.deleted(res);
+    } catch (err) {
+      this._log.error('Failed to delete account', { error: err, accountId: req.params.id });
+      ResponseHandler.error(res, 'Failed to delete account', 500);
+    }
+  }
+}

--- a/src/main/admin/controllers/admin.controller.ts
+++ b/src/main/admin/controllers/admin.controller.ts
@@ -1,21 +1,44 @@
+import { Request, Response } from 'express';
 import { controller, httpGet, httpDelete, request, response } from 'inversify-express-utils';
-import { AuthMiddleware } from '@shared/middleware/auth.middleware';
 import { inject } from 'inversify';
+import { TYPES } from '@shared/types.container';
+import { AuthMiddleware } from '@shared/middleware/auth.middleware';
+import { ResponseHandler } from '@shared/response-handler';
+import { ILogger } from '@shared/logger.interface';
 import { UserService } from '@users/services/user.service';
 
 @controller('/api/admin/users')
 export class AdminController {
-  public constructor(@inject('UserService') private userService: UserService) {}
-
-  @httpGet('/', AuthMiddleware.forRoles('ACCOUNT_OWNER'))
-  public async list(@request() req: any, @response() res: any): Promise<void> {
-    const users = await this.userService.getAll();
-    res.status(200).json({ users });
+  public constructor(
+    @inject(TYPES.UserService) private readonly _userService: UserService,
+    @inject(TYPES.Logger) private readonly _log: ILogger,
+  ) {
+    this._log.context = 'AdminController';
   }
 
-  @httpDelete('/:id', AuthMiddleware.forRoles('ACCOUNT_OWNER'))
-  public async delete(@request() req: any, @response() res: any): Promise<void> {
-    await this.userService.delete(req.params.id);
-    res.status(204).send();
+  /**
+   * Lists all users across all tenants.
+   * @param req - Express request.
+   * @param res - Express response.
+   */
+  @httpGet('/', AuthMiddleware.forRoles('SUPER_ADMIN'))
+  public async list(@request() req: Request, @response() res: Response): Promise<void> {
+    const users = await this._userService.getAll();
+    ResponseHandler.ok(res, { users });
+  }
+
+  /**
+   * Deletes a user by ID.
+   * @param req - Express request with user id in params.
+   * @param res - Express response.
+   */
+  @httpDelete('/:id', AuthMiddleware.forRoles('SUPER_ADMIN'))
+  public async delete(@request() req: Request, @response() res: Response): Promise<void> {
+    try {
+      await this._userService.delete(req.params.id);
+      ResponseHandler.deleted(res);
+    } catch {
+      ResponseHandler.notFound(res);
+    }
   }
 }

--- a/src/main/admin/controllers/dashboard.controller.ts
+++ b/src/main/admin/controllers/dashboard.controller.ts
@@ -1,0 +1,54 @@
+import { Request, Response } from 'express';
+import { controller, httpGet, request, response } from 'inversify-express-utils';
+import { inject } from 'inversify';
+import { TYPES } from '@shared/types.container';
+import { AuthMiddleware } from '@shared/middleware/auth.middleware';
+import { ResponseHandler } from '@shared/response-handler';
+import { ILogger } from '@shared/logger.interface';
+import { DashboardService } from '@admin/services/dashboard.service';
+
+/**
+ * SUPER_ADMIN-only controller for the admin dashboard.
+ * Exposes platform-wide metrics and backend health checks.
+ */
+@controller('/api/admin/dashboard')
+export class DashboardController {
+  public constructor(
+    @inject(TYPES.DashboardService) private readonly _service: DashboardService,
+    @inject(TYPES.Logger) private readonly _log: ILogger,
+  ) {
+    this._log.context = DashboardController.name;
+  }
+
+  /**
+   * Returns aggregated platform-wide metrics (products, accounts, users, subscriptions).
+   * @param req - Express request.
+   * @param res - Express response.
+   */
+  @httpGet('/', AuthMiddleware.forRoles('SUPER_ADMIN'))
+  public async getMetrics(@request() req: Request, @response() res: Response): Promise<void> {
+    try {
+      const metrics = await this._service.getMetrics();
+      ResponseHandler.ok(res, metrics);
+    } catch (err) {
+      this._log.error('Failed to get dashboard metrics', { error: err });
+      ResponseHandler.error(res, 'Failed to get dashboard metrics', 500);
+    }
+  }
+
+  /**
+   * Returns health status of all backend services (MongoDB, PostgreSQL, Redis).
+   * @param req - Express request.
+   * @param res - Express response.
+   */
+  @httpGet('/health', AuthMiddleware.forRoles('SUPER_ADMIN'))
+  public async getHealth(@request() req: Request, @response() res: Response): Promise<void> {
+    try {
+      const health = await this._service.getHealth();
+      ResponseHandler.ok(res, health);
+    } catch (err) {
+      this._log.error('Failed to get health status', { error: err });
+      ResponseHandler.error(res, 'Failed to get health status', 500);
+    }
+  }
+}

--- a/src/main/admin/controllers/index.ts
+++ b/src/main/admin/controllers/index.ts
@@ -1,0 +1,6 @@
+export { AdminController } from './admin.controller';
+export { ProductAdminController } from './product-admin.controller';
+export { QueueAdminController } from './queue-admin.controller';
+export { DashboardController } from './dashboard.controller';
+export { AccountAdminController } from './account-admin.controller';
+export { RoleController } from './role.controller';

--- a/src/main/admin/controllers/product-admin.controller.ts
+++ b/src/main/admin/controllers/product-admin.controller.ts
@@ -1,0 +1,188 @@
+import { Request, Response } from 'express';
+import { controller, httpGet, httpDelete, request, response } from 'inversify-express-utils';
+import { inject } from 'inversify';
+import { TYPES } from '@shared/types.container';
+import { AuthMiddleware } from '@shared/middleware/auth.middleware';
+import { ResponseHandler } from '@shared/response-handler';
+import { ValidateRequestMiddleware } from '@shared/middleware/validate-request.middleware';
+import { ILogger } from '@shared/logger.interface';
+import { ProductAdminService } from '@admin/services/product-admin.service';
+import { ProductListQueryDTO } from '@admin/services/dto/product-list-query.dto';
+
+@controller('/api/admin/products')
+export class ProductAdminController {
+  public constructor(
+    @inject(TYPES.ProductAdminService) private readonly _service: ProductAdminService,
+    @inject(TYPES.Logger) private readonly _log: ILogger,
+  ) {
+    this._log.context = ProductAdminController.name;
+  }
+
+  /**
+   * Lists products with pagination, filtering, and sorting.
+   * @param req - Express request with query parameters.
+   * @param res - Express response.
+   */
+  @httpGet('/', AuthMiddleware.forRoles('SUPER_ADMIN'), ValidateRequestMiddleware.with(ProductListQueryDTO))
+  public async list(@request() req: Request, @response() res: Response): Promise<void> {
+    try {
+      const result = await this._service.list(req.body as ProductListQueryDTO);
+      ResponseHandler.ok(res, result);
+    } catch (err) {
+      this._log.error('Failed to list products', { error: err });
+      ResponseHandler.error(res, 'Failed to list products', 500);
+    }
+  }
+
+  /**
+   * Returns aggregated statistics across all products.
+   * @param req - Express request.
+   * @param res - Express response.
+   */
+  @httpGet('/stats', AuthMiddleware.forRoles('SUPER_ADMIN'))
+  public async getStats(@request() req: Request, @response() res: Response): Promise<void> {
+    try {
+      const stats = await this._service.getStats();
+      ResponseHandler.ok(res, stats);
+    } catch (err) {
+      this._log.error('Failed to get product stats', { error: err });
+      ResponseHandler.error(res, 'Failed to get product stats', 500);
+    }
+  }
+
+  /**
+   * Retrieves a single product by ID.
+   * @param req - Express request with product id in params.
+   * @param res - Express response.
+   */
+  @httpGet('/:id', AuthMiddleware.forRoles('SUPER_ADMIN'))
+  public async getById(@request() req: Request, @response() res: Response): Promise<void> {
+    try {
+      const product = await this._service.getById(req.params.id);
+      if (!product) {
+        ResponseHandler.notFound(res, 'Product not found');
+        return;
+      }
+      ResponseHandler.ok(res, product);
+    } catch (err) {
+      this._log.error('Failed to get product', { error: err, productId: req.params.id });
+      ResponseHandler.error(res, 'Failed to get product', 500);
+    }
+  }
+
+  /**
+   * Retrieves price history for a product.
+   * @param req - Express request with product id in params.
+   * @param res - Express response.
+   */
+  @httpGet('/:id/history/price', AuthMiddleware.forRoles('SUPER_ADMIN'))
+  public async getPriceHistory(@request() req: Request, @response() res: Response): Promise<void> {
+    try {
+      const history = await this._service.getPriceHistory(req.params.id);
+      if (!history) {
+        ResponseHandler.notFound(res, 'Product not found');
+        return;
+      }
+      ResponseHandler.ok(res, history);
+    } catch (err) {
+      this._log.error('Failed to get price history', { error: err, productId: req.params.id });
+      ResponseHandler.error(res, 'Failed to get price history', 500);
+    }
+  }
+
+  /**
+   * Retrieves views history for a product.
+   * @param req - Express request with product id in params.
+   * @param res - Express response.
+   */
+  @httpGet('/:id/history/views', AuthMiddleware.forRoles('SUPER_ADMIN'))
+  public async getViewsHistory(@request() req: Request, @response() res: Response): Promise<void> {
+    try {
+      const history = await this._service.getViewsHistory(req.params.id);
+      if (!history) {
+        ResponseHandler.notFound(res, 'Product not found');
+        return;
+      }
+      ResponseHandler.ok(res, history);
+    } catch (err) {
+      this._log.error('Failed to get views history', { error: err, productId: req.params.id });
+      ResponseHandler.error(res, 'Failed to get views history', 500);
+    }
+  }
+
+  /**
+   * Retrieves location history for a product.
+   * @param req - Express request with product id in params.
+   * @param res - Express response.
+   */
+  @httpGet('/:id/history/location', AuthMiddleware.forRoles('SUPER_ADMIN'))
+  public async getLocationHistory(@request() req: Request, @response() res: Response): Promise<void> {
+    try {
+      const history = await this._service.getLocationHistory(req.params.id);
+      if (!history) {
+        ResponseHandler.notFound(res, 'Product not found');
+        return;
+      }
+      ResponseHandler.ok(res, history);
+    } catch (err) {
+      this._log.error('Failed to get location history', { error: err, productId: req.params.id });
+      ResponseHandler.error(res, 'Failed to get location history', 500);
+    }
+  }
+
+  /**
+   * Retrieves outstanding history for a product.
+   * @param req - Express request with product id in params.
+   * @param res - Express response.
+   */
+  @httpGet('/:id/history/outstanding', AuthMiddleware.forRoles('SUPER_ADMIN'))
+  public async getOutstandingHistory(@request() req: Request, @response() res: Response): Promise<void> {
+    try {
+      const history = await this._service.getOutstandingHistory(req.params.id);
+      if (!history) {
+        ResponseHandler.notFound(res, 'Product not found');
+        return;
+      }
+      ResponseHandler.ok(res, history);
+    } catch (err) {
+      this._log.error('Failed to get outstanding history', { error: err, productId: req.params.id });
+      ResponseHandler.error(res, 'Failed to get outstanding history', 500);
+    }
+  }
+
+  /**
+   * Retrieves promoted history for a product.
+   * @param req - Express request with product id in params.
+   * @param res - Express response.
+   */
+  @httpGet('/:id/history/promoted', AuthMiddleware.forRoles('SUPER_ADMIN'))
+  public async getPromotedHistory(@request() req: Request, @response() res: Response): Promise<void> {
+    try {
+      const history = await this._service.getPromotedHistory(req.params.id);
+      if (!history) {
+        ResponseHandler.notFound(res, 'Product not found');
+        return;
+      }
+      ResponseHandler.ok(res, history);
+    } catch (err) {
+      this._log.error('Failed to get promoted history', { error: err, productId: req.params.id });
+      ResponseHandler.error(res, 'Failed to get promoted history', 500);
+    }
+  }
+
+  /**
+   * Deletes a product by ID.
+   * @param req - Express request with product id in params.
+   * @param res - Express response.
+   */
+  @httpDelete('/:id', AuthMiddleware.forRoles('SUPER_ADMIN'))
+  public async delete(@request() req: Request, @response() res: Response): Promise<void> {
+    try {
+      await this._service.delete(req.params.id);
+      ResponseHandler.deleted(res);
+    } catch (err) {
+      this._log.error('Failed to delete product', { error: err, productId: req.params.id });
+      ResponseHandler.error(res, 'Failed to delete product', 500);
+    }
+  }
+}

--- a/src/main/admin/controllers/queue-admin.controller.ts
+++ b/src/main/admin/controllers/queue-admin.controller.ts
@@ -1,0 +1,101 @@
+import { Request, Response } from 'express';
+import { controller, httpGet, request, response } from 'inversify-express-utils';
+import { inject } from 'inversify';
+import { TYPES } from '@shared/types.container';
+import { AuthMiddleware } from '@shared/middleware/auth.middleware';
+import { ResponseHandler } from '@shared/response-handler';
+import { ILogger } from '@shared/logger.interface';
+import { QueueAdminService } from '@admin/services/queue-admin.service';
+
+/**
+ * SUPER_ADMIN-only controller for queue introspection.
+ * Exposes aggregated job counts, recent jobs, and individual job details
+ * by accessing BullMQ internals through the QueueAdapterRegistry.
+ */
+@controller('/api/admin/queues')
+export class QueueAdminController {
+  public constructor(
+    @inject(TYPES.QueueAdminService) private readonly _service: QueueAdminService,
+    @inject(TYPES.Logger) private readonly _log: ILogger,
+  ) {
+    this._log.context = QueueAdminController.name;
+  }
+
+  /**
+   * Returns job counts for all registered queues.
+   * @param req - Express request.
+   * @param res - Express response.
+   */
+  @httpGet('/stats', AuthMiddleware.forRoles('SUPER_ADMIN'))
+  public async getAllStats(@request() req: Request, @response() res: Response): Promise<void> {
+    try {
+      const stats = await this._service.getAllQueueStats();
+      ResponseHandler.ok(res, { queues: stats });
+    } catch (err) {
+      this._log.error('Failed to get queue stats', { error: err });
+      ResponseHandler.error(res, 'Failed to get queue stats', 500);
+    }
+  }
+
+  /**
+   * Returns job counts for a single queue.
+   * @param req - Express request with queue name in params.
+   * @param res - Express response.
+   */
+  @httpGet('/:name/stats', AuthMiddleware.forRoles('SUPER_ADMIN'))
+  public async getStats(@request() req: Request, @response() res: Response): Promise<void> {
+    try {
+      const stats = await this._service.getQueueStats(req.params.name);
+      if (!stats) {
+        ResponseHandler.notFound(res, 'Queue not found');
+        return;
+      }
+      ResponseHandler.ok(res, stats);
+    } catch (err) {
+      this._log.error('Failed to get queue stats', { error: err, queueName: req.params.name });
+      ResponseHandler.error(res, 'Failed to get queue stats', 500);
+    }
+  }
+
+  /**
+   * Returns recent jobs for a queue.
+   * @param req - Express request with queue name in params and optional limit/status in query.
+   * @param res - Express response.
+   */
+  @httpGet('/:name/jobs', AuthMiddleware.forRoles('SUPER_ADMIN'))
+  public async getRecentJobs(@request() req: Request, @response() res: Response): Promise<void> {
+    try {
+      const limit = req.query.limit ? parseInt(String(req.query.limit), 10) : 20;
+      const status = req.query.status ? String(req.query.status) : undefined;
+      const jobs = await this._service.getRecentJobs(req.params.name, limit, status);
+      ResponseHandler.ok(res, { jobs });
+    } catch (err) {
+      this._log.error('Failed to get recent jobs', { error: err, queueName: req.params.name });
+      ResponseHandler.error(res, 'Failed to get recent jobs', 500);
+    }
+  }
+
+  /**
+   * Returns full detail for a single job.
+   * @param req - Express request with queue name and job id in params.
+   * @param res - Express response.
+   */
+  @httpGet('/:name/jobs/:id', AuthMiddleware.forRoles('SUPER_ADMIN'))
+  public async getJobDetail(@request() req: Request, @response() res: Response): Promise<void> {
+    try {
+      const job = await this._service.getJobDetail(req.params.name, req.params.id);
+      if (!job) {
+        ResponseHandler.notFound(res, 'Job not found');
+        return;
+      }
+      ResponseHandler.ok(res, job);
+    } catch (err) {
+      this._log.error('Failed to get job detail', {
+        error: err,
+        queueName: req.params.name,
+        jobId: req.params.id,
+      });
+      ResponseHandler.error(res, 'Failed to get job detail', 500);
+    }
+  }
+}

--- a/src/main/admin/controllers/role.controller.ts
+++ b/src/main/admin/controllers/role.controller.ts
@@ -1,0 +1,100 @@
+import { Request, Response } from 'express';
+import { controller, httpGet, httpPost, httpDelete, request, response } from 'inversify-express-utils';
+import { inject } from 'inversify';
+import { TYPES } from '@shared/types.container';
+import { AuthMiddleware } from '@shared/middleware/auth.middleware';
+import { ResponseHandler } from '@shared/response-handler';
+import { ILogger } from '@shared/logger.interface';
+import { RoleService } from '@admin/services/role.service';
+import { CreateRoleDTO } from '@admin/services/dto/role.dto';
+
+@controller('/api/admin')
+export class RoleController {
+  public constructor(
+    @inject(TYPES.RoleService) private readonly _service: RoleService,
+    @inject(TYPES.Logger) private readonly _log: ILogger,
+  ) {
+    this._log.context = RoleController.name;
+  }
+
+  /**
+   * Lists all roles with user counts.
+   * @param req - Express request.
+   * @param res - Express response.
+   */
+  @httpGet('/roles', AuthMiddleware.forRoles('SUPER_ADMIN'))
+  public async list(@request() req: Request, @response() res: Response): Promise<void> {
+    try {
+      const roles = await this._service.getAll();
+      ResponseHandler.ok(res, { roles });
+    } catch (err) {
+      this._log.error('Failed to list roles', { error: err });
+      ResponseHandler.error(res, 'Failed to list roles', 500);
+    }
+  }
+
+  /**
+   * Creates a new role.
+   * @param req - Express request with role data in body.
+   * @param res - Express response.
+   */
+  @httpPost('/roles', AuthMiddleware.forRoles('SUPER_ADMIN'))
+  public async create(@request() req: Request, @response() res: Response): Promise<void> {
+    try {
+      const dto = CreateRoleDTO.from(req.body);
+      const role = await this._service.create(dto.name, dto.accountId);
+      ResponseHandler.created(res, 'Role created', role);
+    } catch (err) {
+      this._log.error('Failed to create role', { error: err });
+      ResponseHandler.error(res, 'Failed to create role', 500);
+    }
+  }
+
+  /**
+   * Deletes a role by ID.
+   * @param req - Express request with role id in params.
+   * @param res - Express response.
+   */
+  @httpDelete('/roles/:id', AuthMiddleware.forRoles('SUPER_ADMIN'))
+  public async delete(@request() req: Request, @response() res: Response): Promise<void> {
+    try {
+      await this._service.delete(req.params.id);
+      ResponseHandler.deleted(res);
+    } catch (err) {
+      this._log.error('Failed to delete role', { error: err, roleId: req.params.id });
+      ResponseHandler.error(res, 'Failed to delete role', 500);
+    }
+  }
+
+  /**
+   * Assigns a role to a user.
+   * @param req - Express request with userId and roleId in params.
+   * @param res - Express response.
+   */
+  @httpPost('/users/:userId/roles/:roleId', AuthMiddleware.forRoles('SUPER_ADMIN'))
+  public async assignRole(@request() req: Request, @response() res: Response): Promise<void> {
+    try {
+      await this._service.assignRole(req.params.userId, req.params.roleId);
+      ResponseHandler.ok(res, { message: 'Role assigned successfully' });
+    } catch (err) {
+      this._log.error('Failed to assign role', { error: err, userId: req.params.userId, roleId: req.params.roleId });
+      ResponseHandler.error(res, 'Failed to assign role', 500);
+    }
+  }
+
+  /**
+   * Unassigns a role from a user.
+   * @param req - Express request with userId and roleId in params.
+   * @param res - Express response.
+   */
+  @httpDelete('/users/:userId/roles/:roleId', AuthMiddleware.forRoles('SUPER_ADMIN'))
+  public async unassignRole(@request() req: Request, @response() res: Response): Promise<void> {
+    try {
+      await this._service.unassignRole(req.params.userId, req.params.roleId);
+      ResponseHandler.ok(res, { message: 'Role unassigned successfully' });
+    } catch (err) {
+      this._log.error('Failed to unassign role', { error: err, userId: req.params.userId, roleId: req.params.roleId });
+      ResponseHandler.error(res, 'Failed to unassign role', 500);
+    }
+  }
+}

--- a/src/main/admin/mappers/index.ts
+++ b/src/main/admin/mappers/index.ts
@@ -1,0 +1,14 @@
+export {
+  toProductListItemDTO,
+  toProductDetailDTO,
+  toProductListItemDTOs,
+  toPaginatedResponse,
+  toPriceHistoryEntries,
+  toViewsHistoryEntries,
+  toLocationHistoryEntries,
+  toOutstandingHistoryEntries,
+  toPromotedHistoryEntries,
+  ProductMapper,
+  IPaginatedResponse,
+} from './product.mapper';
+export { toRoleResponseDTO, toRoleResponseDTOs } from './role.mapper';

--- a/src/main/admin/mappers/product.mapper.ts
+++ b/src/main/admin/mappers/product.mapper.ts
@@ -62,7 +62,6 @@ export function toProductListItemDTO(model: IRevolicoProduct): ProductListItemTy
     location: model.location ? { state: model.location.state, municipality: model.location.municipality } : undefined,
     views: model.views,
     seller: model.seller ? { name: model.seller.name } : undefined,
-    metadata: model.metadata ? { scrapedAt: model.metadata.scrapedAt } : undefined,
     createdAt: toISODate((model as unknown as Record<string, unknown>).createdAt),
     updatedAt: toISODate((model as unknown as Record<string, unknown>).updatedAt),
   };
@@ -98,16 +97,6 @@ export function toProductDetailDTO(model: IRevolicoProduct): ProductDetailType {
           whatsapp: model.seller.whatsapp,
         }
       : undefined,
-    metadata: model.metadata
-      ? {
-          source: model.metadata.source as string | undefined,
-          schemaVersion: model.metadata.schemaVersion as number | undefined,
-          scrapedAt: model.metadata.scrapedAt,
-        }
-      : undefined,
-    tags: model.tags,
-    attributes: model.attributes,
-    analytics: model.analytics,
     createdAt: toISODate((model as unknown as Record<string, unknown>).createdAt),
     updatedAt: toISODate((model as unknown as Record<string, unknown>).updatedAt),
   };

--- a/src/main/admin/mappers/product.mapper.ts
+++ b/src/main/admin/mappers/product.mapper.ts
@@ -1,0 +1,286 @@
+import { injectable } from 'inversify';
+import { IRevolicoProduct } from '@scrapers/revolico/models/product.model';
+import { ProductListItemType, ProductDetailType } from '@admin/services/dto/product-response.dto';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Serialize a value that could be a Mongoose ObjectId or already a string. */
+const toStringId = (id: unknown): string => {
+  if (id === undefined || id === null) return '';
+  if (typeof id === 'string') return id;
+  // Mongoose ObjectId instances have a toString() method
+  if (typeof id === 'object' && id !== null && typeof (id as Record<string, unknown>).toString === 'function') {
+    return String(id);
+  }
+  return String(id);
+};
+
+/** Serialize a Date or date-like value to an ISO string, or return as-is if string. */
+const toISODate = (d: unknown): string => {
+  if (d instanceof Date) return d.toISOString();
+  if (typeof d === 'string') return d;
+  return String(d ?? '');
+};
+
+// ---------------------------------------------------------------------------
+// History entry helper: sort desc by updatedAt
+// ---------------------------------------------------------------------------
+
+const sortByUpdatedAtDesc = <T extends { updatedAt: unknown }>(items: T[]): T[] =>
+  [...items].sort((a, b) => {
+    const da = a.updatedAt instanceof Date ? a.updatedAt.getTime() : Number(new Date(a.updatedAt as string));
+    const db = b.updatedAt instanceof Date ? b.updatedAt.getTime() : Number(new Date(b.updatedAt as string));
+    return db - da;
+  });
+
+// ---------------------------------------------------------------------------
+// Exported mapper functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Maps a Mongoose product document to a lightweight ProductListItemDTO-compatible object.
+ * Excludes all history arrays.
+ * @param model - The product document from the database.
+ * @returns A plain object matching ProductListItemType.
+ */
+export function toProductListItemDTO(model: IRevolicoProduct): ProductListItemType {
+  return {
+    _id: toStringId(model._id),
+    ID: model.ID,
+    category: model.category,
+    subcategory: model.subcategory,
+    url: model.url,
+    description: model.description,
+    cost: model.cost,
+    currency: model.currency,
+    price: model.price,
+    imageURL: model.imageURL,
+    isOutstanding: model.isOutstanding,
+    isPromoted: model.isPromoted,
+    location: model.location ? { state: model.location.state, municipality: model.location.municipality } : undefined,
+    views: model.views,
+    seller: model.seller ? { name: model.seller.name } : undefined,
+    metadata: model.metadata ? { scrapedAt: model.metadata.scrapedAt } : undefined,
+    createdAt: toISODate((model as unknown as Record<string, unknown>).createdAt),
+    updatedAt: toISODate((model as unknown as Record<string, unknown>).updatedAt),
+  };
+}
+
+/**
+ * Maps a Mongoose product document to a full ProductDetailDTO-compatible object.
+ * Excludes all history arrays.
+ * @param model - The product document from the database.
+ * @returns A plain object matching ProductDetailType.
+ */
+export function toProductDetailDTO(model: IRevolicoProduct): ProductDetailType {
+  return {
+    _id: toStringId(model._id),
+    ID: model.ID,
+    category: model.category,
+    subcategory: model.subcategory,
+    url: model.url,
+    description: model.description,
+    cost: model.cost,
+    currency: model.currency,
+    price: model.price,
+    imageURL: model.imageURL,
+    isOutstanding: model.isOutstanding,
+    isPromoted: model.isPromoted,
+    location: model.location ? { state: model.location.state, municipality: model.location.municipality } : undefined,
+    views: model.views,
+    seller: model.seller
+      ? {
+          name: model.seller.name,
+          phone: model.seller.phone,
+          email: model.seller.email,
+          whatsapp: model.seller.whatsapp,
+        }
+      : undefined,
+    metadata: model.metadata
+      ? {
+          source: model.metadata.source as string | undefined,
+          schemaVersion: model.metadata.schemaVersion as number | undefined,
+          scrapedAt: model.metadata.scrapedAt,
+        }
+      : undefined,
+    tags: model.tags,
+    attributes: model.attributes,
+    analytics: model.analytics,
+    createdAt: toISODate((model as unknown as Record<string, unknown>).createdAt),
+    updatedAt: toISODate((model as unknown as Record<string, unknown>).updatedAt),
+  };
+}
+
+/**
+ * Maps an array of Mongoose product documents to ProductListItemDTO-compatible objects.
+ * @param models - Array of product documents.
+ * @returns Array of plain objects matching ProductListItemType.
+ */
+export function toProductListItemDTOs(models: IRevolicoProduct[]): ProductListItemType[] {
+  return models.map(toProductListItemDTO);
+}
+
+// ---------------------------------------------------------------------------
+// PaginatedResponse
+// ---------------------------------------------------------------------------
+
+/** Shape of a paginated API response. */
+export interface IPaginatedResponse<T> {
+  data: T[];
+  meta: {
+    total: number;
+    skip: number;
+    limit: number;
+    hasMore: boolean;
+  };
+}
+
+/**
+ * Creates a paginated response wrapper.
+ * @param data - The array of items for the current page.
+ * @param total - Total number of items matching the query.
+ * @param skip - Number of items skipped.
+ * @param limit - Max items per page.
+ * @returns A paginated response object.
+ */
+export function toPaginatedResponse<T>(data: T[], total: number, skip: number, limit: number): IPaginatedResponse<T> {
+  return {
+    data,
+    meta: {
+      total,
+      skip,
+      limit,
+      hasMore: skip + data.length < total,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// History entry mappers
+// ---------------------------------------------------------------------------
+
+/** A history entry with a numeric value and updatedAt timestamp. */
+interface IValueHistoryEntry {
+  value: number;
+  updatedAt: string;
+}
+
+/** A location history entry. */
+interface ILocationHistoryEntry {
+  location: {
+    state: string;
+    municipality?: string;
+  };
+  updatedAt: string;
+}
+
+/** Wrapper for history responses. */
+interface IHistoryWrapper<T> {
+  data: T[];
+  total: number;
+}
+
+/**
+ * Maps and sorts price history entries, newest first.
+ * @param priceHistory - The raw price history array from the product document.
+ * @returns Sorted history entries wrapped in { data, total }.
+ */
+export function toPriceHistoryEntries(priceHistory: { value: number; updatedAt: Date }[] | undefined): IHistoryWrapper<IValueHistoryEntry> {
+  if (!priceHistory || !Array.isArray(priceHistory)) return { data: [], total: 0 };
+  const sorted = sortByUpdatedAtDesc(priceHistory);
+  return {
+    data: sorted.map(e => ({ value: e.value, updatedAt: toISODate(e.updatedAt) })),
+    total: sorted.length,
+  };
+}
+
+/**
+ * Maps and sorts views history entries, newest first.
+ * @param viewsHistory - The raw views history array from the product document.
+ * @returns Sorted history entries wrapped in { data, total }.
+ */
+export function toViewsHistoryEntries(viewsHistory: { value: number; updatedAt: Date }[] | undefined): IHistoryWrapper<IValueHistoryEntry> {
+  if (!viewsHistory || !Array.isArray(viewsHistory)) return { data: [], total: 0 };
+  const sorted = sortByUpdatedAtDesc(viewsHistory);
+  return {
+    data: sorted.map(e => ({ value: e.value, updatedAt: toISODate(e.updatedAt) })),
+    total: sorted.length,
+  };
+}
+
+/**
+ * Maps and sorts location history entries, newest first.
+ * @param locationHistory - The raw location history array from the product document.
+ * @returns Sorted history entries wrapped in { data, total }.
+ */
+export function toLocationHistoryEntries(
+  locationHistory: { value: { state: string; municipality: string }; updatedAt: Date }[] | undefined,
+): IHistoryWrapper<ILocationHistoryEntry> {
+  if (!locationHistory || !Array.isArray(locationHistory)) return { data: [], total: 0 };
+  const sorted = sortByUpdatedAtDesc(locationHistory);
+  return {
+    data: sorted.map(e => ({
+      location: {
+        state: e.value.state,
+        municipality: e.value.municipality,
+      },
+      updatedAt: toISODate(e.updatedAt),
+    })),
+    total: sorted.length,
+  };
+}
+
+/**
+ * Maps and sorts outstanding history entries, newest first.
+ * @param isOutstandingHistory - The raw outstanding history array from the product document.
+ * @returns Sorted history entries wrapped in { data, total }.
+ */
+export function toOutstandingHistoryEntries(
+  isOutstandingHistory: { value: boolean; updatedAt: Date }[] | undefined,
+): IHistoryWrapper<IValueHistoryEntry> {
+  if (!isOutstandingHistory || !Array.isArray(isOutstandingHistory)) return { data: [], total: 0 };
+  const sorted = sortByUpdatedAtDesc(isOutstandingHistory);
+  return {
+    data: sorted.map(e => ({ value: e.value ? 1 : 0, updatedAt: toISODate(e.updatedAt) })),
+    total: sorted.length,
+  };
+}
+
+/**
+ * Maps and sorts promoted history entries, newest first.
+ * @param isPromotedHistory - The raw promoted history array from the product document.
+ * @returns Sorted history entries wrapped in { data, total }.
+ */
+export function toPromotedHistoryEntries(
+  isPromotedHistory: { value: boolean; updatedAt: Date }[] | undefined,
+): IHistoryWrapper<IValueHistoryEntry> {
+  if (!isPromotedHistory || !Array.isArray(isPromotedHistory)) return { data: [], total: 0 };
+  const sorted = sortByUpdatedAtDesc(isPromotedHistory);
+  return {
+    data: sorted.map(e => ({ value: e.value ? 1 : 0, updatedAt: toISODate(e.updatedAt) })),
+    total: sorted.length,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// DI-friendly class (wraps the pure functions for Inversify registration)
+// ---------------------------------------------------------------------------
+
+/**
+ * Mapper for transforming Mongoose product documents into DTOs.
+ * All methods are pure — no DB/queue/logger access.
+ */
+@injectable()
+export class ProductMapper {
+  public toProductListItemDTO = toProductListItemDTO;
+  public toProductDetailDTO = toProductDetailDTO;
+  public toProductListItemDTOs = toProductListItemDTOs;
+  public toPaginatedResponse = toPaginatedResponse;
+  public toPriceHistoryEntries = toPriceHistoryEntries;
+  public toViewsHistoryEntries = toViewsHistoryEntries;
+  public toLocationHistoryEntries = toLocationHistoryEntries;
+  public toOutstandingHistoryEntries = toOutstandingHistoryEntries;
+  public toPromotedHistoryEntries = toPromotedHistoryEntries;
+}

--- a/src/main/admin/mappers/role.mapper.ts
+++ b/src/main/admin/mappers/role.mapper.ts
@@ -1,0 +1,19 @@
+import { RoleResponseDTO, RoleResponseType } from '@admin/services/dto/role.dto';
+
+/**
+ * Converts a Prisma role model (optionally with _count.users) into a RoleResponseDTO.
+ * @param model - The raw role object from Prisma.
+ * @returns A RoleResponseDTO with a flattened userCount.
+ */
+export function toRoleResponseDTO(model: RoleResponseType): RoleResponseDTO {
+  return RoleResponseDTO.from(model);
+}
+
+/**
+ * Converts an array of Prisma role models into RoleResponseDTOs.
+ * @param models - Array of raw role objects from Prisma.
+ * @returns Array of RoleResponseDTOs.
+ */
+export function toRoleResponseDTOs(models: RoleResponseType[]): RoleResponseDTO[] {
+  return models.map(toRoleResponseDTO);
+}

--- a/src/main/admin/services/account-admin.service.ts
+++ b/src/main/admin/services/account-admin.service.ts
@@ -1,0 +1,144 @@
+import { inject, injectable } from 'inversify';
+import { PrismaClient } from '@prisma/client';
+import { ILogger } from '@shared/logger.interface';
+import { TYPES } from '@shared/types.container';
+import { AccountRepository } from '@users/repositories/account.repository';
+
+export interface IAccountStats {
+  id: string;
+  name: string;
+  settings: Record<string, unknown> | null;
+  createdAt: Date;
+  updatedAt: Date;
+  users: Array<{ id: string }>;
+  userCount: number;
+  subscriptionCount: number;
+  alarmCount: number;
+}
+
+export interface IPaginatedAccounts {
+  accounts: IAccountStats[];
+  total: number;
+  skip: number;
+  limit: number;
+}
+
+@injectable()
+export class AccountAdminService {
+  public constructor(
+    @inject(AccountRepository) private readonly _accountRepo: AccountRepository,
+    @inject(TYPES.PrismaClient) private readonly _prisma: PrismaClient,
+    @inject(TYPES.Logger) private readonly _log: ILogger,
+  ) {
+    this._log.context = AccountAdminService.name;
+  }
+
+  /**
+   * Returns a paginated list of accounts with related counts.
+   * @param skip - Number of records to skip.
+   * @param limit - Max records to return.
+   * @returns Paginated accounts with user/subscription/alarm counts.
+   */
+  public async getAll(skip: number, limit: number): Promise<IPaginatedAccounts> {
+    this._log.debug('Fetching paginated accounts', { skip, limit });
+
+    const allAccounts = await this._accountRepo.findAll();
+    const total = allAccounts.length;
+    const paged = allAccounts.slice(skip, skip + limit);
+
+    if (paged.length === 0) {
+      return { accounts: [], total, skip, limit };
+    }
+
+    const accountIds = paged.map(a => a.id);
+
+    const [subscriptionCounts, alarmCounts] = await Promise.all([
+      this._prisma.accountSubscription.groupBy({
+        by: ['accountId'],
+        where: { accountId: { in: accountIds } },
+        _count: { id: true },
+      }),
+      this._prisma.alarm.groupBy({
+        by: ['accountId'],
+        where: { accountId: { in: accountIds } },
+        _count: { id: true },
+      }),
+    ]);
+
+    const subMap = new Map(subscriptionCounts.map(s => [s.accountId, s._count.id]));
+    const alarmMap = new Map(alarmCounts.map(a => [a.accountId, a._count.id]));
+
+    const accounts: IAccountStats[] = paged.map(account => ({
+      id: account.id,
+      name: account.name,
+      settings: account.settings as Record<string, unknown> | null,
+      createdAt: account.createdAt,
+      updatedAt: account.updatedAt,
+      users: account.users,
+      userCount: account.users.length,
+      subscriptionCount: subMap.get(account.id) ?? 0,
+      alarmCount: alarmMap.get(account.id) ?? 0,
+    }));
+
+    return { accounts, total, skip, limit };
+  }
+
+  /**
+   * Returns a single account by ID with related counts.
+   * @param id - The account ID.
+   * @returns Account with stats, or null if not found.
+   */
+  public async getById(id: string): Promise<IAccountStats | null> {
+    this._log.debug('Fetching account by id', { id });
+
+    const account = await this._accountRepo.findById(id);
+    if (!account) return null;
+
+    const [subscriptionCount, alarmCount] = await Promise.all([
+      this._prisma.accountSubscription.count({ where: { accountId: id } }),
+      this._prisma.alarm.count({ where: { accountId: id } }),
+    ]);
+
+    return {
+      id: account.id,
+      name: account.name,
+      settings: account.settings as Record<string, unknown> | null,
+      createdAt: account.createdAt,
+      updatedAt: account.updatedAt,
+      users: account.users,
+      userCount: account.users.length,
+      subscriptionCount,
+      alarmCount,
+    };
+  }
+
+  /**
+   * Updates an account by ID.
+   * @param id - The account ID.
+   * @param data - Partial account data to update.
+   * @returns The updated account.
+   */
+  public async update(
+    id: string,
+    data: Record<string, unknown>,
+  ): Promise<{ id: string; name: string; settings: unknown; createdAt: Date; updatedAt: Date }> {
+    this._log.debug('Updating account', { id, data });
+    const updated = await this._accountRepo.update(id, data);
+    return {
+      id: updated.id,
+      name: updated.name,
+      settings: updated.settings,
+      createdAt: updated.createdAt,
+      updatedAt: updated.updatedAt,
+    };
+  }
+
+  /**
+   * Deletes an account by ID.
+   * @param id - The account ID.
+   */
+  public async delete(id: string): Promise<void> {
+    this._log.debug('Deleting account', { id });
+    await this._accountRepo.delete(id);
+  }
+}

--- a/src/main/admin/services/dashboard.service.ts
+++ b/src/main/admin/services/dashboard.service.ts
@@ -1,0 +1,120 @@
+import { injectable, inject } from 'inversify';
+import { PrismaClient } from '@prisma/client';
+import { ILogger } from '@shared/logger.interface';
+import { TYPES } from '@shared/types.container';
+import { ProductRepository } from '@scrapers/revolico/repositories/product.repository';
+import { IQueueAdapterRegistry } from '@shared/queue/port/queue-adapter-registry.interfaces';
+import { DashboardMetricsDTO } from '@admin/services/dto/dashboard-metrics.dto';
+import { HealthResponseDTO } from '@admin/services/dto/dashboard-metrics.dto';
+import { toProductListItemDTOs } from '@admin/mappers/product.mapper';
+import { IRevolicoProduct } from '@scrapers/revolico/models/product.model';
+
+/**
+ * Service for the SUPER_ADMIN dashboard. Aggregates metrics across all
+ * data sources (MongoDB product data, PostgreSQL tenant/users/subscriptions,
+ * and Redis/BullMQ queue health).
+ */
+@injectable()
+export class DashboardService {
+  public constructor(
+    @inject(ProductRepository) private readonly _productRepo: ProductRepository,
+    @inject(TYPES.PrismaClient) private readonly _prisma: PrismaClient,
+    @inject(TYPES.QueueAdapterRegistry) private readonly _registry: IQueueAdapterRegistry,
+    @inject(TYPES.Logger) private readonly _log: ILogger,
+  ) {
+    this._log.context = DashboardService.name;
+  }
+
+  /**
+   * Aggregates platform-wide metrics from all data sources.
+   * @returns A DashboardMetricsDTO with counts, breakdowns, and recent products.
+   */
+  public async getMetrics(): Promise<DashboardMetricsDTO> {
+    const [productCount, categoriesRaw, recentProductsRaw, totalAccounts, totalUsers, activeSubscriptions] = await Promise.all([
+      this._productRepo.count(),
+      this._productRepo.aggregate([{ $group: { _id: '$category', count: { $sum: 1 } } }]),
+      this._productRepo.find(0, 5, { field: 'createdAt', order: 'desc' }),
+      this._prisma.account.count(),
+      this._prisma.user.count(),
+      this._prisma.accountSubscription.count({ where: { status: 'ACTIVE' } }),
+    ]);
+
+    const categoriesBreakdown = (categoriesRaw as Array<{ _id: string; count: number }>)
+      .filter(c => c._id)
+      .map(c => ({ category: c._id, count: c.count }));
+
+    const recentProducts = toProductListItemDTOs(recentProductsRaw as IRevolicoProduct[]);
+
+    return DashboardMetricsDTO.from({
+      productCount,
+      categoriesBreakdown,
+      totalAccounts,
+      totalUsers,
+      activeSubscriptions,
+      recentProducts,
+    });
+  }
+
+  /**
+   * Checks health of all backend services: MongoDB, PostgreSQL, and Redis (via BullMQ).
+   * Each service returns either 'connected' or 'error' with an optional error message.
+   * @returns A HealthResponseDTO with per-service status and timestamp.
+   */
+  public async getHealth(): Promise<HealthResponseDTO> {
+    const services = await Promise.all([this.checkMongo(), this.checkPostgres(), this.checkRedis()]);
+
+    return HealthResponseDTO.from({
+      services,
+      timestamp: new Date().toISOString(),
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private health check helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Checks MongoDB connectivity by calling ProductRepository.count().
+   * @returns Health status.
+   */
+  private async checkMongo(): Promise<{ service: string; status: 'connected' | 'error'; error?: string }> {
+    try {
+      await this._productRepo.count();
+      return { service: 'mongodb', status: 'connected' };
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      this._log.error('MongoDB health check failed', { error: message });
+      return { service: 'mongodb', status: 'error', error: message };
+    }
+  }
+
+  /**
+   * Checks PostgreSQL connectivity using a raw query.
+   * @returns Health status.
+   */
+  private async checkPostgres(): Promise<{ service: string; status: 'connected' | 'error'; error?: string }> {
+    try {
+      await this._prisma.$queryRaw`SELECT 1`;
+      return { service: 'postgres', status: 'connected' };
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      this._log.error('PostgreSQL health check failed', { error: message });
+      return { service: 'postgres', status: 'error', error: message };
+    }
+  }
+
+  /**
+   * Checks Redis/BullMQ connectivity by accessing dashboard queues.
+   * @returns Health status.
+   */
+  private async checkRedis(): Promise<{ service: string; status: 'connected' | 'error'; error?: string }> {
+    try {
+      this._registry.getCurrent().getDashboardQueues();
+      return { service: 'redis', status: 'connected' };
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      this._log.error('Redis health check failed', { error: message });
+      return { service: 'redis', status: 'error', error: message };
+    }
+  }
+}

--- a/src/main/admin/services/dto/dashboard-metrics.dto.ts
+++ b/src/main/admin/services/dto/dashboard-metrics.dto.ts
@@ -1,0 +1,86 @@
+import { z } from 'zod';
+
+// ---------------------------------------------------------------------------
+// DashboardMetricsDTO — aggregated dashboard overview
+// ---------------------------------------------------------------------------
+
+export const CategoryBreakdownSchema = z.object({
+  category: z.string(),
+  count: z.number(),
+});
+
+export const DashboardMetricsSchema = z.object({
+  productCount: z.number(),
+  categoriesBreakdown: z.array(CategoryBreakdownSchema),
+  totalAccounts: z.number(),
+  totalUsers: z.number(),
+  activeSubscriptions: z.number(),
+  recentProducts: z.array(z.object({}).passthrough()),
+});
+
+export type DashboardMetricsType = z.infer<typeof DashboardMetricsSchema>;
+
+export class DashboardMetricsDTO {
+  public readonly productCount: number;
+  public readonly categoriesBreakdown: { category: string; count: number }[];
+  public readonly totalAccounts: number;
+  public readonly totalUsers: number;
+  public readonly activeSubscriptions: number;
+  public readonly recentProducts: Record<string, unknown>[];
+
+  public constructor(data: DashboardMetricsType) {
+    this.productCount = data.productCount;
+    this.categoriesBreakdown = data.categoriesBreakdown;
+    this.totalAccounts = data.totalAccounts;
+    this.totalUsers = data.totalUsers;
+    this.activeSubscriptions = data.activeSubscriptions;
+    this.recentProducts = data.recentProducts;
+  }
+
+  /**
+   * Creates a DashboardMetricsDTO from raw data, validating with Zod.
+   * @param data - Raw metrics object.
+   * @returns A validated DashboardMetricsDTO instance.
+   */
+  public static from(data: unknown): DashboardMetricsDTO {
+    const parsed = DashboardMetricsSchema.parse(data);
+    return new DashboardMetricsDTO(parsed);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// HealthStatus — individual service health check
+// ---------------------------------------------------------------------------
+
+export const HealthStatusSchema = z.object({
+  service: z.string(),
+  status: z.enum(['connected', 'error']),
+  error: z.string().optional(),
+});
+
+export const HealthResponseSchema = z.object({
+  services: z.array(HealthStatusSchema),
+  timestamp: z.string(),
+});
+
+export type HealthResponseType = z.infer<typeof HealthResponseSchema>;
+
+export class HealthResponseDTO {
+  public readonly services: { service: string; status: 'connected' | 'error'; error?: string }[];
+  public readonly timestamp: string;
+
+  public constructor(data: HealthResponseType) {
+    this.services = data.services;
+    this.timestamp = data.timestamp;
+  }
+
+  /**
+   * Creates a HealthResponseDTO from raw data, validating with Zod.
+   * @param data - Raw health check response.
+   * @returns A validated HealthResponseDTO instance.
+   */
+  public static from(data: unknown): HealthResponseDTO {
+    const parsed = HealthResponseSchema.parse(data);
+    return new HealthResponseDTO(parsed);
+  }
+}

--- a/src/main/admin/services/dto/index.ts
+++ b/src/main/admin/services/dto/index.ts
@@ -1,0 +1,30 @@
+export {
+  ProductListItemSchema,
+  ProductListItemType,
+  ProductListItemDTO,
+  ProductDetailSchema,
+  ProductDetailType,
+  ProductDetailDTO,
+  PriceHistoryEntrySchema,
+  PriceHistoryEntryType,
+  LocationHistoryEntrySchema,
+  LocationHistoryEntryType,
+  ProductHistorySchema,
+  ProductHistoryType,
+  ProductStatsSchema,
+  ProductStatsType,
+} from './product-response.dto';
+export { ProductListQuerySchema, ProductListQueryType, ProductListQueryDTO } from './product-list-query.dto';
+export {
+  CategoryBreakdownSchema,
+  DashboardMetricsSchema,
+  DashboardMetricsType,
+  DashboardMetricsDTO,
+  HealthStatusSchema,
+  HealthResponseSchema,
+  HealthResponseType,
+  HealthResponseDTO,
+} from './dashboard-metrics.dto';
+export { QueueStatsSchema, QueueStatsType, QueueStatsDTO, JobDetailSchema, JobDetailType, JobDetailDTO } from './queue-stats.dto';
+export { CreateRoleSchema, CreateRoleType, CreateRoleDTO, RoleResponseSchema, RoleResponseType, RoleResponseDTO } from './role.dto';
+export { PaginatedResponseSchema, PaginatedResponseType } from './paginated-response.dto';

--- a/src/main/admin/services/dto/paginated-response.dto.ts
+++ b/src/main/admin/services/dto/paginated-response.dto.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+
+export const PaginatedResponseSchema = <T extends z.ZodTypeAny>(
+  itemSchema: T,
+): z.ZodObject<{
+  data: z.ZodArray<T>;
+  meta: z.ZodObject<{
+    total: z.ZodNumber;
+    skip: z.ZodNumber;
+    limit: z.ZodNumber;
+    hasMore: z.ZodBoolean;
+  }>;
+}> =>
+  z.object({
+    data: z.array(itemSchema),
+    meta: z.object({
+      total: z.number(),
+      skip: z.number(),
+      limit: z.number(),
+      hasMore: z.boolean(),
+    }),
+  });
+
+export type PaginatedResponseType<T extends z.ZodTypeAny> = z.infer<ReturnType<typeof PaginatedResponseSchema<T>>>;

--- a/src/main/admin/services/dto/product-list-query.dto.ts
+++ b/src/main/admin/services/dto/product-list-query.dto.ts
@@ -1,0 +1,66 @@
+import { z } from 'zod';
+
+export const ProductListQuerySchema = z.object({
+  skip: z.coerce.number().min(0).default(0),
+  limit: z.coerce.number().min(1).max(100).default(20),
+  sort: z.string().default('createdAt'),
+  order: z.enum(['asc', 'desc']).default('desc'),
+  category: z.string().optional(),
+  subcategory: z.string().optional(),
+  search: z.string().optional(),
+  minPrice: z.coerce.number().optional(),
+  maxPrice: z.coerce.number().optional(),
+  isOutstanding: z.preprocess(v => {
+    if (v === 'false' || v === '0') return false;
+    if (v === 'true' || v === '1') return true;
+    return v;
+  }, z.coerce.boolean().optional()),
+  isPromoted: z.preprocess(v => {
+    if (v === 'false' || v === '0') return false;
+    if (v === 'true' || v === '1') return true;
+    return v;
+  }, z.coerce.boolean().optional()),
+  'location.state': z.string().optional(),
+});
+
+export type ProductListQueryType = z.infer<typeof ProductListQuerySchema>;
+
+export class ProductListQueryDTO {
+  public readonly skip: number;
+  public readonly limit: number;
+  public readonly sort: string;
+  public readonly order: 'asc' | 'desc';
+  public readonly category?: string;
+  public readonly subcategory?: string;
+  public readonly search?: string;
+  public readonly minPrice?: number;
+  public readonly maxPrice?: number;
+  public readonly isOutstanding?: boolean;
+  public readonly isPromoted?: boolean;
+  public readonly 'location.state'?: string;
+
+  public constructor(data: ProductListQueryType) {
+    this.skip = data.skip;
+    this.limit = data.limit;
+    this.sort = data.sort;
+    this.order = data.order;
+    this.category = data.category;
+    this.subcategory = data.subcategory;
+    this.search = data.search;
+    this.minPrice = data.minPrice;
+    this.maxPrice = data.maxPrice;
+    this.isOutstanding = data.isOutstanding;
+    this.isPromoted = data.isPromoted;
+    this['location.state'] = data['location.state'];
+  }
+
+  /**
+   * Creates a ProductListQueryDTO from raw query input.
+   * @param query - Raw query parameters (e.g. from req.query).
+   * @returns A validated ProductListQueryDTO instance.
+   */
+  public static from(query: unknown): ProductListQueryDTO {
+    const parsed = ProductListQuerySchema.parse(query ?? {});
+    return new ProductListQueryDTO(parsed);
+  }
+}

--- a/src/main/admin/services/dto/product-response.dto.ts
+++ b/src/main/admin/services/dto/product-response.dto.ts
@@ -7,11 +7,11 @@ import { z } from 'zod';
 export const ProductListItemSchema = z.object({
   _id: z.string(),
   ID: z.string().optional(),
-  category: z.string().optional(),
+  category: z.string(),
   subcategory: z.string().optional(),
   url: z.string(),
   description: z.string().optional(),
-  cost: z.string().optional(),
+  cost: z.string(),
   currency: z.string(),
   price: z.number(),
   imageURL: z.string().optional(),
@@ -29,11 +29,6 @@ export const ProductListItemSchema = z.object({
       name: z.string().optional(),
     })
     .optional(),
-  metadata: z
-    .object({
-      scrapedAt: z.unknown().optional(),
-    })
-    .optional(),
   createdAt: z.string(),
   updatedAt: z.string(),
 });
@@ -43,11 +38,11 @@ export type ProductListItemType = z.infer<typeof ProductListItemSchema>;
 export class ProductListItemDTO {
   public readonly _id: string;
   public readonly ID?: string;
-  public readonly category?: string;
+  public readonly category: string;
   public readonly subcategory?: string;
   public readonly url: string;
   public readonly description?: string;
-  public readonly cost?: string;
+  public readonly cost: string;
   public readonly currency: string;
   public readonly price: number;
   public readonly imageURL?: string;
@@ -56,7 +51,6 @@ export class ProductListItemDTO {
   public readonly location?: { state?: string; municipality?: string };
   public readonly views?: number;
   public readonly seller?: { name?: string };
-  public readonly metadata?: { scrapedAt?: unknown };
   public readonly createdAt: string;
   public readonly updatedAt: string;
 
@@ -76,7 +70,6 @@ export class ProductListItemDTO {
     this.location = data.location;
     this.views = data.views;
     this.seller = data.seller;
-    this.metadata = data.metadata;
     this.createdAt = data.createdAt;
     this.updatedAt = data.updatedAt;
   }
@@ -99,11 +92,11 @@ export class ProductListItemDTO {
 export const ProductDetailSchema = z.object({
   _id: z.string(),
   ID: z.string().optional(),
-  category: z.string().optional(),
+  category: z.string(),
   subcategory: z.string().optional(),
   url: z.string(),
   description: z.string().optional(),
-  cost: z.string().optional(),
+  cost: z.string(),
   currency: z.string(),
   price: z.number(),
   imageURL: z.string().optional(),
@@ -124,16 +117,6 @@ export const ProductDetailSchema = z.object({
       whatsapp: z.string().optional(),
     })
     .optional(),
-  metadata: z
-    .object({
-      source: z.string().optional(),
-      schemaVersion: z.number().optional(),
-      scrapedAt: z.unknown().optional(),
-    })
-    .optional(),
-  tags: z.array(z.string()).optional(),
-  attributes: z.record(z.string(), z.unknown()).optional(),
-  analytics: z.record(z.string(), z.unknown()).optional(),
   createdAt: z.string(),
   updatedAt: z.string(),
 });
@@ -143,11 +126,11 @@ export type ProductDetailType = z.infer<typeof ProductDetailSchema>;
 export class ProductDetailDTO {
   public readonly _id: string;
   public readonly ID?: string;
-  public readonly category?: string;
+  public readonly category: string;
   public readonly subcategory?: string;
   public readonly url: string;
   public readonly description?: string;
-  public readonly cost?: string;
+  public readonly cost: string;
   public readonly currency: string;
   public readonly price: number;
   public readonly imageURL?: string;
@@ -156,10 +139,6 @@ export class ProductDetailDTO {
   public readonly location?: { state?: string; municipality?: string };
   public readonly views?: number;
   public readonly seller?: { name?: string; phone?: string; email?: string; whatsapp?: string };
-  public readonly metadata?: { source?: string; schemaVersion?: number; scrapedAt?: unknown };
-  public readonly tags?: string[];
-  public readonly attributes?: Record<string, unknown>;
-  public readonly analytics?: Record<string, unknown>;
   public readonly createdAt: string;
   public readonly updatedAt: string;
 
@@ -179,10 +158,6 @@ export class ProductDetailDTO {
     this.location = data.location;
     this.views = data.views;
     this.seller = data.seller;
-    this.metadata = data.metadata;
-    this.tags = data.tags;
-    this.attributes = data.attributes;
-    this.analytics = data.analytics;
     this.createdAt = data.createdAt;
     this.updatedAt = data.updatedAt;
   }

--- a/src/main/admin/services/dto/product-response.dto.ts
+++ b/src/main/admin/services/dto/product-response.dto.ts
@@ -239,3 +239,19 @@ export const ProductHistorySchema = <T extends z.ZodTypeAny>(
   });
 
 export type ProductHistoryType<T extends z.ZodTypeAny> = z.infer<ReturnType<typeof ProductHistorySchema<T>>>;
+
+// ---------------------------------------------------------------------------
+// ProductStatsDTO
+// ---------------------------------------------------------------------------
+
+export const ProductStatsSchema = z.object({
+  totalProducts: z.number(),
+  byCategory: z.array(z.object({ category: z.string(), count: z.number() })),
+  byState: z.array(z.object({ state: z.string(), count: z.number() })),
+  outstandingCount: z.number(),
+  promotedCount: z.number(),
+  lastScrapedAt: z.string().nullable(),
+  priceRange: z.object({ min: z.number(), max: z.number() }),
+});
+
+export type ProductStatsType = z.infer<typeof ProductStatsSchema>;

--- a/src/main/admin/services/dto/product-response.dto.ts
+++ b/src/main/admin/services/dto/product-response.dto.ts
@@ -1,0 +1,241 @@
+import { z } from 'zod';
+
+// ---------------------------------------------------------------------------
+// ProductListItemDTO — lightweight, no history arrays
+// ---------------------------------------------------------------------------
+
+export const ProductListItemSchema = z.object({
+  _id: z.string(),
+  ID: z.string().optional(),
+  category: z.string().optional(),
+  subcategory: z.string().optional(),
+  url: z.string(),
+  description: z.string().optional(),
+  cost: z.string().optional(),
+  currency: z.string(),
+  price: z.number(),
+  imageURL: z.string().optional(),
+  isOutstanding: z.boolean(),
+  isPromoted: z.boolean().optional(),
+  location: z
+    .object({
+      state: z.string().optional(),
+      municipality: z.string().optional(),
+    })
+    .optional(),
+  views: z.number().optional(),
+  seller: z
+    .object({
+      name: z.string().optional(),
+    })
+    .optional(),
+  metadata: z
+    .object({
+      scrapedAt: z.unknown().optional(),
+    })
+    .optional(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+export type ProductListItemType = z.infer<typeof ProductListItemSchema>;
+
+export class ProductListItemDTO {
+  public readonly _id: string;
+  public readonly ID?: string;
+  public readonly category?: string;
+  public readonly subcategory?: string;
+  public readonly url: string;
+  public readonly description?: string;
+  public readonly cost?: string;
+  public readonly currency: string;
+  public readonly price: number;
+  public readonly imageURL?: string;
+  public readonly isOutstanding: boolean;
+  public readonly isPromoted?: boolean;
+  public readonly location?: { state?: string; municipality?: string };
+  public readonly views?: number;
+  public readonly seller?: { name?: string };
+  public readonly metadata?: { scrapedAt?: unknown };
+  public readonly createdAt: string;
+  public readonly updatedAt: string;
+
+  public constructor(data: ProductListItemType) {
+    this._id = data._id;
+    this.ID = data.ID;
+    this.category = data.category;
+    this.subcategory = data.subcategory;
+    this.url = data.url;
+    this.description = data.description;
+    this.cost = data.cost;
+    this.currency = data.currency;
+    this.price = data.price;
+    this.imageURL = data.imageURL;
+    this.isOutstanding = data.isOutstanding;
+    this.isPromoted = data.isPromoted;
+    this.location = data.location;
+    this.views = data.views;
+    this.seller = data.seller;
+    this.metadata = data.metadata;
+    this.createdAt = data.createdAt;
+    this.updatedAt = data.updatedAt;
+  }
+
+  /**
+   * Creates a ProductListItemDTO from raw data.
+   * @param data - The raw product data (typically from Mongoose).
+   * @returns A validated ProductListItemDTO instance.
+   */
+  public static from(data: unknown): ProductListItemDTO {
+    const parsed = ProductListItemSchema.parse(data);
+    return new ProductListItemDTO(parsed);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// ProductDetailDTO — full detail, no history arrays
+// ---------------------------------------------------------------------------
+
+export const ProductDetailSchema = z.object({
+  _id: z.string(),
+  ID: z.string().optional(),
+  category: z.string().optional(),
+  subcategory: z.string().optional(),
+  url: z.string(),
+  description: z.string().optional(),
+  cost: z.string().optional(),
+  currency: z.string(),
+  price: z.number(),
+  imageURL: z.string().optional(),
+  isOutstanding: z.boolean(),
+  isPromoted: z.boolean().optional(),
+  location: z
+    .object({
+      state: z.string().optional(),
+      municipality: z.string().optional(),
+    })
+    .optional(),
+  views: z.number().optional(),
+  seller: z
+    .object({
+      name: z.string().optional(),
+      phone: z.string().optional(),
+      email: z.string().optional(),
+      whatsapp: z.string().optional(),
+    })
+    .optional(),
+  metadata: z
+    .object({
+      source: z.string().optional(),
+      schemaVersion: z.number().optional(),
+      scrapedAt: z.unknown().optional(),
+    })
+    .optional(),
+  tags: z.array(z.string()).optional(),
+  attributes: z.record(z.string(), z.unknown()).optional(),
+  analytics: z.record(z.string(), z.unknown()).optional(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+
+export type ProductDetailType = z.infer<typeof ProductDetailSchema>;
+
+export class ProductDetailDTO {
+  public readonly _id: string;
+  public readonly ID?: string;
+  public readonly category?: string;
+  public readonly subcategory?: string;
+  public readonly url: string;
+  public readonly description?: string;
+  public readonly cost?: string;
+  public readonly currency: string;
+  public readonly price: number;
+  public readonly imageURL?: string;
+  public readonly isOutstanding: boolean;
+  public readonly isPromoted?: boolean;
+  public readonly location?: { state?: string; municipality?: string };
+  public readonly views?: number;
+  public readonly seller?: { name?: string; phone?: string; email?: string; whatsapp?: string };
+  public readonly metadata?: { source?: string; schemaVersion?: number; scrapedAt?: unknown };
+  public readonly tags?: string[];
+  public readonly attributes?: Record<string, unknown>;
+  public readonly analytics?: Record<string, unknown>;
+  public readonly createdAt: string;
+  public readonly updatedAt: string;
+
+  public constructor(data: ProductDetailType) {
+    this._id = data._id;
+    this.ID = data.ID;
+    this.category = data.category;
+    this.subcategory = data.subcategory;
+    this.url = data.url;
+    this.description = data.description;
+    this.cost = data.cost;
+    this.currency = data.currency;
+    this.price = data.price;
+    this.imageURL = data.imageURL;
+    this.isOutstanding = data.isOutstanding;
+    this.isPromoted = data.isPromoted;
+    this.location = data.location;
+    this.views = data.views;
+    this.seller = data.seller;
+    this.metadata = data.metadata;
+    this.tags = data.tags;
+    this.attributes = data.attributes;
+    this.analytics = data.analytics;
+    this.createdAt = data.createdAt;
+    this.updatedAt = data.updatedAt;
+  }
+
+  /**
+   * Creates a ProductDetailDTO from raw data.
+   * @param data - The raw product data (typically from Mongoose).
+   * @returns A validated ProductDetailDTO instance.
+   */
+  public static from(data: unknown): ProductDetailDTO {
+    const parsed = ProductDetailSchema.parse(data);
+    return new ProductDetailDTO(parsed);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// PriceHistoryEntry
+// ---------------------------------------------------------------------------
+
+export const PriceHistoryEntrySchema = z.object({
+  value: z.number(),
+  updatedAt: z.string(),
+});
+
+export type PriceHistoryEntryType = z.infer<typeof PriceHistoryEntrySchema>;
+
+// ---------------------------------------------------------------------------
+// LocationHistoryEntry
+// ---------------------------------------------------------------------------
+
+export const LocationHistoryEntrySchema = z.object({
+  location: z.object({
+    state: z.string(),
+    municipality: z.string().optional(),
+  }),
+  updatedAt: z.string(),
+});
+
+export type LocationHistoryEntryType = z.infer<typeof LocationHistoryEntrySchema>;
+
+// ---------------------------------------------------------------------------
+// ProductHistoryDTO — generic wrapper for history arrays
+// ---------------------------------------------------------------------------
+
+export const ProductHistorySchema = <T extends z.ZodTypeAny>(
+  itemSchema: T,
+): z.ZodObject<{
+  data: z.ZodArray<T>;
+  total: z.ZodNumber;
+}> =>
+  z.object({
+    data: z.array(itemSchema),
+    total: z.number(),
+  });
+
+export type ProductHistoryType<T extends z.ZodTypeAny> = z.infer<ReturnType<typeof ProductHistorySchema<T>>>;

--- a/src/main/admin/services/dto/queue-stats.dto.ts
+++ b/src/main/admin/services/dto/queue-stats.dto.ts
@@ -1,0 +1,90 @@
+import { z } from 'zod';
+
+// ---------------------------------------------------------------------------
+// QueueStatsDTO — per-queue aggregated counts
+// ---------------------------------------------------------------------------
+
+export const QueueStatsSchema = z.object({
+  queueName: z.string(),
+  counts: z.record(z.string(), z.number()),
+});
+
+export type QueueStatsType = z.infer<typeof QueueStatsSchema>;
+
+export class QueueStatsDTO {
+  public readonly queueName: string;
+  public readonly counts: Record<string, number>;
+
+  public constructor(data: QueueStatsType) {
+    this.queueName = data.queueName;
+    this.counts = data.counts;
+  }
+
+  /**
+   * Creates a QueueStatsDTO from a raw object, validating with Zod.
+   * @param data - Raw object with queueName and job counts.
+   * @returns A validated QueueStatsDTO instance.
+   */
+  public static from(data: unknown): QueueStatsDTO {
+    const parsed = QueueStatsSchema.parse(data);
+    return new QueueStatsDTO(parsed);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// JobDetailDTO — single job detail
+// ---------------------------------------------------------------------------
+
+export const JobDetailSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  data: z.unknown().optional(),
+  progress: z.union([z.number(), z.object({}).passthrough()]).optional(),
+  attemptsMade: z.number().optional(),
+  failedReason: z.string().optional(),
+  timestamp: z.number().optional(),
+  processedOn: z.number().nullable().optional(),
+  finishedOn: z.number().nullable().optional(),
+  returnValue: z.unknown().optional(),
+  status: z.string().optional(),
+});
+
+export type JobDetailType = z.infer<typeof JobDetailSchema>;
+
+export class JobDetailDTO {
+  public readonly id: string;
+  public readonly name: string;
+  public readonly data?: unknown;
+  public readonly progress?: number | object;
+  public readonly attemptsMade?: number;
+  public readonly failedReason?: string;
+  public readonly timestamp?: number;
+  public readonly processedOn?: number | null;
+  public readonly finishedOn?: number | null;
+  public readonly returnValue?: unknown;
+  public readonly status?: string;
+
+  public constructor(data: JobDetailType) {
+    this.id = data.id;
+    this.name = data.name;
+    this.data = data.data;
+    this.progress = data.progress;
+    this.attemptsMade = data.attemptsMade;
+    this.failedReason = data.failedReason;
+    this.timestamp = data.timestamp;
+    this.processedOn = data.processedOn;
+    this.finishedOn = data.finishedOn;
+    this.returnValue = data.returnValue;
+    this.status = data.status;
+  }
+
+  /**
+   * Creates a JobDetailDTO from a raw object, validating with Zod.
+   * @param data - Raw job detail object (typically from BullMQ Job.toJSON()).
+   * @returns A validated JobDetailDTO instance.
+   */
+  public static from(data: unknown): JobDetailDTO {
+    const parsed = JobDetailSchema.parse(data);
+    return new JobDetailDTO(parsed);
+  }
+}

--- a/src/main/admin/services/dto/role.dto.ts
+++ b/src/main/admin/services/dto/role.dto.ts
@@ -1,0 +1,75 @@
+import { z } from 'zod';
+
+// ---------------------------------------------------------------------------
+// CreateRoleDTO
+// ---------------------------------------------------------------------------
+
+export const CreateRoleSchema = z.object({
+  name: z.string().min(1, 'Role name is required'),
+  accountId: z.string().optional(),
+});
+
+export type CreateRoleType = z.infer<typeof CreateRoleSchema>;
+
+export class CreateRoleDTO {
+  public readonly name: string;
+  public readonly accountId?: string;
+
+  private constructor(data: CreateRoleType) {
+    this.name = data.name;
+    this.accountId = data.accountId;
+  }
+
+  /**
+   * Creates a CreateRoleDTO from an unvalidated request body.
+   * @param body - The raw request body.
+   * @returns A validated CreateRoleDTO.
+   * @throws ZodError if validation fails.
+   */
+  public static from(body: unknown): CreateRoleDTO {
+    const parsed = CreateRoleSchema.parse(body);
+    return new CreateRoleDTO(parsed);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// RoleResponseDTO
+// ---------------------------------------------------------------------------
+
+export const RoleResponseSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  accountId: z.string().nullable(),
+  _count: z
+    .object({
+      users: z.number(),
+    })
+    .optional(),
+});
+
+export type RoleResponseType = z.infer<typeof RoleResponseSchema>;
+
+export class RoleResponseDTO {
+  public readonly id: string;
+  public readonly name: string;
+  public readonly accountId: string | null;
+  public readonly userCount?: number;
+
+  private constructor(data: RoleResponseType) {
+    this.id = data.id;
+    this.name = data.name;
+    this.accountId = data.accountId;
+    if (data._count) {
+      this.userCount = data._count.users;
+    }
+  }
+
+  /**
+   * Creates a RoleResponseDTO from a Prisma role model.
+   * @param model - The raw Prisma role (optionally with _count).
+   * @returns A RoleResponseDTO.
+   */
+  public static from(model: RoleResponseType): RoleResponseDTO {
+    return new RoleResponseDTO(model);
+  }
+}

--- a/src/main/admin/services/index.ts
+++ b/src/main/admin/services/index.ts
@@ -1,0 +1,5 @@
+export { ProductAdminService } from './product-admin.service';
+export { QueueAdminService } from './queue-admin.service';
+export { DashboardService } from './dashboard.service';
+export { AccountAdminService, IAccountStats, IPaginatedAccounts } from './account-admin.service';
+export { RoleService } from './role.service';

--- a/src/main/admin/services/product-admin.service.ts
+++ b/src/main/admin/services/product-admin.service.ts
@@ -1,0 +1,239 @@
+import { injectable, inject } from 'inversify';
+import { ILogger } from '@shared/logger.interface';
+import { TYPES } from '@shared/types.container';
+import { ProductRepository } from '@scrapers/revolico/repositories/product.repository';
+import { IRevolicoProduct } from '@scrapers/revolico/models/product.model';
+import { RootFilterQuery } from 'mongoose';
+import { ProductListQueryDTO } from '@admin/services/dto/product-list-query.dto';
+import { ProductListItemType, ProductDetailType, ProductStatsType } from '@admin/services/dto/product-response.dto';
+import {
+  toProductListItemDTOs,
+  toProductDetailDTO,
+  toPaginatedResponse,
+  toPriceHistoryEntries,
+  toViewsHistoryEntries,
+  toLocationHistoryEntries,
+  toOutstandingHistoryEntries,
+  toPromotedHistoryEntries,
+  IPaginatedResponse,
+} from '@admin/mappers/product.mapper';
+
+/** Projection that excludes heavy history arrays. */
+const WITHOUT_HISTORY_PROJECTION: Partial<Record<keyof IRevolicoProduct, 0>> = {
+  priceHistory: 0,
+  viewsHistory: 0,
+  locationHistory: 0,
+  isOutstandingHistory: 0,
+  isPromotedHistory: 0,
+};
+
+/** Wrapper type returned by history mappers. */
+interface IHistoryWrapper<T> {
+  data: T[];
+  total: number;
+}
+
+@injectable()
+export class ProductAdminService {
+  public constructor(
+    @inject(ProductRepository) private readonly _repo: ProductRepository,
+    @inject(TYPES.Logger) private readonly _log: ILogger,
+  ) {
+    this._log.context = ProductAdminService.name;
+  }
+
+  /**
+   * Lists products with pagination, filtering, and sorting.
+   * @param query - Validated query parameters.
+   * @returns Paginated list of product DTOs.
+   */
+  public async list(query: ProductListQueryDTO): Promise<IPaginatedResponse<ProductListItemType>> {
+    const filter = this.buildFilter(query);
+    const sortField = query.sort || 'createdAt';
+    const sortOrder = query.order || 'desc';
+
+    const [products, total] = await Promise.all([
+      this._repo.find(
+        query.skip,
+        query.limit,
+        { field: sortField, order: sortOrder },
+        filter,
+        WITHOUT_HISTORY_PROJECTION as Partial<Record<keyof IRevolicoProduct, 1 | 0>>,
+      ),
+      this._repo.count(filter),
+    ]);
+
+    const dtos = toProductListItemDTOs(products);
+    return toPaginatedResponse(dtos, total, query.skip, query.limit);
+  }
+
+  /**
+   * Retrieves a single product by its MongoDB _id (full detail, no history).
+   * @param id - The product _id.
+   * @returns The product DTO or null if not found.
+   */
+  public async getById(id: string): Promise<ProductDetailType | null> {
+    const product = await this._repo.findOne({ _id: id }, WITHOUT_HISTORY_PROJECTION as Partial<Record<keyof IRevolicoProduct, 1 | 0>>);
+    if (!product) return null;
+    return toProductDetailDTO(product);
+  }
+
+  /**
+   * Retrieves price history for a product, sorted newest first.
+   * @param id - The product _id.
+   * @returns History wrapper or null if product not found.
+   */
+  public async getPriceHistory(id: string): Promise<IHistoryWrapper<{ value: number; updatedAt: string }> | null> {
+    const product = await this._repo.findOne({ _id: id });
+    if (!product) return null;
+    return toPriceHistoryEntries(product.priceHistory);
+  }
+
+  /**
+   * Retrieves views history for a product, sorted newest first.
+   * @param id - The product _id.
+   * @returns History wrapper or null if product not found.
+   */
+  public async getViewsHistory(id: string): Promise<IHistoryWrapper<{ value: number; updatedAt: string }> | null> {
+    const product = await this._repo.findOne({ _id: id });
+    if (!product) return null;
+    return toViewsHistoryEntries(product.viewsHistory);
+  }
+
+  /**
+   * Retrieves location history for a product, sorted newest first.
+   * @param id - The product _id.
+   * @returns History wrapper or null if product not found.
+   */
+  public async getLocationHistory(
+    id: string,
+  ): Promise<IHistoryWrapper<{ location: { state: string; municipality?: string }; updatedAt: string }> | null> {
+    const product = await this._repo.findOne({ _id: id });
+    if (!product) return null;
+    return toLocationHistoryEntries(product.locationHistory);
+  }
+
+  /**
+   * Retrieves outstanding history for a product, sorted newest first.
+   * @param id - The product _id.
+   * @returns History wrapper or null if product not found.
+   */
+  public async getOutstandingHistory(id: string): Promise<IHistoryWrapper<{ value: number; updatedAt: string }> | null> {
+    const product = await this._repo.findOne({ _id: id });
+    if (!product) return null;
+    return toOutstandingHistoryEntries(product.isOutstandingHistory);
+  }
+
+  /**
+   * Retrieves promoted history for a product, sorted newest first.
+   * @param id - The product _id.
+   * @returns History wrapper or null if product not found.
+   */
+  public async getPromotedHistory(id: string): Promise<IHistoryWrapper<{ value: number; updatedAt: string }> | null> {
+    const product = await this._repo.findOne({ _id: id });
+    if (!product) return null;
+    return toPromotedHistoryEntries(product.isPromotedHistory);
+  }
+
+  /**
+   * Returns aggregated statistics across all products.
+   * Uses multiple aggregation pipelines to gather: totalProducts, byCategory,
+   * byState, outstandingCount, promotedCount, lastScrapedAt, and priceRange.
+   * @returns Aggregated stats DTO.
+   */
+  public async getStats(): Promise<ProductStatsType> {
+    const [byCategory, byState, counts, meta] = await Promise.all([
+      this._repo.aggregate([{ $group: { _id: '$category', count: { $sum: 1 } } }]),
+      this._repo.aggregate([{ $group: { _id: '$location.state', count: { $sum: 1 } } }]),
+      this._repo.aggregate([
+        {
+          $group: {
+            _id: null,
+            total: { $sum: 1 },
+            outstanding: { $sum: { $cond: ['$isOutstanding', 1, 0] } },
+            promoted: { $sum: { $cond: ['$isPromoted', 1, 0] } },
+          },
+        },
+      ]),
+      this._repo.aggregate([
+        {
+          $group: {
+            _id: null,
+            lastScrapedAt: { $max: '$metadata.scrapedAt' },
+            minPrice: { $min: '$price' },
+            maxPrice: { $max: '$price' },
+          },
+        },
+      ]),
+    ]);
+
+    const countsRow = (counts as Array<Record<string, unknown>>)[0] ?? {};
+    const metaRow = (meta as Array<Record<string, unknown>>)[0] ?? {};
+
+    return {
+      totalProducts: (countsRow.total as number) ?? 0,
+      byCategory: (byCategory as Array<{ _id: string; count: number }>).filter(c => c._id).map(c => ({ category: c._id, count: c.count })),
+      byState: (byState as Array<{ _id: string; count: number }>).filter(s => s._id).map(s => ({ state: s._id, count: s.count })),
+      outstandingCount: (countsRow.outstanding as number) ?? 0,
+      promotedCount: (countsRow.promoted as number) ?? 0,
+      lastScrapedAt:
+        metaRow.lastScrapedAt instanceof Date
+          ? (metaRow.lastScrapedAt as Date).toISOString()
+          : metaRow.lastScrapedAt
+            ? String(metaRow.lastScrapedAt)
+            : null,
+      priceRange: {
+        min: (metaRow.minPrice as number) ?? 0,
+        max: (metaRow.maxPrice as number) ?? 0,
+      },
+    };
+  }
+
+  /**
+   * Deletes a product by its MongoDB _id.
+   * @param id - The product _id to delete.
+   */
+  public async delete(id: string): Promise<void> {
+    await this._repo.deleteById(id);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Builds a Mongoose filter from the query DTO.
+   * @param query - Validated list query.
+   * @returns A Mongoose root filter query.
+   */
+  private buildFilter(query: ProductListQueryDTO): RootFilterQuery<IRevolicoProduct> {
+    const filter: Record<string, unknown> = {};
+
+    if (query.search) {
+      filter.description = { $regex: query.search, $options: 'i' };
+    }
+    if (query.category) {
+      filter.category = query.category;
+    }
+    if (query.subcategory) {
+      filter.subcategory = query.subcategory;
+    }
+    if (query.minPrice !== undefined || query.maxPrice !== undefined) {
+      const priceFilter: Record<string, number> = {};
+      if (query.minPrice !== undefined) priceFilter.$gte = query.minPrice;
+      if (query.maxPrice !== undefined) priceFilter.$lte = query.maxPrice;
+      filter.price = priceFilter;
+    }
+    if (query.isOutstanding !== undefined) {
+      filter.isOutstanding = query.isOutstanding;
+    }
+    if (query.isPromoted !== undefined) {
+      filter.isPromoted = query.isPromoted;
+    }
+    if (query['location.state']) {
+      filter['location.state'] = query['location.state'];
+    }
+
+    return filter as RootFilterQuery<IRevolicoProduct>;
+  }
+}

--- a/src/main/admin/services/queue-admin.service.ts
+++ b/src/main/admin/services/queue-admin.service.ts
@@ -1,0 +1,140 @@
+import { injectable, inject } from 'inversify';
+import { Queue, Job } from 'bullmq';
+import { ILogger } from '@shared/logger.interface';
+import { TYPES } from '@shared/types.container';
+import { IQueueAdapterRegistry } from '@shared/queue/port/queue-adapter-registry.interfaces';
+import { QueueStatsDTO, JobDetailDTO } from '@admin/services/dto/queue-stats.dto';
+
+/**
+ * Service for admin-level queue introspection. Accesses BullMQ internals
+ * through the QueueAdapterRegistry's getDashboardQueues() — the same
+ * low-level IQueueAdapter port that QueueDashboardService uses for Bull-Board.
+ *
+ * For Mock and SQS backends, getDashboardQueues() returns an empty array,
+ * and all methods return empty responses with a warning log. This is an
+ * acknowledged leak in the queue abstraction.
+ */
+@injectable()
+export class QueueAdminService {
+  public constructor(
+    @inject(TYPES.QueueAdapterRegistry) private readonly _registry: IQueueAdapterRegistry,
+    @inject(TYPES.Logger) private readonly _log: ILogger,
+  ) {
+    this._log.context = QueueAdminService.name;
+  }
+
+  /**
+   * Returns job counts for every registered queue.
+   * @returns Array of QueueStatsDTO, one per queue.
+   */
+  public async getAllQueueStats(): Promise<QueueStatsDTO[]> {
+    const dashboardQueues = this._registry.getCurrent().getDashboardQueues();
+
+    if (dashboardQueues.length === 0) {
+      this._log.warn('getAllQueueStats: no dashboard queues available (non-BullMQ backend or no queues registered)');
+      return [];
+    }
+
+    const stats = await Promise.all(
+      dashboardQueues.map(async dq => {
+        const queue = dq.queue as Queue;
+        const counts = await queue.getJobCounts();
+        return QueueStatsDTO.from({ queueName: dq.name, counts });
+      }),
+    );
+
+    return stats;
+  }
+
+  /**
+   * Returns job counts for a specific queue by name.
+   * @param name - The queue name.
+   * @returns QueueStatsDTO or null if the queue is not found.
+   */
+  public async getQueueStats(name: string): Promise<QueueStatsDTO | null> {
+    const dashboardQueues = this._registry.getCurrent().getDashboardQueues();
+    const found = dashboardQueues.find(dq => dq.name === name);
+
+    if (!found) {
+      this._log.warn(`Queue "${name}" not found`);
+      return null;
+    }
+
+    const queue = found.queue as Queue;
+    const counts = await queue.getJobCounts();
+    return QueueStatsDTO.from({ queueName: name, counts });
+  }
+
+  /**
+   * Returns recent jobs for a specific queue.
+   * @param name - The queue name.
+   * @param limit - Max number of jobs to return (default 20).
+   * @param status - Filter by job status ('completed', 'failed', 'active', 'waiting', 'delayed', etc.). When omitted, returns all.
+   * @returns Array of JobDetailDTO.
+   */
+  public async getRecentJobs(name: string, limit: number = 20, status?: string): Promise<JobDetailDTO[]> {
+    const dashboardQueues = this._registry.getCurrent().getDashboardQueues();
+    const found = dashboardQueues.find(dq => dq.name === name);
+
+    if (!found) {
+      this._log.warn(`Queue "${name}" not found`);
+      return [];
+    }
+
+    const queue = found.queue as Queue;
+    const types = status ? [status as any] : undefined;
+    const jobs: Job[] = await queue.getJobs(types, 0, limit - 1, false);
+
+    return jobs.map(job => this.jobToDTO(job));
+  }
+
+  /**
+   * Returns full detail for a single job.
+   * @param name - The queue name.
+   * @param jobId - The job ID.
+   * @returns JobDetailDTO or null if the queue or job is not found.
+   */
+  public async getJobDetail(name: string, jobId: string): Promise<JobDetailDTO | null> {
+    const dashboardQueues = this._registry.getCurrent().getDashboardQueues();
+    const found = dashboardQueues.find(dq => dq.name === name);
+
+    if (!found) {
+      this._log.warn(`Queue "${name}" not found`);
+      return null;
+    }
+
+    const queue = found.queue as Queue;
+    const job: Job | undefined = await queue.getJob(jobId);
+
+    if (!job) {
+      return null;
+    }
+
+    return this.jobToDTO(job);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Converts a BullMQ Job into a JobDetailDTO.
+   * @param job - The BullMQ Job instance.
+   * @returns A JobDetailDTO.
+   */
+  private jobToDTO(job: Job): JobDetailDTO {
+    return JobDetailDTO.from({
+      id: job.id ?? '',
+      name: job.name,
+      data: job.data as unknown | undefined,
+      progress: job.progress as number | object | undefined,
+      attemptsMade: job.attemptsMade,
+      failedReason: job.failedReason ?? undefined,
+      timestamp: job.timestamp ?? undefined,
+      processedOn: job.processedOn ?? null,
+      finishedOn: job.finishedOn ?? null,
+      returnValue: (job as any).returnvalue ?? undefined,
+      status: (job as any)._status ?? undefined,
+    });
+  }
+}

--- a/src/main/admin/services/role.service.ts
+++ b/src/main/admin/services/role.service.ts
@@ -1,0 +1,73 @@
+import { inject, injectable } from 'inversify';
+import { PrismaClient } from '@prisma/client';
+import { ILogger } from '@shared/logger.interface';
+import { TYPES } from '@shared/types.container';
+
+@injectable()
+export class RoleService {
+  public constructor(
+    @inject(TYPES.PrismaClient) private readonly _prisma: PrismaClient,
+    @inject(TYPES.Logger) private readonly _log: ILogger,
+  ) {
+    this._log.context = RoleService.name;
+  }
+
+  /**
+   * Returns all roles with their user count.
+   * @returns Array of roles with _count.users.
+   */
+  public async getAll(): Promise<Array<{ id: string; name: string; accountId: string | null; _count: { users: number } }>> {
+    this._log.debug('Fetching all roles');
+    return this._prisma.role.findMany({
+      include: { _count: { select: { users: true } } },
+    });
+  }
+
+  /**
+   * Creates a new role.
+   * @param name - The role name.
+   * @param accountId - Optional account ID to scope the role.
+   * @returns The created role.
+   */
+  public async create(name: string, accountId?: string): Promise<{ id: string; name: string; accountId: string | null }> {
+    this._log.debug('Creating role', { name, accountId });
+    return this._prisma.role.create({
+      data: { name, accountId: accountId ?? null },
+    });
+  }
+
+  /**
+   * Deletes a role by ID.
+   * @param id - The role ID.
+   */
+  public async delete(id: string): Promise<void> {
+    this._log.debug('Deleting role', { id });
+    await this._prisma.role.delete({ where: { id } });
+  }
+
+  /**
+   * Assigns a role to a user.
+   * @param userId - The user ID.
+   * @param roleId - The role ID to assign.
+   */
+  public async assignRole(userId: string, roleId: string): Promise<void> {
+    this._log.debug('Assigning role to user', { userId, roleId });
+    await this._prisma.user.update({
+      where: { id: userId },
+      data: { roles: { connect: { id: roleId } } },
+    });
+  }
+
+  /**
+   * Unassigns a role from a user.
+   * @param userId - The user ID.
+   * @param roleId - The role ID to remove.
+   */
+  public async unassignRole(userId: string, roleId: string): Promise<void> {
+    this._log.debug('Unassigning role from user', { userId, roleId });
+    await this._prisma.user.update({
+      where: { id: userId },
+      data: { roles: { disconnect: { id: roleId } } },
+    });
+  }
+}

--- a/src/main/docs/modules/admin.paths.ts
+++ b/src/main/docs/modules/admin.paths.ts
@@ -5,6 +5,7 @@ import { TAG } from '../tags';
 import { Schemas } from '../schema-registry';
 
 export function registerAdminPaths(registry: OpenAPIRegistry): void {
+  // ── Admin Users (existing) ────────────────────────────────────────────
   endpoint('get', '/api/admin/users')
     .tag(TAG.ADMIN)
     .summary('List all users (admin)')
@@ -22,5 +23,249 @@ export function registerAdminPaths(registry: OpenAPIRegistry): void {
     .pathParam('id', 'User ID')
     .response204('User deleted')
     .errors(401, 403, 404)
+    .register(registry);
+
+  // ── Admin Products ─────────────────────────────────────────────────────
+  endpoint('get', '/api/admin/products')
+    .tag(TAG.ADMIN_PRODUCTS)
+    .summary('List products with pagination and filtering')
+    .operationId('adminListProducts')
+    .security('bearerAuth')
+    .response(200, 'Paginated list of products', Schemas.PaginatedResponse)
+    .errors(401, 403)
+    .register(registry);
+
+  endpoint('get', '/api/admin/products/stats')
+    .tag(TAG.ADMIN_PRODUCTS)
+    .summary('Get product statistics')
+    .operationId('adminGetProductStats')
+    .security('bearerAuth')
+    .response(200, 'Product statistics', Schemas.ProductStatsDTO)
+    .errors(401, 403)
+    .register(registry);
+
+  endpoint('get', '/api/admin/products/{id}')
+    .tag(TAG.ADMIN_PRODUCTS)
+    .summary('Get product detail by ID')
+    .operationId('adminGetProductById')
+    .security('bearerAuth')
+    .pathParamString('id', 'Product MongoDB ID', '^[a-f0-9]{24}$')
+    .response(200, 'Product detail', Schemas.ProductDetailDTO)
+    .errors(401, 403, 404)
+    .register(registry);
+
+  // Product history endpoints (price, views, location, outstanding, promoted)
+  endpoint('get', '/api/admin/products/{id}/history/price')
+    .tag(TAG.ADMIN_PRODUCTS)
+    .summary('Get price history for a product')
+    .operationId('adminGetProductPriceHistory')
+    .security('bearerAuth')
+    .pathParamString('id', 'Product MongoDB ID', '^[a-f0-9]{24}$')
+    .response(200, 'Price history entries', Schemas.ProductPriceHistoryDTO)
+    .errors(401, 403, 404)
+    .register(registry);
+
+  endpoint('get', '/api/admin/products/{id}/history/views')
+    .tag(TAG.ADMIN_PRODUCTS)
+    .summary('Get views history for a product')
+    .operationId('adminGetProductViewsHistory')
+    .security('bearerAuth')
+    .pathParamString('id', 'Product MongoDB ID', '^[a-f0-9]{24}$')
+    .response(200, 'Views history entries', Schemas.ProductPriceHistoryDTO)
+    .errors(401, 403, 404)
+    .register(registry);
+
+  endpoint('get', '/api/admin/products/{id}/history/location')
+    .tag(TAG.ADMIN_PRODUCTS)
+    .summary('Get location history for a product')
+    .operationId('adminGetProductLocationHistory')
+    .security('bearerAuth')
+    .pathParamString('id', 'Product MongoDB ID', '^[a-f0-9]{24}$')
+    .response(200, 'Location history entries', Schemas.ProductPriceHistoryDTO)
+    .errors(401, 403, 404)
+    .register(registry);
+
+  endpoint('get', '/api/admin/products/{id}/history/outstanding')
+    .tag(TAG.ADMIN_PRODUCTS)
+    .summary('Get outstanding status history for a product')
+    .operationId('adminGetProductOutstandingHistory')
+    .security('bearerAuth')
+    .pathParamString('id', 'Product MongoDB ID', '^[a-f0-9]{24}$')
+    .response(200, 'Outstanding history entries', Schemas.ProductPriceHistoryDTO)
+    .errors(401, 403, 404)
+    .register(registry);
+
+  endpoint('get', '/api/admin/products/{id}/history/promoted')
+    .tag(TAG.ADMIN_PRODUCTS)
+    .summary('Get promoted status history for a product')
+    .operationId('adminGetProductPromotedHistory')
+    .security('bearerAuth')
+    .pathParamString('id', 'Product MongoDB ID', '^[a-f0-9]{24}$')
+    .response(200, 'Promoted history entries', Schemas.ProductPriceHistoryDTO)
+    .errors(401, 403, 404)
+    .register(registry);
+
+  endpoint('delete', '/api/admin/products/{id}')
+    .tag(TAG.ADMIN_PRODUCTS)
+    .summary('Delete a product by ID')
+    .operationId('adminDeleteProduct')
+    .security('bearerAuth')
+    .pathParamString('id', 'Product MongoDB ID', '^[a-f0-9]{24}$')
+    .response204('Product deleted')
+    .errors(401, 403, 404)
+    .register(registry);
+
+  // ── Admin Queues ──────────────────────────────────────────────────────
+  endpoint('get', '/api/admin/queues/stats')
+    .tag(TAG.ADMIN_QUEUES)
+    .summary('Get job counts for all queues')
+    .operationId('adminGetAllQueueStats')
+    .security('bearerAuth')
+    .response(200, 'All queue statistics', z.object({ queues: z.array(Schemas.QueueStatsDTO) }))
+    .errors(401, 403)
+    .register(registry);
+
+  endpoint('get', '/api/admin/queues/{name}/stats')
+    .tag(TAG.ADMIN_QUEUES)
+    .summary('Get job counts for a single queue')
+    .operationId('adminGetQueueStats')
+    .security('bearerAuth')
+    .pathParamString('name', 'Queue name (e.g. scraping, notification)')
+    .response(200, 'Queue statistics', Schemas.QueueStatsDTO)
+    .errors(401, 403, 404)
+    .register(registry);
+
+  endpoint('get', '/api/admin/queues/{name}/jobs')
+    .tag(TAG.ADMIN_QUEUES)
+    .summary('Get recent jobs for a queue')
+    .operationId('adminGetRecentJobs')
+    .security('bearerAuth')
+    .pathParamString('name', 'Queue name (e.g. scraping, notification)')
+    .response(200, 'Recent jobs', z.object({ jobs: z.array(Schemas.JobDetailDTO) }))
+    .errors(401, 403)
+    .register(registry);
+
+  endpoint('get', '/api/admin/queues/{name}/jobs/{id}')
+    .tag(TAG.ADMIN_QUEUES)
+    .summary('Get full detail for a single job')
+    .operationId('adminGetJobDetail')
+    .security('bearerAuth')
+    .pathParamString('name', 'Queue name (e.g. scraping, notification)')
+    .pathParamString('id', 'Job ID')
+    .response(200, 'Job detail', Schemas.JobDetailDTO)
+    .errors(401, 403, 404)
+    .register(registry);
+
+  // ── Admin Dashboard ───────────────────────────────────────────────────
+  endpoint('get', '/api/admin/dashboard')
+    .tag(TAG.ADMIN_DASHBOARD)
+    .summary('Get dashboard metrics')
+    .operationId('adminGetDashboardMetrics')
+    .security('bearerAuth')
+    .response(200, 'Dashboard metrics', Schemas.DashboardMetricsDTO)
+    .errors(401, 403)
+    .register(registry);
+
+  endpoint('get', '/api/admin/dashboard/health')
+    .tag(TAG.ADMIN_DASHBOARD)
+    .summary('Get backend health status')
+    .operationId('adminGetHealth')
+    .security('bearerAuth')
+    .response(200, 'Health status', Schemas.HealthResponseDTO)
+    .errors(401, 403)
+    .register(registry);
+
+  // ── Admin Accounts ────────────────────────────────────────────────────
+  endpoint('get', '/api/admin/accounts')
+    .tag(TAG.ADMIN_ACCOUNTS)
+    .summary('List all accounts with pagination')
+    .operationId('adminListAccounts')
+    .security('bearerAuth')
+    .response(200, 'Paginated list of accounts', Schemas.PaginatedResponse)
+    .errors(401, 403)
+    .register(registry);
+
+  endpoint('get', '/api/admin/accounts/{id}')
+    .tag(TAG.ADMIN_ACCOUNTS)
+    .summary('Get account detail by ID')
+    .operationId('adminGetAccountById')
+    .security('bearerAuth')
+    .pathParam('id', 'Account ID')
+    .response(200, 'Account detail', z.object({ account: Schemas.AccountDTO }))
+    .errors(401, 403, 404)
+    .register(registry);
+
+  endpoint('put', '/api/admin/accounts/{id}')
+    .tag(TAG.ADMIN_ACCOUNTS)
+    .summary('Update an account by ID')
+    .operationId('adminUpdateAccount')
+    .security('bearerAuth')
+    .pathParam('id', 'Account ID')
+    .requestBody(z.object({ name: z.string().optional(), settings: z.record(z.unknown()).optional() }), 'Account update data')
+    .response(200, 'Account updated', z.object({ account: Schemas.AccountDTO }))
+    .errors(400, 401, 403, 404)
+    .register(registry);
+
+  endpoint('delete', '/api/admin/accounts/{id}')
+    .tag(TAG.ADMIN_ACCOUNTS)
+    .summary('Delete an account by ID')
+    .operationId('adminDeleteAccount')
+    .security('bearerAuth')
+    .pathParam('id', 'Account ID')
+    .response204('Account deleted')
+    .errors(401, 403, 404)
+    .register(registry);
+
+  // ── Admin Roles ───────────────────────────────────────────────────────
+  endpoint('get', '/api/admin/roles')
+    .tag(TAG.ADMIN_ROLES)
+    .summary('List all roles with user counts')
+    .operationId('adminListRoles')
+    .security('bearerAuth')
+    .response(200, 'List of roles', z.object({ roles: z.array(Schemas.RoleResponseDTO) }))
+    .errors(401, 403)
+    .register(registry);
+
+  endpoint('post', '/api/admin/roles')
+    .tag(TAG.ADMIN_ROLES)
+    .summary('Create a new role')
+    .operationId('adminCreateRole')
+    .security('bearerAuth')
+    .requestBody(Schemas.CreateRoleDTO, 'Role creation data')
+    .response(201, 'Role created', Schemas.RoleResponseDTO)
+    .errors(400, 401, 403)
+    .register(registry);
+
+  endpoint('delete', '/api/admin/roles/{id}')
+    .tag(TAG.ADMIN_ROLES)
+    .summary('Delete a role by ID')
+    .operationId('adminDeleteRole')
+    .security('bearerAuth')
+    .pathParam('id', 'Role ID')
+    .response204('Role deleted')
+    .errors(401, 403, 404)
+    .register(registry);
+
+  // ── Admin User-Role Management ────────────────────────────────────────
+  endpoint('post', '/api/admin/users/{userId}/roles/{roleId}')
+    .tag(TAG.ADMIN_ROLES)
+    .summary('Assign a role to a user')
+    .operationId('adminAssignRoleToUser')
+    .security('bearerAuth')
+    .pathParam('userId', 'User ID')
+    .pathParam('roleId', 'Role ID')
+    .response(200, 'Role assigned', z.object({ message: z.string() }))
+    .errors(400, 401, 403, 404)
+    .register(registry);
+
+  endpoint('delete', '/api/admin/users/{userId}/roles/{roleId}')
+    .tag(TAG.ADMIN_ROLES)
+    .summary('Unassign a role from a user')
+    .operationId('adminUnassignRoleFromUser')
+    .security('bearerAuth')
+    .pathParam('userId', 'User ID')
+    .pathParam('roleId', 'Role ID')
+    .response(200, 'Role unassigned', z.object({ message: z.string() }))
+    .errors(400, 401, 403, 404)
     .register(registry);
 }

--- a/src/main/docs/schema-registry.ts
+++ b/src/main/docs/schema-registry.ts
@@ -26,6 +26,18 @@ import { UpdateAlarmSchema } from '@alarms/dto/update-alarm.dto';
 import { GenerateLinkCodeSchema } from '@bots/services/dto/generate-link-code.dto';
 import { ConfirmLinkSchema } from '@bots/services/dto/confirm-link.dto';
 import { LinkHistoryQuerySchema } from '@bots/services/dto/link-history.dto';
+// Admin DTOs
+import {
+  ProductListItemSchema,
+  ProductDetailSchema,
+  PriceHistoryEntrySchema,
+  ProductHistorySchema,
+  ProductStatsSchema,
+} from '@admin/services/dto/product-response.dto';
+import { ProductListQuerySchema } from '@admin/services/dto/product-list-query.dto';
+import { DashboardMetricsSchema, HealthResponseSchema } from '@admin/services/dto/dashboard-metrics.dto';
+import { QueueStatsSchema, JobDetailSchema } from '@admin/services/dto/queue-stats.dto';
+import { CreateRoleSchema, RoleResponseSchema } from '@admin/services/dto/role.dto';
 
 // ── Companion schemas for DTOs without Zod ───────────────────────────
 const AlarmResponseSchema = z.object({
@@ -163,4 +175,30 @@ export function registerAllSchemas(registry: OpenAPIRegistry): void {
   Schemas.GenerateLinkCodeResponseDTO = registry.register('GenerateLinkCodeResponseDTO', GenerateLinkCodeResponseSchema);
   Schemas.LinkStatusResponseDTO = registry.register('LinkStatusResponseDTO', LinkStatusResponseSchema);
   Schemas.LinkHistoryEntryDTO = registry.register('LinkHistoryEntryDTO', LinkHistoryEntrySchema);
+
+  // Admin DTOs
+  const ProductPriceHistoryDTO = ProductHistorySchema(PriceHistoryEntrySchema);
+  Schemas.PaginatedResponse = registry.register(
+    'PaginatedResponse',
+    z.object({
+      data: z.array(z.object({}).passthrough()).openapi({ description: 'Array of items for the current page' }),
+      meta: z.object({
+        total: z.number().openapi({ description: 'Total number of items matching the query' }),
+        skip: z.number().openapi({ description: 'Number of items skipped' }),
+        limit: z.number().openapi({ description: 'Max items per page' }),
+        hasMore: z.boolean().openapi({ description: 'Whether additional pages are available' }),
+      }),
+    }),
+  );
+  Schemas.ProductListItemDTO = registry.register('ProductListItemDTO', ProductListItemSchema);
+  Schemas.ProductDetailDTO = registry.register('ProductDetailDTO', ProductDetailSchema);
+  Schemas.ProductPriceHistoryDTO = registry.register('ProductPriceHistoryDTO', ProductPriceHistoryDTO);
+  Schemas.ProductListQueryDTO = registry.register('ProductListQueryDTO', ProductListQuerySchema);
+  Schemas.ProductStatsDTO = registry.register('ProductStatsDTO', ProductStatsSchema);
+  Schemas.DashboardMetricsDTO = registry.register('DashboardMetricsDTO', DashboardMetricsSchema);
+  Schemas.HealthResponseDTO = registry.register('HealthResponseDTO', HealthResponseSchema);
+  Schemas.QueueStatsDTO = registry.register('QueueStatsDTO', QueueStatsSchema);
+  Schemas.JobDetailDTO = registry.register('JobDetailDTO', JobDetailSchema);
+  Schemas.CreateRoleDTO = registry.register('CreateRoleDTO', CreateRoleSchema);
+  Schemas.RoleResponseDTO = registry.register('RoleResponseDTO', RoleResponseSchema);
 }

--- a/src/main/docs/tags.ts
+++ b/src/main/docs/tags.ts
@@ -9,6 +9,12 @@ export const TAG = {
   SCRAPING: 'Scraping',
   ADMIN: 'Admin',
   BOTS: 'Bots',
+  // Admin subgroup tags
+  ADMIN_PRODUCTS: 'Admin - Products',
+  ADMIN_DASHBOARD: 'Admin - Dashboard',
+  ADMIN_QUEUES: 'Admin - Queues',
+  ADMIN_ACCOUNTS: 'Admin - Accounts',
+  ADMIN_ROLES: 'Admin - Roles',
 } as const;
 
 export const API_TAGS = [
@@ -22,4 +28,9 @@ export const API_TAGS = [
   { name: TAG.SCRAPING, description: 'Product scraping job management' },
   { name: TAG.ADMIN, description: 'Super-admin endpoints' },
   { name: TAG.BOTS, description: 'WhatsApp / Telegram bot account linking' },
+  { name: TAG.ADMIN_PRODUCTS, description: 'Admin product management' },
+  { name: TAG.ADMIN_DASHBOARD, description: 'Admin dashboard and health checks' },
+  { name: TAG.ADMIN_QUEUES, description: 'Admin queue introspection' },
+  { name: TAG.ADMIN_ACCOUNTS, description: 'Admin account management' },
+  { name: TAG.ADMIN_ROLES, description: 'Admin role management' },
 ];

--- a/src/main/scrapers/revolico/repositories/product.repository.ts
+++ b/src/main/scrapers/revolico/repositories/product.repository.ts
@@ -1,7 +1,7 @@
 import { DBContext } from '@config/db-config';
 import { inject, injectable } from 'inversify';
 import productModel, { IRevolicoProduct } from '../models/product.model';
-import { Model, RootFilterQuery } from 'mongoose';
+import { Model, RootFilterQuery, PipelineStage } from 'mongoose';
 import { DeleteResult } from 'mongodb';
 
 export interface ICustomInsertManyResult {
@@ -93,6 +93,24 @@ export class ProductRepository {
   }
 
   /**
+   * Deletes a single product by its MongoDB _id.
+   * @param _id - The MongoDB ObjectId of the product to delete.
+   * @returns The delete result.
+   */
+  public async deleteById(_id: string): Promise<DeleteResult> {
+    return this._model.deleteOne({ _id });
+  }
+
+  /**
+   * Runs a MongoDB aggregation pipeline.
+   * @param pipeline - The aggregation pipeline stages.
+   * @returns The aggregation result.
+   */
+  public async aggregate(pipeline: PipelineStage[]): Promise<unknown[]> {
+    return this._model.aggregate(pipeline).exec();
+  }
+
+  /**
    * Inserts or updates a single product in the database.
    * @param {IRevolicoProduct} product - The product to be inserted or updated.
    * @param {keyof IRevolicoProduct[]} filterFields - The fields to use as filter. Defaults to ['ID'].
@@ -125,6 +143,10 @@ export class ProductRepository {
         location: product.location,
         views: product.views,
         seller: product.seller,
+        metadata: product.metadata,
+        tags: product.tags,
+        attributes: product.attributes,
+        analytics: product.analytics,
       },
       $push: {
         ...(product.price ? { priceHistory: { value: product.price, updatedAt: new Date() } } : {}),

--- a/src/main/scrapers/revolico/repositories/product.repository.ts
+++ b/src/main/scrapers/revolico/repositories/product.repository.ts
@@ -143,10 +143,6 @@ export class ProductRepository {
         location: product.location,
         views: product.views,
         seller: product.seller,
-        metadata: product.metadata,
-        tags: product.tags,
-        attributes: product.attributes,
-        analytics: product.analytics,
       },
       $push: {
         ...(product.price ? { priceHistory: { value: product.price, updatedAt: new Date() } } : {}),

--- a/src/main/shared/container.ts
+++ b/src/main/shared/container.ts
@@ -49,6 +49,10 @@ import { AccountRepository } from '@users/repositories/account.repository';
 import { AdminController } from '@admin/controllers/admin.controller';
 import { ProductAdminController } from '@admin/controllers/product-admin.controller';
 import { ProductAdminService } from '@admin/services/product-admin.service';
+import { QueueAdminController } from '@admin/controllers/queue-admin.controller';
+import { QueueAdminService } from '@admin/services/queue-admin.service';
+import { DashboardController } from '@admin/controllers/dashboard.controller';
+import { DashboardService } from '@admin/services/dashboard.service';
 import { AlarmController } from '@alarms/controllers/alarm.controller';
 import { NotificationController } from '@alarms/controllers/notification.controller';
 import { AlarmService } from '@alarms/services/alarm.service';
@@ -74,7 +78,6 @@ import { GenericListingScraperService } from '@scrapers/revolico/services/scrapi
 import { GenericDetailScraperService } from '@scrapers/revolico/services/scraping/generic-detail-scraper.service';
 import { AnalyticsService } from '@scrapers/revolico/services/analytics.service';
 import { RuleBasedExtractorService } from '@scrapers/revolico/services/attribute-extractor/rule-based-extractor.service';
-import { LLMExtractorService } from '@scrapers/revolico/services/attribute-extractor/llm-extractor.service';
 import { AttributeExtractorService } from '@scrapers/revolico/services/attribute-extractor/attribute-extractor.service';
 // Bots (WhatsApp / Telegram)
 import { BotService } from '@bots/services/bot.service';
@@ -155,10 +158,14 @@ container.bind(TYPES.ProductMapper).to(ProductMapper);
 
 //services
 container.bind<ProductAdminService>(TYPES.ProductAdminService).to(ProductAdminService);
+container.bind<QueueAdminService>(TYPES.QueueAdminService).to(QueueAdminService);
+container.bind<DashboardService>(TYPES.DashboardService).to(DashboardService);
 
 //controllers
 container.bind<AdminController>(TYPES.AdminController).to(AdminController);
 container.bind<ProductAdminController>(TYPES.ProductAdminController).to(ProductAdminController);
+container.bind<QueueAdminController>(TYPES.QueueAdminController).to(QueueAdminController);
+container.bind<DashboardController>(TYPES.DashboardController).to(DashboardController);
 container.bind<ScrapingController>(TYPES.RevolicoScraping).to(ScrapingController);
 container.bind<ScraperConfigController>(TYPES.ScraperConfigController).to(ScraperConfigController);
 container.bind<UserController>(TYPES.UserController).to(UserController);
@@ -189,7 +196,6 @@ container.bind<GenericListingScraperService>(TYPES.GenericListingScraper).to(Gen
 container.bind<GenericDetailScraperService>(TYPES.GenericDetailScraper).to(GenericDetailScraperService).inSingletonScope();
 container.bind<AnalyticsService>(TYPES.AnalyticsService).to(AnalyticsService).inSingletonScope();
 container.bind<RuleBasedExtractorService>(RuleBasedExtractorService).to(RuleBasedExtractorService).inSingletonScope();
-container.bind<LLMExtractorService>(LLMExtractorService).to(LLMExtractorService).inSingletonScope();
 container.bind<AttributeExtractorService>(AttributeExtractorService).to(AttributeExtractorService).inSingletonScope();
 
 //middlewares

--- a/src/main/shared/container.ts
+++ b/src/main/shared/container.ts
@@ -46,6 +46,7 @@ import { TokenService } from './security/token.service';
 import { UserIdentityRepository } from '@users/repositories/user-identity.repository';
 import { ProviderTokenVerifier } from '@shared/security/provider-token-verifier';
 import { AccountRepository } from '@users/repositories/account.repository';
+import { AdminController } from '@admin/controllers/admin.controller';
 import { AlarmController } from '@alarms/controllers/alarm.controller';
 import { NotificationController } from '@alarms/controllers/notification.controller';
 import { AlarmService } from '@alarms/services/alarm.service';
@@ -145,6 +146,7 @@ container.bind(TYPES.AlarmMapper).to(AlarmMapper);
 container.bind(TYPES.NotificationMapper).to(NotificationMapper);
 
 //controllers
+container.bind<AdminController>(TYPES.AdminController).to(AdminController);
 container.bind<ScrapingController>(TYPES.RevolicoScraping).to(ScrapingController);
 container.bind<ScraperConfigController>(TYPES.ScraperConfigController).to(ScraperConfigController);
 container.bind<UserController>(TYPES.UserController).to(UserController);

--- a/src/main/shared/container.ts
+++ b/src/main/shared/container.ts
@@ -47,6 +47,8 @@ import { UserIdentityRepository } from '@users/repositories/user-identity.reposi
 import { ProviderTokenVerifier } from '@shared/security/provider-token-verifier';
 import { AccountRepository } from '@users/repositories/account.repository';
 import { AdminController } from '@admin/controllers/admin.controller';
+import { ProductAdminController } from '@admin/controllers/product-admin.controller';
+import { ProductAdminService } from '@admin/services/product-admin.service';
 import { AlarmController } from '@alarms/controllers/alarm.controller';
 import { NotificationController } from '@alarms/controllers/notification.controller';
 import { AlarmService } from '@alarms/services/alarm.service';
@@ -56,6 +58,7 @@ import { AlarmRepository } from '@alarms/repositories/alarm.repository';
 import { NotificationRepository } from '@alarms/repositories/notification.repository';
 import { AlarmMapper } from '@alarms/mappers/alarm.mapper';
 import { NotificationMapper } from '@alarms/mappers/notification.mapper';
+import { ProductMapper } from '@admin/mappers/product.mapper';
 import { ConditionRegistry } from '@alarms/conditions/condition-registry';
 import { PriceDropsBelowCondition } from '@alarms/conditions/price-drops-below.condition';
 import { PriceRisesAboveCondition } from '@alarms/conditions/price-rises-above.condition';
@@ -69,6 +72,10 @@ import { ScraperConfigRegistryService } from '@scrapers/revolico/services/scrapi
 import { ScraperConfigService } from '@scrapers/revolico/services/scraping/scraper-config.service';
 import { GenericListingScraperService } from '@scrapers/revolico/services/scraping/generic-listing-scraper.service';
 import { GenericDetailScraperService } from '@scrapers/revolico/services/scraping/generic-detail-scraper.service';
+import { AnalyticsService } from '@scrapers/revolico/services/analytics.service';
+import { RuleBasedExtractorService } from '@scrapers/revolico/services/attribute-extractor/rule-based-extractor.service';
+import { LLMExtractorService } from '@scrapers/revolico/services/attribute-extractor/llm-extractor.service';
+import { AttributeExtractorService } from '@scrapers/revolico/services/attribute-extractor/attribute-extractor.service';
 // Bots (WhatsApp / Telegram)
 import { BotService } from '@bots/services/bot.service';
 import { BotController } from '@bots/controllers/bot.controller';
@@ -144,9 +151,14 @@ container.bind(TYPES.SubscriptionsMapper).to(SubscriptionsMapper);
 container.bind(TYPES.PlanMapper).to(PlanMapper);
 container.bind(TYPES.AlarmMapper).to(AlarmMapper);
 container.bind(TYPES.NotificationMapper).to(NotificationMapper);
+container.bind(TYPES.ProductMapper).to(ProductMapper);
+
+//services
+container.bind<ProductAdminService>(TYPES.ProductAdminService).to(ProductAdminService);
 
 //controllers
 container.bind<AdminController>(TYPES.AdminController).to(AdminController);
+container.bind<ProductAdminController>(TYPES.ProductAdminController).to(ProductAdminController);
 container.bind<ScrapingController>(TYPES.RevolicoScraping).to(ScrapingController);
 container.bind<ScraperConfigController>(TYPES.ScraperConfigController).to(ScraperConfigController);
 container.bind<UserController>(TYPES.UserController).to(UserController);
@@ -175,6 +187,10 @@ container.bind<ScraperConfigRegistryService>(TYPES.ScraperConfigRegistry).to(Scr
 container.bind<ScraperConfigService>(TYPES.ScraperConfigService).to(ScraperConfigService).inSingletonScope();
 container.bind<GenericListingScraperService>(TYPES.GenericListingScraper).to(GenericListingScraperService).inSingletonScope();
 container.bind<GenericDetailScraperService>(TYPES.GenericDetailScraper).to(GenericDetailScraperService).inSingletonScope();
+container.bind<AnalyticsService>(TYPES.AnalyticsService).to(AnalyticsService).inSingletonScope();
+container.bind<RuleBasedExtractorService>(RuleBasedExtractorService).to(RuleBasedExtractorService).inSingletonScope();
+container.bind<LLMExtractorService>(LLMExtractorService).to(LLMExtractorService).inSingletonScope();
+container.bind<AttributeExtractorService>(AttributeExtractorService).to(AttributeExtractorService).inSingletonScope();
 
 //middlewares
 container.bind<AuthMiddleware>(TYPES.AuthMiddleware).to(AuthMiddleware);

--- a/src/main/shared/container.ts
+++ b/src/main/shared/container.ts
@@ -53,6 +53,10 @@ import { QueueAdminController } from '@admin/controllers/queue-admin.controller'
 import { QueueAdminService } from '@admin/services/queue-admin.service';
 import { DashboardController } from '@admin/controllers/dashboard.controller';
 import { DashboardService } from '@admin/services/dashboard.service';
+import { AccountAdminService } from '@admin/services/account-admin.service';
+import { RoleService } from '@admin/services/role.service';
+import { AccountAdminController } from '@admin/controllers/account-admin.controller';
+import { RoleController } from '@admin/controllers/role.controller';
 import { AlarmController } from '@alarms/controllers/alarm.controller';
 import { NotificationController } from '@alarms/controllers/notification.controller';
 import { AlarmService } from '@alarms/services/alarm.service';
@@ -160,12 +164,16 @@ container.bind(TYPES.ProductMapper).to(ProductMapper);
 container.bind<ProductAdminService>(TYPES.ProductAdminService).to(ProductAdminService);
 container.bind<QueueAdminService>(TYPES.QueueAdminService).to(QueueAdminService);
 container.bind<DashboardService>(TYPES.DashboardService).to(DashboardService);
+container.bind<AccountAdminService>(TYPES.AccountAdminService).to(AccountAdminService);
+container.bind<RoleService>(TYPES.RoleService).to(RoleService);
 
 //controllers
 container.bind<AdminController>(TYPES.AdminController).to(AdminController);
 container.bind<ProductAdminController>(TYPES.ProductAdminController).to(ProductAdminController);
 container.bind<QueueAdminController>(TYPES.QueueAdminController).to(QueueAdminController);
 container.bind<DashboardController>(TYPES.DashboardController).to(DashboardController);
+container.bind<AccountAdminController>(TYPES.AccountAdminController).to(AccountAdminController);
+container.bind<RoleController>(TYPES.RoleController).to(RoleController);
 container.bind<ScrapingController>(TYPES.RevolicoScraping).to(ScrapingController);
 container.bind<ScraperConfigController>(TYPES.ScraperConfigController).to(ScraperConfigController);
 container.bind<UserController>(TYPES.UserController).to(UserController);

--- a/src/main/shared/container.ts
+++ b/src/main/shared/container.ts
@@ -80,9 +80,6 @@ import { ScraperConfigRegistryService } from '@scrapers/revolico/services/scrapi
 import { ScraperConfigService } from '@scrapers/revolico/services/scraping/scraper-config.service';
 import { GenericListingScraperService } from '@scrapers/revolico/services/scraping/generic-listing-scraper.service';
 import { GenericDetailScraperService } from '@scrapers/revolico/services/scraping/generic-detail-scraper.service';
-import { AnalyticsService } from '@scrapers/revolico/services/analytics.service';
-import { RuleBasedExtractorService } from '@scrapers/revolico/services/attribute-extractor/rule-based-extractor.service';
-import { AttributeExtractorService } from '@scrapers/revolico/services/attribute-extractor/attribute-extractor.service';
 // Bots (WhatsApp / Telegram)
 import { BotService } from '@bots/services/bot.service';
 import { BotController } from '@bots/controllers/bot.controller';
@@ -202,9 +199,6 @@ container.bind<ScraperConfigRegistryService>(TYPES.ScraperConfigRegistry).to(Scr
 container.bind<ScraperConfigService>(TYPES.ScraperConfigService).to(ScraperConfigService).inSingletonScope();
 container.bind<GenericListingScraperService>(TYPES.GenericListingScraper).to(GenericListingScraperService).inSingletonScope();
 container.bind<GenericDetailScraperService>(TYPES.GenericDetailScraper).to(GenericDetailScraperService).inSingletonScope();
-container.bind<AnalyticsService>(TYPES.AnalyticsService).to(AnalyticsService).inSingletonScope();
-container.bind<RuleBasedExtractorService>(RuleBasedExtractorService).to(RuleBasedExtractorService).inSingletonScope();
-container.bind<AttributeExtractorService>(AttributeExtractorService).to(AttributeExtractorService).inSingletonScope();
 
 //middlewares
 container.bind<AuthMiddleware>(TYPES.AuthMiddleware).to(AuthMiddleware);

--- a/src/main/shared/types.container.ts
+++ b/src/main/shared/types.container.ts
@@ -76,4 +76,17 @@ export const TYPES = {
   ScraperConfigController: Symbol.for('ScraperConfigController'),
   GenericListingScraper: Symbol.for('GenericListingScraper'),
   GenericDetailScraper: Symbol.for('GenericDetailScraper'),
+  // Admin module
+  AdminController: Symbol.for('AdminController'),
+  ProductAdminController: Symbol.for('ProductAdminController'),
+  ProductAdminService: Symbol.for('ProductAdminService'),
+  ProductMapper: Symbol.for('ProductMapper'),
+  DashboardController: Symbol.for('DashboardController'),
+  DashboardService: Symbol.for('DashboardService'),
+  QueueAdminController: Symbol.for('QueueAdminController'),
+  QueueAdminService: Symbol.for('QueueAdminService'),
+  AccountAdminController: Symbol.for('AccountAdminController'),
+  AccountAdminService: Symbol.for('AccountAdminService'),
+  RoleController: Symbol.for('RoleController'),
+  RoleService: Symbol.for('RoleService'),
 };

--- a/swagger.json
+++ b/swagger.json
@@ -51,6 +51,26 @@
     {
       "name": "Bots",
       "description": "WhatsApp / Telegram bot account linking"
+    },
+    {
+      "name": "Admin - Products",
+      "description": "Admin product management"
+    },
+    {
+      "name": "Admin - Dashboard",
+      "description": "Admin dashboard and health checks"
+    },
+    {
+      "name": "Admin - Queues",
+      "description": "Admin queue introspection"
+    },
+    {
+      "name": "Admin - Accounts",
+      "description": "Admin account management"
+    },
+    {
+      "name": "Admin - Roles",
+      "description": "Admin role management"
     }
   ],
   "security": [
@@ -1014,6 +1034,623 @@
           "id",
           "action",
           "createdAt"
+        ]
+      },
+      "PaginatedResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {}
+            },
+            "description": "Array of items for the current page"
+          },
+          "meta": {
+            "type": "object",
+            "properties": {
+              "total": {
+                "type": "number",
+                "description": "Total number of items matching the query"
+              },
+              "skip": {
+                "type": "number",
+                "description": "Number of items skipped"
+              },
+              "limit": {
+                "type": "number",
+                "description": "Max items per page"
+              },
+              "hasMore": {
+                "type": "boolean",
+                "description": "Whether additional pages are available"
+              }
+            },
+            "required": [
+              "total",
+              "skip",
+              "limit",
+              "hasMore"
+            ]
+          }
+        },
+        "required": [
+          "data",
+          "meta"
+        ]
+      },
+      "ProductListItemDTO": {
+        "type": "object",
+        "properties": {
+          "_id": {
+            "type": "string"
+          },
+          "ID": {
+            "type": "string"
+          },
+          "category": {
+            "type": "string"
+          },
+          "subcategory": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "cost": {
+            "type": "string"
+          },
+          "currency": {
+            "type": "string"
+          },
+          "price": {
+            "type": "number"
+          },
+          "imageURL": {
+            "type": "string"
+          },
+          "isOutstanding": {
+            "type": "boolean"
+          },
+          "isPromoted": {
+            "type": "boolean"
+          },
+          "location": {
+            "type": "object",
+            "properties": {
+              "state": {
+                "type": "string"
+              },
+              "municipality": {
+                "type": "string"
+              }
+            }
+          },
+          "views": {
+            "type": "number"
+          },
+          "seller": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              }
+            }
+          },
+          "metadata": {
+            "type": "object",
+            "properties": {
+              "scrapedAt": {
+                "nullable": true
+              }
+            }
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "_id",
+          "url",
+          "currency",
+          "price",
+          "isOutstanding",
+          "createdAt",
+          "updatedAt"
+        ]
+      },
+      "ProductDetailDTO": {
+        "type": "object",
+        "properties": {
+          "_id": {
+            "type": "string"
+          },
+          "ID": {
+            "type": "string"
+          },
+          "category": {
+            "type": "string"
+          },
+          "subcategory": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "cost": {
+            "type": "string"
+          },
+          "currency": {
+            "type": "string"
+          },
+          "price": {
+            "type": "number"
+          },
+          "imageURL": {
+            "type": "string"
+          },
+          "isOutstanding": {
+            "type": "boolean"
+          },
+          "isPromoted": {
+            "type": "boolean"
+          },
+          "location": {
+            "type": "object",
+            "properties": {
+              "state": {
+                "type": "string"
+              },
+              "municipality": {
+                "type": "string"
+              }
+            }
+          },
+          "views": {
+            "type": "number"
+          },
+          "seller": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "phone": {
+                "type": "string"
+              },
+              "email": {
+                "type": "string"
+              },
+              "whatsapp": {
+                "type": "string"
+              }
+            }
+          },
+          "metadata": {
+            "type": "object",
+            "properties": {
+              "source": {
+                "type": "string"
+              },
+              "schemaVersion": {
+                "type": "number"
+              },
+              "scrapedAt": {
+                "nullable": true
+              }
+            }
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "attributes": {
+            "type": "object",
+            "additionalProperties": {
+              "nullable": true
+            }
+          },
+          "analytics": {
+            "type": "object",
+            "additionalProperties": {
+              "nullable": true
+            }
+          },
+          "createdAt": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "_id",
+          "url",
+          "currency",
+          "price",
+          "isOutstanding",
+          "createdAt",
+          "updatedAt"
+        ]
+      },
+      "ProductPriceHistoryDTO": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "value": {
+                  "type": "number"
+                },
+                "updatedAt": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "value",
+                "updatedAt"
+              ]
+            }
+          },
+          "total": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "data",
+          "total"
+        ]
+      },
+      "ProductListQueryDTO": {
+        "type": "object",
+        "properties": {
+          "skip": {
+            "type": "number",
+            "nullable": true,
+            "minimum": 0,
+            "default": 0
+          },
+          "limit": {
+            "type": "number",
+            "minimum": 1,
+            "maximum": 100,
+            "default": 20
+          },
+          "sort": {
+            "type": "string",
+            "default": "createdAt"
+          },
+          "order": {
+            "type": "string",
+            "enum": [
+              "asc",
+              "desc"
+            ],
+            "default": "desc"
+          },
+          "category": {
+            "type": "string"
+          },
+          "subcategory": {
+            "type": "string"
+          },
+          "search": {
+            "type": "string"
+          },
+          "minPrice": {
+            "type": "number",
+            "nullable": true
+          },
+          "maxPrice": {
+            "type": "number",
+            "nullable": true
+          },
+          "isOutstanding": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "isPromoted": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "location.state": {
+            "type": "string"
+          }
+        }
+      },
+      "ProductStatsDTO": {
+        "type": "object",
+        "properties": {
+          "totalProducts": {
+            "type": "number"
+          },
+          "byCategory": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "category": {
+                  "type": "string"
+                },
+                "count": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "category",
+                "count"
+              ]
+            }
+          },
+          "byState": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "state": {
+                  "type": "string"
+                },
+                "count": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "state",
+                "count"
+              ]
+            }
+          },
+          "outstandingCount": {
+            "type": "number"
+          },
+          "promotedCount": {
+            "type": "number"
+          },
+          "lastScrapedAt": {
+            "type": "string",
+            "nullable": true
+          },
+          "priceRange": {
+            "type": "object",
+            "properties": {
+              "min": {
+                "type": "number"
+              },
+              "max": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "min",
+              "max"
+            ]
+          }
+        },
+        "required": [
+          "totalProducts",
+          "byCategory",
+          "byState",
+          "outstandingCount",
+          "promotedCount",
+          "lastScrapedAt",
+          "priceRange"
+        ]
+      },
+      "DashboardMetricsDTO": {
+        "type": "object",
+        "properties": {
+          "productCount": {
+            "type": "number"
+          },
+          "categoriesBreakdown": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "category": {
+                  "type": "string"
+                },
+                "count": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "category",
+                "count"
+              ]
+            }
+          },
+          "totalAccounts": {
+            "type": "number"
+          },
+          "totalUsers": {
+            "type": "number"
+          },
+          "activeSubscriptions": {
+            "type": "number"
+          },
+          "recentProducts": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {}
+            }
+          }
+        },
+        "required": [
+          "productCount",
+          "categoriesBreakdown",
+          "totalAccounts",
+          "totalUsers",
+          "activeSubscriptions",
+          "recentProducts"
+        ]
+      },
+      "HealthResponseDTO": {
+        "type": "object",
+        "properties": {
+          "services": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "service": {
+                  "type": "string"
+                },
+                "status": {
+                  "type": "string",
+                  "enum": [
+                    "connected",
+                    "error"
+                  ]
+                },
+                "error": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "service",
+                "status"
+              ]
+            }
+          },
+          "timestamp": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "services",
+          "timestamp"
+        ]
+      },
+      "QueueStatsDTO": {
+        "type": "object",
+        "properties": {
+          "queueName": {
+            "type": "string"
+          },
+          "counts": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "number"
+            }
+          }
+        },
+        "required": [
+          "queueName",
+          "counts"
+        ]
+      },
+      "JobDetailDTO": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "data": {
+            "nullable": true
+          },
+          "progress": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "object",
+                "properties": {}
+              }
+            ]
+          },
+          "attemptsMade": {
+            "type": "number"
+          },
+          "failedReason": {
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "number"
+          },
+          "processedOn": {
+            "type": "number",
+            "nullable": true
+          },
+          "finishedOn": {
+            "type": "number",
+            "nullable": true
+          },
+          "returnValue": {
+            "nullable": true
+          },
+          "status": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name"
+        ]
+      },
+      "CreateRoleDTO": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "accountId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ]
+      },
+      "RoleResponseDTO": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "accountId": {
+            "type": "string",
+            "nullable": true
+          },
+          "_count": {
+            "type": "object",
+            "properties": {
+              "users": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "users"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "accountId"
         ]
       },
       "AuthResponseDTO": {
@@ -6028,6 +6665,4284 @@
         "responses": {
           "204": {
             "description": "User deleted"
+          },
+          "401": {
+            "description": "Unauthorized - missing or invalid token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden - insufficient role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/products": {
+      "get": {
+        "tags": [
+          "Admin - Products"
+        ],
+        "summary": "List products with pagination and filtering",
+        "operationId": "adminListProducts",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated list of products",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - missing or invalid token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden - insufficient role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/products/stats": {
+      "get": {
+        "tags": [
+          "Admin - Products"
+        ],
+        "summary": "Get product statistics",
+        "operationId": "adminGetProductStats",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Product statistics",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProductStatsDTO"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - missing or invalid token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden - insufficient role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/products/{id}": {
+      "get": {
+        "tags": [
+          "Admin - Products"
+        ],
+        "summary": "Get product detail by ID",
+        "operationId": "adminGetProductById",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-f0-9]{24}$",
+              "description": "Product MongoDB ID"
+            },
+            "required": true,
+            "description": "Product MongoDB ID",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Product detail",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProductDetailDTO"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - missing or invalid token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden - insufficient role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Admin - Products"
+        ],
+        "summary": "Delete a product by ID",
+        "operationId": "adminDeleteProduct",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-f0-9]{24}$",
+              "description": "Product MongoDB ID"
+            },
+            "required": true,
+            "description": "Product MongoDB ID",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Product deleted"
+          },
+          "401": {
+            "description": "Unauthorized - missing or invalid token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden - insufficient role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/products/{id}/history/price": {
+      "get": {
+        "tags": [
+          "Admin - Products"
+        ],
+        "summary": "Get price history for a product",
+        "operationId": "adminGetProductPriceHistory",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-f0-9]{24}$",
+              "description": "Product MongoDB ID"
+            },
+            "required": true,
+            "description": "Product MongoDB ID",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Price history entries",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProductPriceHistoryDTO"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - missing or invalid token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden - insufficient role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/products/{id}/history/views": {
+      "get": {
+        "tags": [
+          "Admin - Products"
+        ],
+        "summary": "Get views history for a product",
+        "operationId": "adminGetProductViewsHistory",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-f0-9]{24}$",
+              "description": "Product MongoDB ID"
+            },
+            "required": true,
+            "description": "Product MongoDB ID",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Views history entries",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProductPriceHistoryDTO"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - missing or invalid token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden - insufficient role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/products/{id}/history/location": {
+      "get": {
+        "tags": [
+          "Admin - Products"
+        ],
+        "summary": "Get location history for a product",
+        "operationId": "adminGetProductLocationHistory",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-f0-9]{24}$",
+              "description": "Product MongoDB ID"
+            },
+            "required": true,
+            "description": "Product MongoDB ID",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Location history entries",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProductPriceHistoryDTO"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - missing or invalid token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden - insufficient role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/products/{id}/history/outstanding": {
+      "get": {
+        "tags": [
+          "Admin - Products"
+        ],
+        "summary": "Get outstanding status history for a product",
+        "operationId": "adminGetProductOutstandingHistory",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-f0-9]{24}$",
+              "description": "Product MongoDB ID"
+            },
+            "required": true,
+            "description": "Product MongoDB ID",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Outstanding history entries",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProductPriceHistoryDTO"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - missing or invalid token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden - insufficient role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/products/{id}/history/promoted": {
+      "get": {
+        "tags": [
+          "Admin - Products"
+        ],
+        "summary": "Get promoted status history for a product",
+        "operationId": "adminGetProductPromotedHistory",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "pattern": "^[a-f0-9]{24}$",
+              "description": "Product MongoDB ID"
+            },
+            "required": true,
+            "description": "Product MongoDB ID",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Promoted history entries",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProductPriceHistoryDTO"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - missing or invalid token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden - insufficient role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/queues/stats": {
+      "get": {
+        "tags": [
+          "Admin - Queues"
+        ],
+        "summary": "Get job counts for all queues",
+        "operationId": "adminGetAllQueueStats",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "All queue statistics",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "queues": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/QueueStatsDTO"
+                      }
+                    }
+                  },
+                  "required": [
+                    "queues"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - missing or invalid token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden - insufficient role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/queues/{name}/stats": {
+      "get": {
+        "tags": [
+          "Admin - Queues"
+        ],
+        "summary": "Get job counts for a single queue",
+        "operationId": "adminGetQueueStats",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Queue name (e.g. scraping, notification)"
+            },
+            "required": true,
+            "description": "Queue name (e.g. scraping, notification)",
+            "name": "name",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Queue statistics",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QueueStatsDTO"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - missing or invalid token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden - insufficient role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/queues/{name}/jobs": {
+      "get": {
+        "tags": [
+          "Admin - Queues"
+        ],
+        "summary": "Get recent jobs for a queue",
+        "operationId": "adminGetRecentJobs",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Queue name (e.g. scraping, notification)"
+            },
+            "required": true,
+            "description": "Queue name (e.g. scraping, notification)",
+            "name": "name",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Recent jobs",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "jobs": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/JobDetailDTO"
+                      }
+                    }
+                  },
+                  "required": [
+                    "jobs"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - missing or invalid token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden - insufficient role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/queues/{name}/jobs/{id}": {
+      "get": {
+        "tags": [
+          "Admin - Queues"
+        ],
+        "summary": "Get full detail for a single job",
+        "operationId": "adminGetJobDetail",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Queue name (e.g. scraping, notification)"
+            },
+            "required": true,
+            "description": "Queue name (e.g. scraping, notification)",
+            "name": "name",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Job ID"
+            },
+            "required": true,
+            "description": "Job ID",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Job detail",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JobDetailDTO"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - missing or invalid token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden - insufficient role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/dashboard": {
+      "get": {
+        "tags": [
+          "Admin - Dashboard"
+        ],
+        "summary": "Get dashboard metrics",
+        "operationId": "adminGetDashboardMetrics",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Dashboard metrics",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DashboardMetricsDTO"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - missing or invalid token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden - insufficient role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/dashboard/health": {
+      "get": {
+        "tags": [
+          "Admin - Dashboard"
+        ],
+        "summary": "Get backend health status",
+        "operationId": "adminGetHealth",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Health status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HealthResponseDTO"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - missing or invalid token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden - insufficient role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/accounts": {
+      "get": {
+        "tags": [
+          "Admin - Accounts"
+        ],
+        "summary": "List all accounts with pagination",
+        "operationId": "adminListAccounts",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated list of accounts",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - missing or invalid token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden - insufficient role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/accounts/{id}": {
+      "get": {
+        "tags": [
+          "Admin - Accounts"
+        ],
+        "summary": "Get account detail by ID",
+        "operationId": "adminGetAccountById",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Account ID"
+            },
+            "required": true,
+            "description": "Account ID",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account detail",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "account": {
+                      "$ref": "#/components/schemas/AccountDTO"
+                    }
+                  },
+                  "required": [
+                    "account"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - missing or invalid token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden - insufficient role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Admin - Accounts"
+        ],
+        "summary": "Update an account by ID",
+        "operationId": "adminUpdateAccount",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Account ID"
+            },
+            "required": true,
+            "description": "Account ID",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "description": "Account update data",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "settings": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "nullable": true
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Account updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "account": {
+                      "$ref": "#/components/schemas/AccountDTO"
+                    }
+                  },
+                  "required": [
+                    "account"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - missing or invalid token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden - insufficient role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Admin - Accounts"
+        ],
+        "summary": "Delete an account by ID",
+        "operationId": "adminDeleteAccount",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Account ID"
+            },
+            "required": true,
+            "description": "Account ID",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Account deleted"
+          },
+          "401": {
+            "description": "Unauthorized - missing or invalid token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden - insufficient role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/roles": {
+      "get": {
+        "tags": [
+          "Admin - Roles"
+        ],
+        "summary": "List all roles with user counts",
+        "operationId": "adminListRoles",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of roles",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "roles": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/RoleResponseDTO"
+                      }
+                    }
+                  },
+                  "required": [
+                    "roles"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - missing or invalid token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden - insufficient role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Admin - Roles"
+        ],
+        "summary": "Create a new role",
+        "operationId": "adminCreateRole",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "description": "Role creation data",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateRoleDTO"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Role created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RoleResponseDTO"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - missing or invalid token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden - insufficient role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/roles/{id}": {
+      "delete": {
+        "tags": [
+          "Admin - Roles"
+        ],
+        "summary": "Delete a role by ID",
+        "operationId": "adminDeleteRole",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Role ID"
+            },
+            "required": true,
+            "description": "Role ID",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Role deleted"
+          },
+          "401": {
+            "description": "Unauthorized - missing or invalid token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden - insufficient role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/users/{userId}/roles/{roleId}": {
+      "post": {
+        "tags": [
+          "Admin - Roles"
+        ],
+        "summary": "Assign a role to a user",
+        "operationId": "adminAssignRoleToUser",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "User ID"
+            },
+            "required": true,
+            "description": "User ID",
+            "name": "userId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Role ID"
+            },
+            "required": true,
+            "description": "Role ID",
+            "name": "roleId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Role assigned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - missing or invalid token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden - insufficient role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Admin - Roles"
+        ],
+        "summary": "Unassign a role from a user",
+        "operationId": "adminUnassignRoleFromUser",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "User ID"
+            },
+            "required": true,
+            "description": "User ID",
+            "name": "userId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Role ID"
+            },
+            "required": true,
+            "description": "Role ID",
+            "name": "roleId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Role unassigned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
           },
           "401": {
             "description": "Unauthorized - missing or invalid token",


### PR DESCRIPTION
## Summary

Expande el modulo Super Admin con 26 nuevos endpoints REST para el dashboard, eliminando la necesidad de usar consola.

## Endpoints nuevos (26)

### Products — `/api/admin/products` (9)
- `GET /` — Listado paginado con filtros (categoria, precio, busqueda, ubicacion)
- `GET /stats` — Estadisticas agregadas
- `GET /:id` — Detalle de producto
- `GET /:id/history/price` — Historial de precios
- `GET /:id/history/views` — Historial de vistas
- `GET /:id/history/location` — Historial de ubicacion
- `GET /:id/history/outstanding` — Historial de destacados
- `GET /:id/history/promoted` — Historial de promovidos
- `DELETE /:id` — Eliminar producto

### Queues — `/api/admin/queues` (4)
- `GET /stats` — Stats de todas las colas BullMQ
- `GET /:name/stats` — Stats de una cola
- `GET /:name/jobs` — Jobs recientes
- `GET /:name/jobs/:id` — Detalle de job

### Dashboard — `/api/admin/dashboard` (2)
- `GET /` — Metricas unificadas
- `GET /health` — Health check (MongoDB, Redis, PostgreSQL)

### Accounts — `/api/admin/accounts` (4)
- `GET /` — Listado cross-tenant paginado
- `GET /:id` — Detalle con stats
- `PUT /:id` — Actualizar
- `DELETE /:id` — Eliminar

### Roles — `/api/admin` (5)
- `GET /roles` — Listar roles con user counts
- `POST /roles` — Crear rol
- `DELETE /roles/:id` — Eliminar rol
- `POST /users/:userId/roles/:roleId` — Asignar rol
- `DELETE /users/:userId/roles/:roleId` — Desasignar rol

### Users — `/api/admin/users` (2, corregidos)
- `GET /` — Listar usuarios
- `DELETE /:id` — Eliminar usuario

## Changes

| Fase | Commits | Que hizo |
|------|---------|----------|
| 1 | `fix(admin)` | AdminController arreglado: DI con TYPES, SUPER_ADMIN gating, Request/Response tipados, ResponseHandler |
| 2 | `feat(admin)` x3 | ProductRepository extendido, DTOs, ProductMapper, ProductAdminService + Controller con 9 endpoints |
| 3 | `feat(admin)` x2 | QueueAdmin, Dashboard, AccountAdmin, Role management |
| 4 | `docs(admin)` | OpenAPI docs (39 schemas, 45 paths), barrel files |

## Verification

- **645 tests passing** (63 suites, 0 failures)
- **swagger.json** synced (`npm run docs:validate` OK)
- **Swagger UI** en `/api-docs` con todos los endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)