### PR TITLE
feat(cron): add automated scraping scheduler with multi-store support

### DIFF
--- a/.claude/skills/cron-scheduler/SKILL.md
+++ b/.claude/skills/cron-scheduler/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: cron-scheduler
+description: Use when editing files under src/main/cron/ or adding automated scraping schedules — covers StoreRegistry multi-store registration, CronSchedulerService (node-cron) patterns, generic JSON jobs, and the node-cron require() type cast gotcha.
+---
+
+# Cron Scheduler — Agent Instructions
+
+## Module structure
+
+```
+src/main/cron/
+├── store-registry.ts                  # IStoreConfig, IFieldSchema, Map<key, config>
+├── controllers/
+│   └── schedule.controller.ts         # ScheduleController + StoreInfoController
+├── services/
+│   ├── dto/                           # Zod DTOs (jobs: z.object({}).passthrough())
+│   ├── schedule.service.ts            # CRUD + hot re-registration
+│   └── scheduler.service.ts           # node-cron runtime
+├── repositories/
+│   └── schedule.repository.ts         # Prisma CRUD + updateLastRunAt
+├── mappers/
+│   └── schedule.mapper.ts             # toScheduleResponseDTO
+└── errors/
+    └── schedule-not-found.error.ts
+```
+
+Related: `src/main/types/node-cron.d.ts` (ambient types, found by `tsc`), `src/main/scrapers/<store>/index.ts` (store registration).
+
+## StoreRegistry
+
+In-memory `Map<string, IStoreConfig>`. Each store module calls `register()` at bootstrap. The scheduler resolves `store → scrapingQueue` at tick time.
+
+```typescript
+// IStoreConfig shape
+interface IStoreConfig {
+  displayName: string;      // "Revolico"
+  scrapingQueue: string;    // "PRODUCTS_SCRAPING"
+  jobSchema: {
+    fields: IFieldSchema[]; // drives dynamic admin-dashboard forms
+  };
+}
+interface IFieldSchema {
+  name: string;             // "category"
+  type: 'string' | 'number' | 'boolean';
+  required: boolean;
+  label: string;            // "Categoría"
+  placeholder?: string;
+}
+```
+
+`list()` returns `Array<{ key: string } & IStoreConfig>` — consumed by `GET /api/admin/stores` for the admin dashboard.
+
+## CronSchedulerService
+
+node-cron v3 runtime. Maintains a `Map<string, CronScheduledTask>`.
+
+### node-cron import (GOTCHA)
+
+ts-node-dev cannot resolve the ambient `.d.ts` at `src/main/types/node-cron.d.ts`. The service uses `require()` with an inline type cast:
+
+```typescript
+type CronScheduledTask = { start(): void; stop(): void };
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const cron = require('node-cron') as {
+  schedule(expression: string, func: () => void, opts?: { scheduled?: boolean; timezone?: string }): CronScheduledTask;
+};
+```
+
+When writing tests, mock `node-cron` as `{ schedule: jest.fn() }` (plain object, no `__esModule`/`default` wrapper — the `require()` returns the mock directly).
+
+### Lifecycle
+
+- **`initialize()`**: reads all enabled schedules from repo, calls `register()` for each. Called once at bootstrap (`app.ts`).
+- **`register(schedule)`**: stops any existing task for the same id, then if enabled calls `cron.schedule(cronExpr, onTick)`.
+- **`unregister(id)`**: stops and removes the task. No-op for unknown ids.
+- **`shutdown()`**: stops all tasks, clears map. Called in `App.close()`.
+
+### onTick flow
+
+1. Resolve `storeRegistry.get(schedule.store).scrapingQueue` → queueName
+2. For each job in `schedule.jobs` (cast as `Array<Record<string, unknown>>`): enqueue via `QueueContext` with `{ attempts: 2, backoff: 5000 }` in a try/catch — one failing job does NOT block siblings
+3. Best-effort `repo.updateLastRunAt(id)` — failure is silently swallowed
+
+Invalid cron expressions are caught in `register()` (logged, don't throw).
+
+## ScheduleService
+
+CRUD orchestration. Every write method syncs the scheduler immediately:
+
+| Method | Scheduler call |
+|--------|---------------|
+| `create(dto)` | `scheduler.register(row)` |
+| `update(id, dto)` | `scheduler.register(row)` |
+| `delete(id)` | `scheduler.unregister(id)` |
+| `toggle(id)` | `scheduler.register(row)` |
+
+No restart needed — changes take effect on the next tick.
+
+## ScrapingSchedule model (Prisma)
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `name` | String `@unique` | Human-readable label |
+| `store` | String | Key resolvable by StoreRegistry |
+| `cron` | String | Standard 5-field cron expression |
+| `enabled` | Boolean | Toggled via PATCH; scheduler skips disabled |
+| `jobs` | Json | Array of store-specific objects — opaque to the scheduler |
+| `lastRunAt` | DateTime? | Best-effort metadata, updated after each tick |
+
+No `accountId` — tenant isolation does NOT apply. SUPER_ADMIN only.
+
+## Generic JSON jobs
+
+DTOs use `z.array(z.object({}).passthrough()).min(1)`. The scheduler never inspects job fields — it passes them through to the queue. Each store module interprets its own shape.
+
+Revolico jobs: `{ category: string, subcategory?: string, pageNumber?: number, totalPages?: number }`.
+
+## Adding a new store
+
+3 steps:
+
+1. **Create `src/main/scrapers/<store>/index.ts`** with a `registerXxxStore(container)` function calling `storeRegistry.register(key, config)`. The `jobSchema.fields` array defines what the admin dashboard renders.
+2. **Call it in `app.ts`** before `scheduler.initialize()`.
+3. **Add the store's scraping queue** to its `IQueueModule` implementation if it doesn't already exist.
+
+## DI pattern
+
+Add Symbol to `types.container.ts`, binding to `container.ts`. Bind `StoreRegistry` and `CronSchedulerService` in singleton scope.
+
+```typescript
+// types.container.ts
+StoreRegistry: Symbol.for('StoreRegistry'),
+CronSchedulerService: Symbol.for('CronSchedulerService'),
+
+// container.ts
+container.bind<StoreRegistry>(TYPES.StoreRegistry).to(StoreRegistry).inSingletonScope();
+container.bind<CronSchedulerService>(TYPES.CronSchedulerService).to(CronSchedulerService).inSingletonScope();
+```
+
+## Cross-references
+
+- `src/main/cron/` — implementation
+- `src/main/docs/modules/scheduling.paths.ts` — OpenAPI paths
+- `src/main/scrapers/revolico/index.ts` — reference store registration
+- `src/main/scrapers/CLAUDE.md` — scraper module patterns (section 8: store registration)
+- `src/main/CLAUDE.md` — code patterns (Cron Module section)
+- `swagger.json` — endpoint details (tag: `Admin - Scraping Schedules`)
+- `.claude/skills/testing/SKILL.md` — Jest patterns (node-cron mock uses `require` style)

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ tmp/
 # Visual Studio Code
 ######################
 .vscode/settings.*
+.vscode/tasks.json
+.vscode/launch.json
 
 ############# Local resources AI Agents ###########
 .plans

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,6 +158,7 @@ Run before `git commit` — see @.claude/rules/compliance-checklist.md for the f
 | Add a new alarm condition                   | `.claude/skills/alarm-condition/SKILL.md`           |
 | Bot module (WhatsApp + Telegram)            | `.claude/skills/bots/SKILL.md`                      |
 | TypeScript best practices                   | `.claude/skills/typescript-best-practices/SKILL.md` |
+| Cron scraping scheduler                     | `.claude/skills/cron-scheduler/SKILL.md`            |
 | PostgreSQL / Prisma schema                  | `prisma/schema.prisma`                              |
 | MongoDB / Mongoose connection               | `src/main/config/db-config.ts`                      |
 | Queue port & adapters (BullMQ / Mock / SQS) | `src/main/shared/queue/`                            |

--- a/README.md
+++ b/README.md
@@ -135,6 +135,56 @@ src/main/scrapers/
 
 New stores (e.g. `porlalivre/`) add their own directory under `src/main/scrapers/` with store-specific models, controllers, and JSONata expressions. They import shared enrichment from `@scrapers/services/` — no need to reimplement attribute extraction or analytics.
 
+## Automated Scraping Scheduler
+
+The platform includes a **cron-based scheduler** that automates scraping — instead of manually calling the scraping endpoint for each category, you create persistent schedules that fire on cron expressions.
+
+### How it works
+
+1. Create a `ScrapingSchedule` via the admin API (endpoints documented in Swagger at `/api-docs` under **Admin - Scraping Schedules**).
+2. Each schedule targets a **store** (e.g. `revolico`) and carries a **cron expression** plus a list of **jobs** — store-specific scraping descriptors.
+3. At bootstrap the scheduler reads enabled schedules from PostgreSQL, registers them with `node-cron`, and enqueues scraping jobs to the correct BullMQ queue on each tick.
+4. Changes via the API (create, update, toggle, delete) take effect **immediately** — no restart required.
+
+### Store registration
+
+Each store module registers itself in the `StoreRegistry` at startup, publishing its queue name and a `jobSchema` that the admin dashboard uses for dynamic forms:
+
+```typescript
+// src/main/scrapers/revolico/index.ts
+registry.register('revolico', {
+  displayName: 'Revolico',
+  scrapingQueue: QUEUE_NAME.products_scraping,
+  jobSchema: {
+    fields: [
+      { name: 'category', type: 'string', required: true, label: 'Categoría' },
+      // ...
+    ],
+  },
+});
+```
+
+New stores auto-register the same way — the scheduler is store-agnostic.
+
+### Quick example
+
+```bash
+# Create a daily 6am schedule for two Revolico categories
+curl -X POST /api/admin/scraping-schedules \
+  -H "Authorization: Bearer <token>" \
+  -d '{
+    "name": "Morning scrape",
+    "store": "revolico",
+    "cron": "0 6 * * *",
+    "jobs": [
+      {"category": "celulares", "totalPages": 2},
+      {"category": "electronicos"}
+    ]
+  }'
+```
+
+See `src/main/cron/` for the implementation and `.claude/skills/cron-scheduler/SKILL.md` for AI agent guidance.
+
 ## Deployment
 
 The `Deploy Scrapers API` workflow (`.github/workflows/ec2-deploy.yml`) builds the image, pushes it to Quay.io, and runs the container on a self-hosted runner on the production EC2 host. While the project is an MVP **without** a production host, both build and deploy jobs skip themselves — CI stays green and no work is performed.
@@ -172,6 +222,7 @@ The repository ships project-specific guidance for Claude Code (and other AI ass
 | TypeScript patterns           | [.claude/skills/typescript-best-practices/SKILL.md](.claude/skills/typescript-best-practices/SKILL.md) |
 | Scraper module                | [src/main/scrapers/CLAUDE.md](src/main/scrapers/CLAUDE.md)                                             |
 | Revolico scraper              | [.claude/skills/revolico-scraper/SKILL.md](.claude/skills/revolico-scraper/SKILL.md)                   |
+| Cron scheduler                | [.claude/skills/cron-scheduler/SKILL.md](.claude/skills/cron-scheduler/SKILL.md)                       |
 
 ## Recommended Claude Code plugin: superpowers
 

--- a/prisma/migrations/20260709151146_add_scraping_schedule/migration.sql
+++ b/prisma/migrations/20260709151146_add_scraping_schedule/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE "ScrapingSchedule" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "store" TEXT NOT NULL DEFAULT 'revolico',
+    "cron" TEXT NOT NULL,
+    "enabled" BOOLEAN NOT NULL DEFAULT true,
+    "jobs" JSONB NOT NULL,
+    "lastRunAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ScrapingSchedule_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ScrapingSchedule_name_key" ON "ScrapingSchedule"("name");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -348,3 +348,18 @@ model Rule {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 }
+
+// -----------------------------------------------------------------------------
+// Scraping Schedule — cron-driven automated scraping per store
+// -----------------------------------------------------------------------------
+model ScrapingSchedule {
+  id        String    @id @default(uuid())
+  name      String    @unique
+  store     String    @default("revolico")
+  cron      String
+  enabled   Boolean   @default(true)
+  jobs      Json
+  lastRunAt DateTime?
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
+}

--- a/src/__tests__/integration/schedule-api.test.ts
+++ b/src/__tests__/integration/schedule-api.test.ts
@@ -1,0 +1,481 @@
+// Avoid importing ESM 'jose' via ProviderTokenVerifier during tests
+jest.mock('@shared/security/provider-token-verifier', () => ({
+  ProviderTokenVerifier: jest.fn().mockImplementation(() => ({
+    verifyProvider: jest.fn().mockResolvedValue({
+      providerId: 'prov-1',
+      email: 'schedule_provider@test.local',
+      email_verified: true,
+      name: 'Provider User',
+      picture: null,
+    }),
+  })),
+}));
+
+import request from 'supertest';
+import { v4 as uuidv4 } from 'uuid';
+import { App } from '../../main/app';
+import { container } from '@shared/container';
+import { TYPES } from '@shared/types.container';
+import { PgDBContext } from '@config/pg-db';
+
+let app: any;
+let appInstance: App;
+let pgDb: PgDBContext;
+let testAccountId: string;
+let memberToken: string;
+let superAdminToken: string;
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Seeds a single ScrapingSchedule row directly in PostgreSQL.
+ * Each call uses a unique default name to avoid unique-constraint collisions.
+ */
+async function seedSchedule(overrides: Record<string, unknown> = {}): Promise<Record<string, any>> {
+  const id = (overrides.id as string) ?? uuidv4();
+  const name = (overrides.name as string) ?? `test-schedule-${uuidv4().slice(0, 8)}`;
+  const store = (overrides.store as string) ?? 'revolico';
+  const cron = (overrides.cron as string) ?? '0 6 * * *';
+  const enabled = overrides.enabled !== undefined ? (overrides.enabled as boolean) : true;
+  const jobs = overrides.jobs ?? [{ category: 'test' }];
+  const { rows } = await pgDb.query(
+    `INSERT INTO "ScrapingSchedule" (id, name, store, cron, enabled, jobs, "createdAt", "updatedAt")
+     VALUES ($1, $2, $3, $4, $5, $6::jsonb, NOW(), NOW()) RETURNING *`,
+    [id, name, store, cron, enabled, JSON.stringify(jobs)],
+  );
+  return rows[0];
+}
+
+// ─── Lifecycle ───────────────────────────────────────────────────────────────
+
+beforeAll(async () => {
+  appInstance = new App();
+  app = await appInstance.setup();
+  pgDb = container.get<PgDBContext>(TYPES.TenantDB);
+  // App.setup() already connects PgDBContext (singleton) — no need for pgDb.dbConnect()
+
+  // Provision a fresh tenant + role assignments for this test
+  testAccountId = uuidv4();
+  await pgDb.query(
+    `INSERT INTO public."Account" ("id", "name", "createdAt", "updatedAt") VALUES ($1, $2, NOW(), NOW()) ON CONFLICT ("id") DO NOTHING`,
+    [testAccountId, 'Schedule API Test Account'],
+  );
+
+  const rolesResult = await pgDb.query(`SELECT "id", "name" FROM public."Role" WHERE "accountId" IS NULL`);
+  const roles = rolesResult.rows;
+  const memberRoleId = roles.find((r: any) => r.name === 'MEMBER')?.id;
+  const superAdminRoleId = roles.find((r: any) => r.name === 'SUPER_ADMIN')?.id;
+
+  const memberRes = await request(app)
+    .post('/api/accounts/register/local')
+    .send({
+      email: 'sched_member@test.local',
+      username: 'sched_member_user',
+      password: 'SecurePass123',
+      accountId: testAccountId,
+      roleIds: memberRoleId ? [memberRoleId] : [],
+    });
+  memberToken = memberRes.body.data?.token;
+
+  const superAdminRes = await request(app)
+    .post('/api/accounts/register/local')
+    .send({
+      email: 'sched_superadmin@test.local',
+      username: 'sched_superadmin_user',
+      password: 'SecurePass123',
+      accountId: testAccountId,
+      roleIds: superAdminRoleId ? [superAdminRoleId] : [],
+    });
+  superAdminToken = superAdminRes.body.data?.token;
+});
+
+afterAll(async () => {
+  try {
+    // Clean up any ScrapingSchedule rows this test created
+    await pgDb.query(`DELETE FROM "ScrapingSchedule" WHERE "name" LIKE 'test-schedule-%'`);
+
+    // Delete bot-related FK tables first
+    try {
+      await pgDb.query('DELETE FROM public."bot_link_audit" WHERE "accountId" = $1', [testAccountId]);
+    } catch {
+      /* table may not exist yet */
+    }
+    try {
+      await pgDb.query('DELETE FROM public."bot_link_codes" WHERE "accountId" = $1', [testAccountId]);
+    } catch {
+      /* table may not exist yet */
+    }
+    try {
+      await pgDb.query('DELETE FROM public."bot_conversations" WHERE "accountId" = $1', [testAccountId]);
+    } catch {
+      /* table may not exist yet */
+    }
+
+    await pgDb.query('DELETE FROM public."UserIdentity" WHERE "userId" IN (SELECT "id" FROM public."User" WHERE "accountId" = $1)', [
+      testAccountId,
+    ]);
+    await pgDb.query('DELETE FROM public."User" WHERE "accountId" = $1', [testAccountId]);
+    await pgDb.query('DELETE FROM public."Account" WHERE "id" = $1', [testAccountId]);
+  } catch {
+    // ignore cleanup errors
+  }
+  await appInstance.close();
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// POST /api/admin/scraping-schedules
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('POST /api/admin/scraping-schedules', () => {
+  const createdNames: string[] = [];
+
+  afterEach(async () => {
+    for (const name of createdNames) {
+      await pgDb.query(`DELETE FROM "ScrapingSchedule" WHERE "name" = $1`, [name]);
+    }
+    createdNames.length = 0;
+  });
+
+  it('rejects unauthenticated requests with 401', async () => {
+    const res = await request(app)
+      .post('/api/admin/scraping-schedules')
+      .send({ name: 'unused', store: 'revolico', cron: '0 6 * * *', jobs: [{ cat: 'a' }] });
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects non-SUPER_ADMIN users with 403', async () => {
+    const res = await request(app)
+      .post('/api/admin/scraping-schedules')
+      .set('Authorization', `Bearer ${memberToken}`)
+      .send({ name: 'unused', store: 'revolico', cron: '0 6 * * *', jobs: [{ cat: 'a' }] });
+    expect(res.status).toBe(403);
+  });
+
+  it('creates a schedule with 201 and correct response shape', async () => {
+    const name = 'test-schedule-create-valid';
+    createdNames.push(name);
+
+    const res = await request(app)
+      .post('/api/admin/scraping-schedules')
+      .set('Authorization', `Bearer ${superAdminToken}`)
+      .send({
+        name,
+        store: 'revolico',
+        cron: '0 6 * * *',
+        enabled: true,
+        jobs: [{ category: 'celulares' }],
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.status).toBe('success');
+    expect(res.body.message).toBe('Scraping schedule created');
+    expect(res.body.data.schedule).toBeDefined();
+
+    const s = res.body.data.schedule;
+    expect(s.id).toMatch(/^[0-9a-f-]{36}$/i);
+    expect(s.name).toBe(name);
+    expect(s.store).toBe('revolico');
+    expect(s.cron).toBe('0 6 * * *');
+    expect(s.enabled).toBe(true);
+    expect(s.jobs).toEqual([{ category: 'celulares' }]);
+    expect(s.lastRunAt).toBeNull();
+    expect(typeof s.createdAt).toBe('string');
+    expect(typeof s.updatedAt).toBe('string');
+
+    // Verify the row landed in PostgreSQL
+    const dbRes = await pgDb.query(`SELECT * FROM "ScrapingSchedule" WHERE "name" = $1`, [name]);
+    expect(dbRes.rows).toHaveLength(1);
+    expect(dbRes.rows[0].enabled).toBe(true);
+  });
+
+  it('defaults enabled to true when omitted', async () => {
+    const name = 'test-schedule-create-noenabled';
+    createdNames.push(name);
+
+    const res = await request(app)
+      .post('/api/admin/scraping-schedules')
+      .set('Authorization', `Bearer ${superAdminToken}`)
+      .send({
+        name,
+        store: 'revolico',
+        cron: '0 6 * * *',
+        jobs: [{ category: 'celulares' }],
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.data.schedule.enabled).toBe(true);
+  });
+
+  it('returns 400 when name is missing', async () => {
+    const res = await request(app)
+      .post('/api/admin/scraping-schedules')
+      .set('Authorization', `Bearer ${superAdminToken}`)
+      .send({
+        store: 'revolico',
+        cron: '0 6 * * *',
+        jobs: [{ category: 'celulares' }],
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.status).toBe('error');
+  });
+
+  it('returns 400 when jobs is an empty array', async () => {
+    const res = await request(app).post('/api/admin/scraping-schedules').set('Authorization', `Bearer ${superAdminToken}`).send({
+      name: 'test-schedule-empty-jobs',
+      store: 'revolico',
+      cron: '0 6 * * *',
+      jobs: [],
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body.status).toBe('error');
+  });
+
+  it('creates a schedule with a non-existent store (no API-layer validation)', async () => {
+    const name = 'test-schedule-unknown-store';
+    createdNames.push(name);
+
+    const res = await request(app)
+      .post('/api/admin/scraping-schedules')
+      .set('Authorization', `Bearer ${superAdminToken}`)
+      .send({
+        name,
+        store: 'non-existent-store',
+        cron: '0 6 * * *',
+        jobs: [{ category: 'test' }],
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.data.schedule.store).toBe('non-existent-store');
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// GET /api/admin/scraping-schedules (list)
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('GET /api/admin/scraping-schedules', () => {
+  beforeAll(async () => {
+    await seedSchedule({ name: 'test-schedule-list-1' });
+    await seedSchedule({ name: 'test-schedule-list-2', enabled: false });
+  });
+
+  afterAll(async () => {
+    await pgDb.query(`DELETE FROM "ScrapingSchedule" WHERE "name" IN ($1, $2)`, ['test-schedule-list-1', 'test-schedule-list-2']);
+  });
+
+  it('rejects unauthenticated requests with 401', async () => {
+    const res = await request(app).get('/api/admin/scraping-schedules');
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects non-SUPER_ADMIN users with 403', async () => {
+    const res = await request(app).get('/api/admin/scraping-schedules').set('Authorization', `Bearer ${memberToken}`);
+    expect(res.status).toBe(403);
+  });
+
+  it('returns all schedules for SUPER_ADMIN', async () => {
+    const res = await request(app).get('/api/admin/scraping-schedules').set('Authorization', `Bearer ${superAdminToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.schedules).toBeInstanceOf(Array);
+    // Filter to only test schedules (seed data may add extra rows)
+    const testSchedules = res.body.data.schedules.filter((s: any) => s.name.startsWith('test-schedule-'));
+    expect(testSchedules).toHaveLength(2);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// GET /api/admin/scraping-schedules/:id
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('GET /api/admin/scraping-schedules/:id', () => {
+  let seededSchedule: Record<string, any>;
+
+  beforeAll(async () => {
+    seededSchedule = await seedSchedule({ name: 'test-schedule-get-by-id' });
+  });
+
+  afterAll(async () => {
+    await pgDb.query(`DELETE FROM "ScrapingSchedule" WHERE "id" = $1`, [seededSchedule.id]);
+  });
+
+  it('returns the schedule when it exists', async () => {
+    const res = await request(app)
+      .get(`/api/admin/scraping-schedules/${seededSchedule.id}`)
+      .set('Authorization', `Bearer ${superAdminToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.schedule.id).toBe(seededSchedule.id);
+    expect(res.body.data.schedule.name).toBe(seededSchedule.name);
+    expect(res.body.data.schedule.store).toBe(seededSchedule.store);
+    expect(res.body.data.schedule.cron).toBe(seededSchedule.cron);
+  });
+
+  it('returns 404 when the id does not exist', async () => {
+    const fakeId = uuidv4();
+    const res = await request(app).get(`/api/admin/scraping-schedules/${fakeId}`).set('Authorization', `Bearer ${superAdminToken}`);
+
+    expect(res.status).toBe(404);
+    expect(res.body.message).toContain(fakeId);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// PUT /api/admin/scraping-schedules/:id
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('PUT /api/admin/scraping-schedules/:id', () => {
+  let seededSchedule: Record<string, any>;
+
+  beforeAll(async () => {
+    seededSchedule = await seedSchedule({ name: 'test-schedule-update' });
+  });
+
+  afterAll(async () => {
+    await pgDb.query(`DELETE FROM "ScrapingSchedule" WHERE "id" = $1`, [seededSchedule.id]);
+  });
+
+  it('updates the name and the response reflects the change', async () => {
+    const newName = 'test-schedule-updated-name';
+    const res = await request(app)
+      .put(`/api/admin/scraping-schedules/${seededSchedule.id}`)
+      .set('Authorization', `Bearer ${superAdminToken}`)
+      .send({ name: newName });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.schedule.name).toBe(newName);
+
+    // Verify the change persisted in PostgreSQL
+    const dbRes = await pgDb.query(`SELECT "name" FROM "ScrapingSchedule" WHERE "id" = $1`, [seededSchedule.id]);
+    expect(dbRes.rows[0].name).toBe(newName);
+  });
+
+  it('returns 404 when the id does not exist', async () => {
+    const fakeId = uuidv4();
+    const res = await request(app)
+      .put(`/api/admin/scraping-schedules/${fakeId}`)
+      .set('Authorization', `Bearer ${superAdminToken}`)
+      .send({ name: 'whatever' });
+
+    expect(res.status).toBe(404);
+    expect(res.body.message).toContain(fakeId);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// DELETE /api/admin/scraping-schedules/:id
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('DELETE /api/admin/scraping-schedules/:id', () => {
+  let seededId: string;
+
+  beforeAll(async () => {
+    const s = await seedSchedule({ name: 'test-schedule-delete' });
+    seededId = s.id;
+  });
+
+  afterAll(async () => {
+    // Safety net — the test below should have deleted it, but if it failed
+    // mid-way, make sure the row is removed anyway.
+    await pgDb.query(`DELETE FROM "ScrapingSchedule" WHERE "id" = $1`, [seededId]);
+  });
+
+  it('deletes the schedule and removes it from the DB', async () => {
+    const res = await request(app).delete(`/api/admin/scraping-schedules/${seededId}`).set('Authorization', `Bearer ${superAdminToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.message).toBe('http:deleted');
+
+    // Verify the row is gone from PostgreSQL
+    const dbRes = await pgDb.query(`SELECT * FROM "ScrapingSchedule" WHERE "id" = $1`, [seededId]);
+    expect(dbRes.rows).toHaveLength(0);
+  });
+
+  it('returns 404 when the id does not exist', async () => {
+    const fakeId = uuidv4();
+    const res = await request(app).delete(`/api/admin/scraping-schedules/${fakeId}`).set('Authorization', `Bearer ${superAdminToken}`);
+
+    expect(res.status).toBe(404);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// PATCH /api/admin/scraping-schedules/:id/toggle
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('PATCH /api/admin/scraping-schedules/:id/toggle', () => {
+  let seededId: string;
+
+  beforeAll(async () => {
+    const s = await seedSchedule({ name: 'test-schedule-toggle', enabled: true });
+    seededId = s.id;
+  });
+
+  afterAll(async () => {
+    await pgDb.query(`DELETE FROM "ScrapingSchedule" WHERE "id" = $1`, [seededId]);
+  });
+
+  it('toggles enabled from true to false', async () => {
+    const res = await request(app)
+      .patch(`/api/admin/scraping-schedules/${seededId}/toggle`)
+      .set('Authorization', `Bearer ${superAdminToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.schedule.enabled).toBe(false);
+  });
+
+  it('toggles enabled from false back to true', async () => {
+    const res = await request(app)
+      .patch(`/api/admin/scraping-schedules/${seededId}/toggle`)
+      .set('Authorization', `Bearer ${superAdminToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.schedule.enabled).toBe(true);
+  });
+
+  it('returns 404 when the id does not exist', async () => {
+    const fakeId = uuidv4();
+    const res = await request(app)
+      .patch(`/api/admin/scraping-schedules/${fakeId}/toggle`)
+      .set('Authorization', `Bearer ${superAdminToken}`);
+
+    expect(res.status).toBe(404);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// GET /api/admin/stores
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('GET /api/admin/stores', () => {
+  it('rejects non-SUPER_ADMIN with 403', async () => {
+    const res = await request(app).get('/api/admin/stores').set('Authorization', `Bearer ${memberToken}`);
+    expect(res.status).toBe(403);
+  });
+
+  it('returns registered stores including revolico with expected shape', async () => {
+    const res = await request(app).get('/api/admin/stores').set('Authorization', `Bearer ${superAdminToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.stores).toBeInstanceOf(Array);
+
+    const revolico = res.body.data.stores.find((s: any) => s.key === 'revolico');
+    expect(revolico).toBeDefined();
+    expect(revolico.displayName).toBe('Revolico');
+    expect(revolico.scrapingQueue).toBe('PRODUCTS_SCRAPING');
+    expect(revolico.jobSchema).toBeDefined();
+    expect(revolico.jobSchema.fields).toBeInstanceOf(Array);
+    expect(revolico.jobSchema.fields.length).toBeGreaterThan(0);
+
+    // Verify field schema shape
+    const firstField = revolico.jobSchema.fields[0];
+    expect(firstField).toMatchObject({
+      name: expect.any(String),
+      type: expect.stringMatching(/^(string|number|boolean)$/),
+      required: expect.any(Boolean),
+      label: expect.any(String),
+    });
+  });
+});

--- a/src/__tests__/unit/cron/create-schedule.dto.test.ts
+++ b/src/__tests__/unit/cron/create-schedule.dto.test.ts
@@ -1,0 +1,160 @@
+import { CreateScheduleDTO } from '@cron/services/dto/create-schedule.dto';
+import { ValidationError } from '@shared/errors/validation.error';
+
+describe('CreateScheduleDTO', () => {
+  describe('from', () => {
+    it('should create a DTO with valid body containing all fields', () => {
+      const body = {
+        name: 'Daily Revolico Check',
+        store: 'revolico',
+        cron: '0 8 * * *',
+        enabled: true,
+        jobs: [{ category: 'electronics' }, { category: 'vehicles' }],
+      };
+
+      const dto = CreateScheduleDTO.from(body);
+
+      expect(dto).toBeInstanceOf(CreateScheduleDTO);
+      expect(dto.name).toBe('Daily Revolico Check');
+      expect(dto.store).toBe('revolico');
+      expect(dto.cron).toBe('0 8 * * *');
+      expect(dto.enabled).toBe(true);
+      expect(dto.jobs).toHaveLength(2);
+      expect(dto.jobs[0]).toEqual({ category: 'electronics' });
+      expect(dto.jobs[1]).toEqual({ category: 'vehicles' });
+    });
+
+    it('should default enabled to true when omitted', () => {
+      const body = {
+        name: 'Weekend Scan',
+        store: 'revolico',
+        cron: '0 10 * * 6',
+        jobs: [{ category: 'all' }],
+      };
+
+      const dto = CreateScheduleDTO.from(body);
+
+      expect(dto.enabled).toBe(true);
+    });
+
+    it('should throw ValidationError when name is missing', () => {
+      const body = {
+        store: 'revolico',
+        cron: '0 * * * *',
+        jobs: [{ category: 'test' }],
+      };
+
+      expect(() => CreateScheduleDTO.from(body)).toThrow(ValidationError);
+    });
+
+    it('should throw ValidationError when store is missing', () => {
+      const body = {
+        name: 'Test',
+        cron: '0 * * * *',
+        jobs: [{ category: 'test' }],
+      };
+
+      let error: unknown;
+      try {
+        CreateScheduleDTO.from(body);
+      } catch (e) {
+        error = e;
+      }
+
+      expect(error).toBeInstanceOf(ValidationError);
+      const validationError = error as ValidationError;
+      expect(validationError.validationErrors).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: 'invalid_type',
+            message: 'Required',
+            path: ['store'],
+          }),
+        ]),
+      );
+    });
+
+    it('should throw ValidationError when cron is empty string', () => {
+      const body = {
+        name: 'Test',
+        store: 'revolico',
+        cron: '',
+        jobs: [{ category: 'test' }],
+      };
+
+      let error: unknown;
+      try {
+        CreateScheduleDTO.from(body);
+      } catch (e) {
+        error = e;
+      }
+
+      expect(error).toBeInstanceOf(ValidationError);
+      const validationError = error as ValidationError;
+      expect(validationError.validationErrors).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            message: 'Cron expression is required',
+            path: ['cron'],
+          }),
+        ]),
+      );
+    });
+
+    it('should throw ValidationError when jobs array is empty', () => {
+      const body = {
+        name: 'Test',
+        store: 'revolico',
+        cron: '0 * * * *',
+        jobs: [],
+      };
+
+      expect(() => CreateScheduleDTO.from(body)).toThrow(ValidationError);
+    });
+
+    it('should accept jobs with extra fields beyond category', () => {
+      const body = {
+        name: 'Deep Scan',
+        store: 'revolico',
+        cron: '30 */4 * * *',
+        jobs: [{ category: 'electronics', subcategory: 'laptops', pageNumber: 3 }],
+      };
+
+      const dto = CreateScheduleDTO.from(body);
+
+      expect(dto.jobs).toHaveLength(1);
+      expect(dto.jobs[0]).toEqual({
+        category: 'electronics',
+        subcategory: 'laptops',
+        pageNumber: 3,
+      });
+    });
+
+    it('should throw ValidationError when jobs is a string instead of an array', () => {
+      const body = {
+        name: 'Test',
+        store: 'revolico',
+        cron: '0 * * * *',
+        jobs: 'not-an-array',
+      };
+
+      let error: unknown;
+      try {
+        CreateScheduleDTO.from(body);
+      } catch (e) {
+        error = e;
+      }
+
+      expect(error).toBeInstanceOf(ValidationError);
+      const validationError = error as ValidationError;
+      expect(validationError.validationErrors).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: 'invalid_type',
+            path: ['jobs'],
+          }),
+        ]),
+      );
+    });
+  });
+});

--- a/src/__tests__/unit/cron/schedule.controller.test.ts
+++ b/src/__tests__/unit/cron/schedule.controller.test.ts
@@ -1,0 +1,397 @@
+import 'reflect-metadata';
+import { Request, Response } from 'express';
+import { ScheduleController, StoreInfoController } from '@cron/controllers/schedule.controller';
+import { ScheduleNotFoundError } from '@cron/errors';
+import { IScheduleResponseDTO } from '@cron/mappers';
+
+// ===========================================================================
+// ScheduleController
+// ===========================================================================
+
+describe('ScheduleController', () => {
+  let controller: ScheduleController;
+  let serviceMock: Record<string, jest.Mock>;
+
+  let loggerMock: Record<string, any>;
+  let req: Partial<Request>;
+  let res: Partial<Response>;
+
+  /** Stub schedule response DTO shape */
+  const sampleSchedule: IScheduleResponseDTO = {
+    id: 'sched-1',
+    name: 'Daily Revolico Check',
+    store: 'revolico',
+    cron: '0 8 * * *',
+    enabled: true,
+    jobs: [{ category: 'electronics' }],
+    lastRunAt: null,
+    createdAt: '2025-06-01T00:00:00.000Z',
+    updatedAt: '2025-06-01T00:00:00.000Z',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    serviceMock = {
+      list: jest.fn(),
+      findOne: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+      toggle: jest.fn(),
+    };
+
+    loggerMock = {
+      context: '',
+      info: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn(),
+      log: jest.fn(),
+    };
+
+    controller = new ScheduleController(serviceMock as any, loggerMock as any);
+
+    res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    };
+  });
+
+  // =========================================================================
+  // list
+  // =========================================================================
+  describe('list', () => {
+    it('returns 200 with schedules array', async () => {
+      const schedules = [sampleSchedule];
+      serviceMock.list.mockResolvedValue(schedules);
+
+      await controller.list(res as Response);
+
+      expect(serviceMock.list).toHaveBeenCalledTimes(1);
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'success',
+          data: { schedules },
+        }),
+      );
+    });
+
+    it('returns 500 when service.list throws', async () => {
+      serviceMock.list.mockRejectedValue(new Error('DB error'));
+
+      await controller.list(res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'error',
+          message: 'Failed to list scraping schedules',
+        }),
+      );
+      expect(loggerMock.error).toHaveBeenCalled();
+    });
+  });
+
+  // =========================================================================
+  // findOne
+  // =========================================================================
+  describe('findOne', () => {
+    it('returns 200 with schedule when found', async () => {
+      req = { params: { id: 'sched-1' } };
+      serviceMock.findOne.mockResolvedValue(sampleSchedule);
+
+      await controller.findOne('sched-1', res as Response);
+
+      expect(serviceMock.findOne).toHaveBeenCalledWith('sched-1');
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'success',
+          data: { schedule: sampleSchedule },
+        }),
+      );
+    });
+
+    it('returns 404 when ScheduleNotFoundError is thrown', async () => {
+      req = { params: { id: 'no-such-id' } };
+      serviceMock.findOne.mockRejectedValue(new ScheduleNotFoundError('no-such-id'));
+
+      await controller.findOne('no-such-id', res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'error',
+          message: expect.stringContaining('no-such-id'),
+        }),
+      );
+    });
+
+    it('returns 500 on unexpected error', async () => {
+      req = { params: { id: 'sched-1' } };
+      serviceMock.findOne.mockRejectedValue(new Error('Unexpected'));
+
+      await controller.findOne('sched-1', res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(loggerMock.error).toHaveBeenCalled();
+    });
+  });
+
+  // =========================================================================
+  // create
+  // =========================================================================
+  describe('create', () => {
+    it('returns 201 with created schedule', async () => {
+      req = {
+        body: {
+          name: 'New Schedule',
+          store: 'revolico',
+          cron: '0 * * * *',
+          enabled: true,
+          jobs: [{ category: 'all' }],
+        },
+      };
+      serviceMock.create.mockResolvedValue(sampleSchedule);
+
+      await controller.create(req as Request, res as Response);
+
+      expect(serviceMock.create).toHaveBeenCalledWith(req.body);
+      expect(res.status).toHaveBeenCalledWith(201);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'success',
+          message: 'Scraping schedule created',
+          data: { schedule: sampleSchedule },
+        }),
+      );
+    });
+
+    it('returns 500 when service.create throws', async () => {
+      req = { body: { name: 'Bad' } };
+      serviceMock.create.mockRejectedValue(new Error('Validation failed'));
+
+      await controller.create(req as Request, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(loggerMock.error).toHaveBeenCalled();
+    });
+  });
+
+  // =========================================================================
+  // update
+  // =========================================================================
+  describe('update', () => {
+    it('returns 200 with updated schedule', async () => {
+      req = {
+        params: { id: 'sched-1' },
+        body: { cron: '0 */2 * * *' },
+      };
+      serviceMock.update.mockResolvedValue({ ...sampleSchedule, cron: '0 */2 * * *' });
+
+      await controller.update('sched-1', req as Request, res as Response);
+
+      expect(serviceMock.update).toHaveBeenCalledWith('sched-1', req.body);
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'success',
+          data: { schedule: { ...sampleSchedule, cron: '0 */2 * * *' } },
+        }),
+      );
+    });
+
+    it('returns 404 when ScheduleNotFoundError is thrown', async () => {
+      req = { params: { id: 'bad-id' }, body: {} };
+      serviceMock.update.mockRejectedValue(new ScheduleNotFoundError('bad-id'));
+
+      await controller.update('bad-id', req as Request, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'error',
+          message: expect.stringContaining('bad-id'),
+        }),
+      );
+    });
+
+    it('returns 500 on unexpected error', async () => {
+      req = { params: { id: 'sched-1' }, body: {} };
+      serviceMock.update.mockRejectedValue(new Error('Unexpected'));
+
+      await controller.update('sched-1', req as Request, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(loggerMock.error).toHaveBeenCalled();
+    });
+  });
+
+  // =========================================================================
+  // delete
+  // =========================================================================
+  describe('delete', () => {
+    it('returns 200 on successful deletion', async () => {
+      req = { params: { id: 'sched-1' } };
+      serviceMock.delete.mockResolvedValue(undefined);
+
+      await controller.delete('sched-1', res as Response);
+
+      expect(serviceMock.delete).toHaveBeenCalledWith('sched-1');
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'success',
+          message: 'http:deleted',
+        }),
+      );
+    });
+
+    it('returns 404 when ScheduleNotFoundError is thrown', async () => {
+      req = { params: { id: 'bad-id' } };
+      serviceMock.delete.mockRejectedValue(new ScheduleNotFoundError('bad-id'));
+
+      await controller.delete('bad-id', res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'error',
+          message: expect.stringContaining('bad-id'),
+        }),
+      );
+    });
+
+    it('returns 500 on unexpected error', async () => {
+      req = { params: { id: 'sched-1' } };
+      serviceMock.delete.mockRejectedValue(new Error('Unexpected'));
+
+      await controller.delete('sched-1', res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(loggerMock.error).toHaveBeenCalled();
+    });
+  });
+
+  // =========================================================================
+  // toggle
+  // =========================================================================
+  describe('toggle', () => {
+    it('returns 200 with toggled schedule', async () => {
+      req = { params: { id: 'sched-1' } };
+      const toggled = { ...sampleSchedule, enabled: false };
+      serviceMock.toggle.mockResolvedValue(toggled);
+
+      await controller.toggle('sched-1', res as Response);
+
+      expect(serviceMock.toggle).toHaveBeenCalledWith('sched-1');
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'success',
+          data: { schedule: toggled },
+        }),
+      );
+    });
+
+    it('returns 404 when ScheduleNotFoundError is thrown', async () => {
+      req = { params: { id: 'bad-id' } };
+      serviceMock.toggle.mockRejectedValue(new ScheduleNotFoundError('bad-id'));
+
+      await controller.toggle('bad-id', res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'error',
+          message: expect.stringContaining('bad-id'),
+        }),
+      );
+    });
+
+    it('returns 500 on unexpected error', async () => {
+      req = { params: { id: 'sched-1' } };
+      serviceMock.toggle.mockRejectedValue(new Error('Unexpected'));
+
+      await controller.toggle('sched-1', res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(loggerMock.error).toHaveBeenCalled();
+    });
+  });
+});
+
+// ===========================================================================
+// StoreInfoController
+// ===========================================================================
+
+describe('StoreInfoController', () => {
+  let controller: StoreInfoController;
+  let storeRegistryMock: Record<string, jest.Mock>;
+  let res: Partial<Response>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    storeRegistryMock = {
+      list: jest.fn(),
+      get: jest.fn(),
+    };
+
+    controller = new StoreInfoController(storeRegistryMock as any);
+
+    res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    };
+  });
+
+  describe('listStores', () => {
+    it('returns 200 with stores list', async () => {
+      const stores = [{ key: 'revolico', displayName: 'Revolico', scrapingQueue: 'revolico-queue', jobSchema: { fields: [] } }];
+      storeRegistryMock.list.mockReturnValue(stores);
+
+      await controller.listStores(res as Response);
+
+      expect(storeRegistryMock.list).toHaveBeenCalledTimes(1);
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'success',
+          data: { stores },
+        }),
+      );
+    });
+
+    it('returns 200 when no stores are registered', async () => {
+      storeRegistryMock.list.mockReturnValue([]);
+
+      await controller.listStores(res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: { stores: [] },
+        }),
+      );
+    });
+
+    it('returns 500 when list() throws', async () => {
+      storeRegistryMock.list.mockImplementation(() => {
+        throw new Error('Registry error');
+      });
+
+      await controller.listStores(res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'error',
+          message: 'Failed to list stores',
+        }),
+      );
+    });
+  });
+});

--- a/src/__tests__/unit/cron/schedule.mapper.test.ts
+++ b/src/__tests__/unit/cron/schedule.mapper.test.ts
@@ -1,0 +1,63 @@
+import { toScheduleResponseDTO } from '@cron/mappers/schedule.mapper';
+import { ScrapingSchedule } from '@prisma/client';
+
+function mockSchedule(overrides: Partial<ScrapingSchedule> = {}): ScrapingSchedule {
+  return {
+    id: '123',
+    name: 'test',
+    store: 'revolico',
+    cron: '0 * * * *',
+    enabled: true,
+    jobs: [{ category: 'test' }],
+    lastRunAt: new Date('2026-01-01'),
+    createdAt: new Date('2026-01-01'),
+    updatedAt: new Date('2026-01-02'),
+    ...overrides,
+  };
+}
+
+describe('toScheduleResponseDTO', () => {
+  it('should map a full model to DTO with ISO date strings', () => {
+    const model = mockSchedule();
+    const dto = toScheduleResponseDTO(model);
+
+    expect(dto.id).toBe('123');
+    expect(dto.name).toBe('test');
+    expect(dto.store).toBe('revolico');
+    expect(dto.cron).toBe('0 * * * *');
+    expect(dto.enabled).toBe(true);
+    expect(dto.jobs).toEqual([{ category: 'test' }]);
+    expect(dto.lastRunAt).toBe('2026-01-01T00:00:00.000Z');
+    expect(dto.createdAt).toBe('2026-01-01T00:00:00.000Z');
+    expect(dto.updatedAt).toBe('2026-01-02T00:00:00.000Z');
+  });
+
+  it('should map lastRunAt as null when model has no last run', () => {
+    const model = mockSchedule({ lastRunAt: null });
+    const dto = toScheduleResponseDTO(model);
+
+    expect(dto.lastRunAt).toBeNull();
+  });
+
+  it('should pass through jobs array as-is', () => {
+    const jobs = [{ category: 'electronics', subcategory: 'laptops', page: 1 }, { category: 'vehicles' }];
+    const model = mockSchedule({ jobs: jobs as unknown as ScrapingSchedule['jobs'] });
+    const dto = toScheduleResponseDTO(model);
+
+    expect(dto.jobs).toEqual(jobs);
+  });
+
+  it('should map enabled as true', () => {
+    const model = mockSchedule({ enabled: true });
+    const dto = toScheduleResponseDTO(model);
+
+    expect(dto.enabled).toBe(true);
+  });
+
+  it('should map enabled as false', () => {
+    const model = mockSchedule({ enabled: false });
+    const dto = toScheduleResponseDTO(model);
+
+    expect(dto.enabled).toBe(false);
+  });
+});

--- a/src/__tests__/unit/cron/schedule.repository.test.ts
+++ b/src/__tests__/unit/cron/schedule.repository.test.ts
@@ -1,0 +1,158 @@
+import 'reflect-metadata';
+import { ScheduleRepository, ICreateScheduleInput, IUpdateScheduleInput } from '@cron/repositories/schedule.repository';
+import { ScrapingSchedule } from '@prisma/client';
+
+describe('ScheduleRepository', () => {
+  let repo: ScheduleRepository;
+  let mockFindMany: jest.Mock;
+  let mockFindUnique: jest.Mock;
+  let mockCreate: jest.Mock;
+  let mockUpdate: jest.Mock;
+  let mockDelete: jest.Mock;
+
+  const now = new Date('2026-07-09T12:00:00Z');
+  const mockSchedule: ScrapingSchedule = {
+    id: 'sched-1',
+    name: 'Test Schedule',
+    store: 'revolico',
+    cron: '*/5 * * * *',
+    enabled: true,
+    jobs: [{ url: 'https://revolico.example.com/page/1' }],
+    lastRunAt: null,
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  const mockScheduleList: ScrapingSchedule[] = [mockSchedule, { ...mockSchedule, id: 'sched-2', name: 'Second Schedule' }];
+
+  beforeEach(() => {
+    mockFindMany = jest.fn();
+    mockFindUnique = jest.fn();
+    mockCreate = jest.fn();
+    mockUpdate = jest.fn();
+    mockDelete = jest.fn();
+
+    const mockPrisma = {
+      scrapingSchedule: {
+        findMany: mockFindMany,
+        findUnique: mockFindUnique,
+        create: mockCreate,
+        update: mockUpdate,
+        delete: mockDelete,
+      },
+    };
+
+    repo = new ScheduleRepository(mockPrisma as any);
+  });
+
+  describe('findAll', () => {
+    it('should call findMany with orderBy createdAt asc and return all schedules', async () => {
+      mockFindMany.mockResolvedValue(mockScheduleList);
+
+      const result = await repo.findAll();
+
+      expect(mockFindMany).toHaveBeenCalledTimes(1);
+      expect(mockFindMany).toHaveBeenCalledWith({ orderBy: { createdAt: 'asc' } });
+      expect(result).toEqual(mockScheduleList);
+      expect(result).toHaveLength(2);
+    });
+  });
+
+  describe('findById', () => {
+    it('should call findUnique with the given id and return the schedule when found', async () => {
+      mockFindUnique.mockResolvedValue(mockSchedule);
+
+      const result = await repo.findById('sched-1');
+
+      expect(mockFindUnique).toHaveBeenCalledTimes(1);
+      expect(mockFindUnique).toHaveBeenCalledWith({ where: { id: 'sched-1' } });
+      expect(result).toEqual(mockSchedule);
+    });
+
+    it('should return null when the schedule is not found', async () => {
+      mockFindUnique.mockResolvedValue(null);
+
+      const result = await repo.findById('nonexistent');
+
+      expect(mockFindUnique).toHaveBeenCalledTimes(1);
+      expect(mockFindUnique).toHaveBeenCalledWith({ where: { id: 'nonexistent' } });
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('create', () => {
+    it('should call create with the input data and return the created schedule', async () => {
+      const input: ICreateScheduleInput = {
+        name: 'New Schedule',
+        store: 'revolico',
+        cron: '0 * * * *',
+        enabled: true,
+        jobs: [{ url: 'https://revolico.example.com/page/1' }],
+      };
+      const created: ScrapingSchedule = {
+        id: 'sched-3',
+        ...input,
+        lastRunAt: null,
+        createdAt: now,
+        updatedAt: now,
+      };
+      mockCreate.mockResolvedValue(created);
+
+      const result = await repo.create(input);
+
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+      expect(mockCreate).toHaveBeenCalledWith({ data: input });
+      expect(result).toEqual(created);
+    });
+  });
+
+  describe('update', () => {
+    it('should call update with the id and data and return the updated schedule', async () => {
+      const updateData: IUpdateScheduleInput = { name: 'Updated Name', enabled: false };
+      const updated: ScrapingSchedule = {
+        ...mockSchedule,
+        name: 'Updated Name',
+        enabled: false,
+        updatedAt: new Date(),
+      };
+      mockUpdate.mockResolvedValue(updated);
+
+      const result = await repo.update('sched-1', updateData);
+
+      expect(mockUpdate).toHaveBeenCalledTimes(1);
+      expect(mockUpdate).toHaveBeenCalledWith({
+        where: { id: 'sched-1' },
+        data: updateData,
+      });
+      expect(result).toEqual(updated);
+    });
+  });
+
+  describe('delete', () => {
+    it('should call delete with the id and resolve', async () => {
+      mockDelete.mockResolvedValue(undefined);
+
+      await repo.delete('sched-1');
+
+      expect(mockDelete).toHaveBeenCalledTimes(1);
+      expect(mockDelete).toHaveBeenCalledWith({ where: { id: 'sched-1' } });
+    });
+  });
+
+  describe('updateLastRunAt', () => {
+    it('should call update with the id and a Date for lastRunAt', async () => {
+      mockUpdate.mockResolvedValue({
+        ...mockSchedule,
+        lastRunAt: new Date(),
+      });
+
+      await repo.updateLastRunAt('sched-1');
+
+      expect(mockUpdate).toHaveBeenCalledTimes(1);
+      expect(mockUpdate).toHaveBeenCalledWith({
+        where: { id: 'sched-1' },
+        data: { lastRunAt: expect.any(Date) },
+      });
+    });
+  });
+});

--- a/src/__tests__/unit/cron/schedule.service.test.ts
+++ b/src/__tests__/unit/cron/schedule.service.test.ts
@@ -1,0 +1,293 @@
+import 'reflect-metadata';
+import { ScheduleService } from '@cron/services/schedule.service';
+import { ScheduleRepository } from '@cron/repositories/schedule.repository';
+import { CronSchedulerService } from '@cron/services/scheduler.service';
+import { CreateScheduleDTO, UpdateScheduleDTO } from '@cron/services/dto';
+import { ScheduleNotFoundError } from '@cron/errors';
+import { IScheduleResponseDTO } from '@cron/mappers';
+import { ScrapingSchedule, Prisma } from '@prisma/client';
+
+describe('ScheduleService', () => {
+  let service: ScheduleService;
+  let mockRepo: jest.Mocked<Pick<ScheduleRepository, 'findAll' | 'findById' | 'create' | 'update' | 'delete'>>;
+  let mockScheduler: jest.Mocked<Pick<CronSchedulerService, 'register' | 'unregister'>>;
+  let mockLogger: { info: jest.Mock; debug: jest.Mock; error: jest.Mock; warn: jest.Mock; context: string };
+
+  const now = new Date('2026-07-09T12:00:00Z');
+
+  const mockSchedule: ScrapingSchedule = {
+    id: 'sched-1',
+    name: 'Test Schedule',
+    store: 'revolico',
+    cron: '*/5 * * * *',
+    enabled: true,
+    jobs: [{ url: 'https://revolico.example.com/page/1' }],
+    lastRunAt: null,
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  const mockScheduleList: ScrapingSchedule[] = [mockSchedule, { ...mockSchedule, id: 'sched-2', name: 'Second Schedule' }];
+
+  beforeEach(() => {
+    mockRepo = {
+      findAll: jest.fn(),
+      findById: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    };
+
+    mockScheduler = {
+      register: jest.fn(),
+      unregister: jest.fn(),
+    };
+
+    mockLogger = {
+      info: jest.fn(),
+      debug: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+      context: '',
+    };
+
+    service = new ScheduleService(
+      mockRepo as unknown as ScheduleRepository,
+      mockScheduler as unknown as CronSchedulerService,
+      mockLogger as any,
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // list
+  // ---------------------------------------------------------------------------
+  describe('list', () => {
+    it('should call repo.findAll and map each result to a response DTO', async () => {
+      mockRepo.findAll.mockResolvedValue(mockScheduleList);
+
+      const result = await service.list();
+
+      expect(mockRepo.findAll).toHaveBeenCalledTimes(1);
+      expect(result).toHaveLength(2);
+      expect(result[0]).toMatchObject<Partial<IScheduleResponseDTO>>({
+        id: 'sched-1',
+        name: 'Test Schedule',
+        store: 'revolico',
+        enabled: true,
+      });
+      expect(result[1]).toMatchObject<Partial<IScheduleResponseDTO>>({
+        id: 'sched-2',
+        name: 'Second Schedule',
+      });
+      expect(result[0].createdAt).toBe('2026-07-09T12:00:00.000Z');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // findOne
+  // ---------------------------------------------------------------------------
+  describe('findOne', () => {
+    it('should call repo.findById and return the mapped DTO when found', async () => {
+      mockRepo.findById.mockResolvedValue(mockSchedule);
+
+      const result = await service.findOne('sched-1');
+
+      expect(mockRepo.findById).toHaveBeenCalledTimes(1);
+      expect(mockRepo.findById).toHaveBeenCalledWith('sched-1');
+      expect(result).toMatchObject<Partial<IScheduleResponseDTO>>({
+        id: 'sched-1',
+        name: 'Test Schedule',
+        cron: '*/5 * * * *',
+      });
+    });
+
+    it('should throw ScheduleNotFoundError when the schedule does not exist', async () => {
+      mockRepo.findById.mockResolvedValue(null);
+
+      await expect(service.findOne('nonexistent')).rejects.toThrow(ScheduleNotFoundError);
+      await expect(service.findOne('nonexistent')).rejects.toThrow('Scraping schedule not found for id="nonexistent"');
+      expect(mockRepo.findById).toHaveBeenCalledWith('nonexistent');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // create
+  // ---------------------------------------------------------------------------
+  describe('create', () => {
+    it('should call repo.create and scheduler.register, then return the mapped DTO', async () => {
+      const dto = CreateScheduleDTO.from({
+        name: 'New Schedule',
+        store: 'revolico',
+        cron: '0 * * * *',
+        enabled: true,
+        jobs: [{ url: 'https://revolico.example.com/page/1' }],
+      });
+
+      const created = {
+        id: 'sched-3',
+        name: dto.name,
+        store: dto.store,
+        cron: dto.cron,
+        enabled: dto.enabled,
+        jobs: dto.jobs as Prisma.JsonValue,
+        lastRunAt: null,
+        createdAt: now,
+        updatedAt: now,
+      } as ScrapingSchedule;
+      mockRepo.create.mockResolvedValue(created);
+
+      const result = await service.create(dto);
+
+      expect(mockRepo.create).toHaveBeenCalledTimes(1);
+      expect(mockRepo.create).toHaveBeenCalledWith({
+        name: 'New Schedule',
+        store: 'revolico',
+        cron: '0 * * * *',
+        enabled: true,
+        jobs: [{ url: 'https://revolico.example.com/page/1' }],
+      });
+      expect(mockScheduler.register).toHaveBeenCalledTimes(1);
+      expect(mockScheduler.register).toHaveBeenCalledWith(created);
+      expect(mockLogger.info).toHaveBeenCalledWith('Scraping schedule created', {
+        scheduleId: 'sched-3',
+        store: 'revolico',
+        cron: '0 * * * *',
+        enabled: true,
+      });
+      expect(result).toMatchObject<Partial<IScheduleResponseDTO>>({
+        id: 'sched-3',
+        name: 'New Schedule',
+        store: 'revolico',
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // update
+  // ---------------------------------------------------------------------------
+  describe('update', () => {
+    it('should check existence, call repo.update and scheduler.register, then return the mapped DTO', async () => {
+      mockRepo.findById.mockResolvedValue(mockSchedule);
+
+      const dto = UpdateScheduleDTO.from({ name: 'Updated Name', enabled: false });
+      const updated: ScrapingSchedule = {
+        ...mockSchedule,
+        name: 'Updated Name',
+        enabled: false,
+        updatedAt: new Date(),
+      };
+      mockRepo.update.mockResolvedValue(updated);
+
+      const result = await service.update('sched-1', dto);
+
+      expect(mockRepo.findById).toHaveBeenCalledWith('sched-1');
+      expect(mockRepo.update).toHaveBeenCalledWith('sched-1', {
+        name: 'Updated Name',
+        enabled: false,
+      });
+      expect(mockScheduler.register).toHaveBeenCalledWith(updated);
+      expect(mockLogger.info).toHaveBeenCalledWith('Scraping schedule updated', {
+        scheduleId: 'sched-1',
+        changes: ['name', 'enabled'],
+      });
+      expect(result).toMatchObject<Partial<IScheduleResponseDTO>>({
+        id: 'sched-1',
+        name: 'Updated Name',
+        enabled: false,
+      });
+    });
+
+    it('should throw ScheduleNotFoundError when the schedule does not exist', async () => {
+      mockRepo.findById.mockResolvedValue(null);
+
+      const dto = UpdateScheduleDTO.from({ name: 'Updated Name' });
+
+      await expect(service.update('nonexistent', dto)).rejects.toThrow(ScheduleNotFoundError);
+      expect(mockRepo.findById).toHaveBeenCalledWith('nonexistent');
+      expect(mockRepo.update).not.toHaveBeenCalled();
+      expect(mockScheduler.register).not.toHaveBeenCalled();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // delete
+  // ---------------------------------------------------------------------------
+  describe('delete', () => {
+    it('should check existence, call repo.delete and scheduler.unregister', async () => {
+      mockRepo.findById.mockResolvedValue(mockSchedule);
+      mockRepo.delete.mockResolvedValue(undefined);
+
+      await service.delete('sched-1');
+
+      expect(mockRepo.findById).toHaveBeenCalledWith('sched-1');
+      expect(mockRepo.delete).toHaveBeenCalledWith('sched-1');
+      expect(mockScheduler.unregister).toHaveBeenCalledWith('sched-1');
+      expect(mockLogger.info).toHaveBeenCalledWith('Scraping schedule deleted', {
+        scheduleId: 'sched-1',
+      });
+    });
+
+    it('should throw ScheduleNotFoundError when the schedule does not exist', async () => {
+      mockRepo.findById.mockResolvedValue(null);
+
+      await expect(service.delete('nonexistent')).rejects.toThrow(ScheduleNotFoundError);
+      expect(mockRepo.findById).toHaveBeenCalledWith('nonexistent');
+      expect(mockRepo.delete).not.toHaveBeenCalled();
+      expect(mockScheduler.unregister).not.toHaveBeenCalled();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // toggle
+  // ---------------------------------------------------------------------------
+  describe('toggle', () => {
+    it('should flip enabled from true to false, call repo.update and scheduler.register', async () => {
+      const enabledSchedule: ScrapingSchedule = { ...mockSchedule, enabled: true };
+      mockRepo.findById.mockResolvedValue(enabledSchedule);
+
+      const updated: ScrapingSchedule = { ...mockSchedule, enabled: false, updatedAt: new Date() };
+      mockRepo.update.mockResolvedValue(updated);
+
+      const result = await service.toggle('sched-1');
+
+      expect(mockRepo.findById).toHaveBeenCalledWith('sched-1');
+      expect(mockRepo.update).toHaveBeenCalledWith('sched-1', { enabled: false });
+      expect(mockScheduler.register).toHaveBeenCalledWith(updated);
+      expect(mockLogger.info).toHaveBeenCalledWith('Scraping schedule toggled', {
+        scheduleId: 'sched-1',
+        enabled: false,
+      });
+      expect(result).toMatchObject<Partial<IScheduleResponseDTO>>({
+        id: 'sched-1',
+        enabled: false,
+      });
+    });
+
+    it('should flip enabled from false to true, call repo.update and scheduler.register', async () => {
+      const disabledSchedule: ScrapingSchedule = { ...mockSchedule, enabled: false };
+      mockRepo.findById.mockResolvedValue(disabledSchedule);
+
+      const updated: ScrapingSchedule = { ...mockSchedule, enabled: true, updatedAt: new Date() };
+      mockRepo.update.mockResolvedValue(updated);
+
+      const result = await service.toggle('sched-1');
+
+      expect(mockRepo.findById).toHaveBeenCalledWith('sched-1');
+      expect(mockRepo.update).toHaveBeenCalledWith('sched-1', { enabled: true });
+      expect(mockScheduler.register).toHaveBeenCalledWith(updated);
+      expect(result).toMatchObject<Partial<IScheduleResponseDTO>>({
+        id: 'sched-1',
+        enabled: true,
+      });
+    });
+
+    it('should throw ScheduleNotFoundError when the schedule does not exist', async () => {
+      mockRepo.findById.mockResolvedValue(null);
+
+      await expect(service.toggle('nonexistent')).rejects.toThrow(ScheduleNotFoundError);
+      expect(mockRepo.findById).toHaveBeenCalledWith('nonexistent');
+      expect(mockRepo.update).not.toHaveBeenCalled();
+      expect(mockScheduler.register).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/__tests__/unit/cron/scheduler.service.test.ts
+++ b/src/__tests__/unit/cron/scheduler.service.test.ts
@@ -1,0 +1,315 @@
+import 'reflect-metadata';
+import { CronSchedulerService } from '@cron/services/scheduler.service';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+jest.mock('node-cron', () => {
+  const schedule = jest.fn().mockReturnValue({ start: jest.fn(), stop: jest.fn() });
+  return {
+    __esModule: true,
+    default: { schedule },
+  };
+});
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const mockNodeCron = require('node-cron');
+const mockSchedule = mockNodeCron.default.schedule;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates a minimal ScrapingSchedule-shaped object for testing.
+ * Override any field by passing an `overrides` map.
+ */
+function mockScheduleModel(overrides: Record<string, unknown> = {}): any {
+  return {
+    id: 'sched-1',
+    name: 'Test Schedule',
+    store: 'revolico',
+    cron: '0 */6 * * *',
+    enabled: true,
+    jobs: [{ category: 'electronics' }],
+    lastRunAt: null,
+    createdAt: new Date('2025-06-01T00:00:00.000Z'),
+    updatedAt: new Date('2025-06-01T00:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+
+describe('CronSchedulerService', () => {
+  let scheduler: CronSchedulerService;
+
+  let logger: Record<string, any>;
+  let repo: Record<string, jest.Mock>;
+  let storeRegistry: Record<string, jest.Mock>;
+  let qContext: Record<string, jest.Mock>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Restore default return value for mockSchedule after clearAllMocks
+    mockSchedule.mockReturnValue({ start: jest.fn(), stop: jest.fn() });
+
+    logger = {
+      context: '',
+      info: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn(),
+      log: jest.fn(),
+    };
+
+    repo = {
+      findAll: jest.fn().mockResolvedValue([]),
+      updateLastRunAt: jest.fn().mockResolvedValue(undefined),
+    };
+
+    storeRegistry = {
+      get: jest.fn(),
+      list: jest.fn(),
+    };
+
+    qContext = {
+      enqueue: jest.fn().mockResolvedValue('job-id-1'),
+    };
+
+    scheduler = new CronSchedulerService(logger as any, repo as any, storeRegistry as any, qContext as any);
+  });
+
+  // ===========================================================================
+  // initialize
+  // ===========================================================================
+  describe('initialize', () => {
+    it('calls repo.findAll and registers each enabled schedule', async () => {
+      const s1 = mockScheduleModel({ id: 's-1', name: 'Alpha', cron: '0 * * * *' });
+      const s2 = mockScheduleModel({ id: 's-2', name: 'Beta', cron: '*/5 * * * *' });
+      repo.findAll.mockResolvedValue([s1, s2]);
+
+      await scheduler.initialize();
+
+      expect(repo.findAll).toHaveBeenCalledTimes(1);
+      expect(mockSchedule).toHaveBeenCalledTimes(2);
+      expect(mockSchedule).toHaveBeenCalledWith(s1.cron, expect.any(Function), { scheduled: true });
+      expect(mockSchedule).toHaveBeenCalledWith(s2.cron, expect.any(Function), { scheduled: true });
+    });
+
+    it('skips disabled schedules and does not register them', async () => {
+      const enabled = mockScheduleModel({ id: 's-1', name: 'Active', cron: '0 * * * *' });
+      const disabled = mockScheduleModel({ id: 's-2', name: 'Inactive', enabled: false, cron: '0 0 * * *' });
+      repo.findAll.mockResolvedValue([enabled, disabled]);
+
+      await scheduler.initialize();
+
+      expect(mockSchedule).toHaveBeenCalledTimes(1);
+      expect(mockSchedule).toHaveBeenCalledWith(enabled.cron, expect.any(Function), { scheduled: true });
+      expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('Inactive'));
+    });
+  });
+
+  // ===========================================================================
+  // register — enabled schedule
+  // ===========================================================================
+  describe('register (enabled)', () => {
+    it('calls cron.schedule and stores the task', () => {
+      const schedule = mockScheduleModel();
+
+      scheduler.register(schedule);
+
+      expect(mockSchedule).toHaveBeenCalledTimes(1);
+      expect(mockSchedule).toHaveBeenCalledWith(schedule.cron, expect.any(Function), { scheduled: true });
+    });
+
+    it('stops any existing task for the same id before registering', () => {
+      const existingTask = { start: jest.fn(), stop: jest.fn() };
+      mockSchedule.mockReturnValueOnce(existingTask);
+      scheduler.register(mockScheduleModel({ id: 's-1' }));
+
+      const newTask = { start: jest.fn(), stop: jest.fn() };
+      mockSchedule.mockReturnValueOnce(newTask);
+      scheduler.register(mockScheduleModel({ id: 's-1', cron: '0 0 * * *' }));
+
+      // First task should have been stopped before second registration
+      expect(existingTask.stop).toHaveBeenCalledTimes(1);
+      // cron.schedule should have been called twice
+      expect(mockSchedule).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // ===========================================================================
+  // register — disabled schedule
+  // ===========================================================================
+  describe('register (disabled)', () => {
+    it('unregisters existing task and does NOT create a new cron task', () => {
+      const existingTask = { start: jest.fn(), stop: jest.fn() };
+      mockSchedule.mockReturnValueOnce(existingTask);
+      // Register initially as enabled
+      scheduler.register(mockScheduleModel({ id: 's-1' }));
+
+      // Now register as disabled — should unregister the existing task & skip
+      mockSchedule.mockClear();
+      scheduler.register(mockScheduleModel({ id: 's-1', enabled: false }));
+
+      expect(existingTask.stop).toHaveBeenCalledTimes(1);
+      expect(mockSchedule).not.toHaveBeenCalled();
+      expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('disabled'));
+    });
+  });
+
+  // ===========================================================================
+  // register — invalid cron expression
+  // ===========================================================================
+  describe('register (invalid cron)', () => {
+    it('catches the error, logs it, and does not throw', () => {
+      mockSchedule.mockImplementationOnce(() => {
+        throw new Error('Invalid cron expression');
+      });
+
+      const schedule = mockScheduleModel({ id: 's-2', name: 'Broken' });
+      scheduler.register(schedule);
+
+      expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('invalid cron expression'), expect.any(Error));
+    });
+  });
+
+  // ===========================================================================
+  // unregister
+  // ===========================================================================
+  describe('unregister', () => {
+    it('stops and removes an existing task', () => {
+      const task = { start: jest.fn(), stop: jest.fn() };
+      mockSchedule.mockReturnValueOnce(task);
+      scheduler.register(mockScheduleModel({ id: 's-1' }));
+
+      scheduler.unregister('s-1');
+
+      expect(task.stop).toHaveBeenCalledTimes(1);
+      // Calling unregister again should be a no-op (task already removed)
+      jest.clearAllMocks();
+      task.stop = jest.fn();
+      scheduler.unregister('s-1');
+      expect(task.stop).not.toHaveBeenCalled();
+    });
+
+    it('is a no-op for an unknown id', () => {
+      // Should not throw
+      expect(() => scheduler.unregister('non-existent')).not.toThrow();
+    });
+  });
+
+  // ===========================================================================
+  // shutdown
+  // ===========================================================================
+  describe('shutdown', () => {
+    it('stops all running tasks and clears the internal map', () => {
+      const task1 = { start: jest.fn(), stop: jest.fn() };
+      const task2 = { start: jest.fn(), stop: jest.fn() };
+      mockSchedule.mockReturnValueOnce(task1).mockReturnValueOnce(task2);
+
+      scheduler.register(mockScheduleModel({ id: 's-1' }));
+      scheduler.register(mockScheduleModel({ id: 's-2' }));
+
+      // Re-invoke shutdown twice to prove idempotency
+      scheduler.shutdown();
+      scheduler.shutdown();
+
+      expect(task1.stop).toHaveBeenCalledTimes(1);
+      expect(task2.stop).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ===========================================================================
+  // _onTick — happy path
+  // ===========================================================================
+  describe('_onTick (happy path)', () => {
+    it('resolves store, enqueues each job, and updates lastRunAt', async () => {
+      const schedule = mockScheduleModel({
+        jobs: [{ category: 'electronics' }, { category: 'vehicles' }],
+      });
+
+      storeRegistry.get.mockReturnValue({ scrapingQueue: 'revolico-queue' });
+
+      // Register so the cron callback is captured, then invoke it
+      scheduler.register(schedule);
+      const onTickCb = mockSchedule.mock.calls[0][1];
+      await onTickCb();
+
+      expect(storeRegistry.get).toHaveBeenCalledWith('revolico');
+      expect(qContext.enqueue).toHaveBeenCalledTimes(2);
+      expect(qContext.enqueue).toHaveBeenCalledWith('revolico-queue', { category: 'electronics' }, { attempts: 2, backoff: 5000 });
+      expect(qContext.enqueue).toHaveBeenCalledWith('revolico-queue', { category: 'vehicles' }, { attempts: 2, backoff: 5000 });
+      expect(repo.updateLastRunAt).toHaveBeenCalledWith(schedule.id);
+    });
+  });
+
+  // ===========================================================================
+  // _onTick — job failure isolation
+  // ===========================================================================
+  describe('_onTick (error isolation)', () => {
+    it('does not block subsequent jobs when one enqueue fails', async () => {
+      const schedule = mockScheduleModel({
+        jobs: [{ category: 'electronics' }, { category: 'vehicles' }, { category: 'furniture' }],
+      });
+
+      storeRegistry.get.mockReturnValue({ scrapingQueue: 'revolico-queue' });
+      qContext.enqueue.mockResolvedValueOnce('ok').mockRejectedValueOnce(new Error('Queue full')).mockResolvedValueOnce('ok');
+
+      scheduler.register(schedule);
+      const onTickCb = mockSchedule.mock.calls[0][1];
+      await onTickCb();
+
+      // 3 enqueue calls were attempted
+      expect(qContext.enqueue).toHaveBeenCalledTimes(3);
+      // The error was logged
+      expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('Failed to enqueue job #1'), expect.any(Error));
+      // lastRunAt was still updated (error is isolated to the failing job)
+      expect(repo.updateLastRunAt).toHaveBeenCalledWith(schedule.id);
+    });
+  });
+
+  // ===========================================================================
+  // _onTick — unknown store
+  // ===========================================================================
+  describe('_onTick (unknown store)', () => {
+    it('logs an error and returns early without enqueuing', async () => {
+      const schedule = mockScheduleModel({ store: 'unknown-store' });
+
+      storeRegistry.get.mockImplementation(() => {
+        throw new Error('Unknown store: "unknown-store"');
+      });
+
+      scheduler.register(schedule);
+      const onTickCb = mockSchedule.mock.calls[0][1];
+      await onTickCb();
+
+      expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('unknown store'), expect.any(Error));
+      expect(qContext.enqueue).not.toHaveBeenCalled();
+      expect(repo.updateLastRunAt).not.toHaveBeenCalled();
+    });
+  });
+
+  // ===========================================================================
+  // _onTick — updateLastRunAt failure silently swallowed
+  // ===========================================================================
+  describe('_onTick (updateLastRunAt failure)', () => {
+    it('swallows the error and does not affect job enqueuing', async () => {
+      const schedule = mockScheduleModel();
+      storeRegistry.get.mockReturnValue({ scrapingQueue: 'revolico-queue' });
+      repo.updateLastRunAt.mockRejectedValue(new Error('DB timeout'));
+
+      scheduler.register(schedule);
+      const onTickCb = mockSchedule.mock.calls[0][1];
+      await onTickCb();
+
+      // Jobs were enqueued despite the DB failure
+      expect(qContext.enqueue).toHaveBeenCalledTimes(1);
+      // The error from updateLastRunAt is silently swallowed (no log.error)
+      expect(logger.error).not.toHaveBeenCalledWith(expect.stringContaining('DB timeout'), expect.anything());
+    });
+  });
+});

--- a/src/__tests__/unit/cron/scheduler.service.test.ts
+++ b/src/__tests__/unit/cron/scheduler.service.test.ts
@@ -5,17 +5,12 @@ import { CronSchedulerService } from '@cron/services/scheduler.service';
 // Mocks
 // ---------------------------------------------------------------------------
 
-jest.mock('node-cron', () => {
-  const schedule = jest.fn().mockReturnValue({ start: jest.fn(), stop: jest.fn() });
-  return {
-    __esModule: true,
-    default: { schedule },
-  };
-});
+jest.mock('node-cron', () => ({
+  schedule: jest.fn().mockReturnValue({ start: jest.fn(), stop: jest.fn() }),
+}));
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
-const mockNodeCron = require('node-cron');
-const mockSchedule = mockNodeCron.default.schedule;
+const mockSchedule = require('node-cron').schedule as jest.Mock;
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/src/__tests__/unit/cron/update-schedule.dto.test.ts
+++ b/src/__tests__/unit/cron/update-schedule.dto.test.ts
@@ -1,0 +1,80 @@
+import { UpdateScheduleDTO } from '@cron/services/dto/update-schedule.dto';
+import { ValidationError } from '@shared/errors/validation.error';
+
+describe('UpdateScheduleDTO', () => {
+  describe('from', () => {
+    it('should create a DTO when all optional fields are provided', () => {
+      const body = {
+        name: 'Updated Schedule',
+        store: 'revolico',
+        cron: '30 9 * * *',
+        enabled: false,
+        jobs: [{ category: 'electronics' }],
+      };
+
+      const dto = UpdateScheduleDTO.from(body);
+
+      expect(dto).toBeInstanceOf(UpdateScheduleDTO);
+      expect(dto.name).toBe('Updated Schedule');
+      expect(dto.store).toBe('revolico');
+      expect(dto.cron).toBe('30 9 * * *');
+      expect(dto.enabled).toBe(false);
+      expect(dto.jobs).toHaveLength(1);
+      expect(dto.jobs![0]).toEqual({ category: 'electronics' });
+    });
+
+    it('should return a DTO with all undefined when body is empty', () => {
+      const dto = UpdateScheduleDTO.from({});
+
+      expect(dto).toBeInstanceOf(UpdateScheduleDTO);
+      expect(dto.name).toBeUndefined();
+      expect(dto.store).toBeUndefined();
+      expect(dto.cron).toBeUndefined();
+      expect(dto.enabled).toBeUndefined();
+      expect(dto.jobs).toBeUndefined();
+    });
+
+    it('should return a DTO with only enabled set when only enabled is provided', () => {
+      const dto = UpdateScheduleDTO.from({ enabled: false });
+
+      expect(dto.enabled).toBe(false);
+      expect(dto.name).toBeUndefined();
+      expect(dto.store).toBeUndefined();
+      expect(dto.cron).toBeUndefined();
+      expect(dto.jobs).toBeUndefined();
+    });
+
+    it('should create a DTO with a single-element jobs array', () => {
+      const body = {
+        jobs: [{ category: 'vehicles' }],
+      };
+
+      const dto = UpdateScheduleDTO.from(body);
+
+      expect(dto.jobs).toHaveLength(1);
+      expect(dto.jobs![0]).toEqual({ category: 'vehicles' });
+    });
+
+    it('should throw ValidationError when jobs array is empty', () => {
+      const body = { jobs: [] };
+
+      let error: unknown;
+      try {
+        UpdateScheduleDTO.from(body);
+      } catch (e) {
+        error = e;
+      }
+
+      expect(error).toBeInstanceOf(ValidationError);
+      const validationError = error as ValidationError;
+      expect(validationError.validationErrors).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            message: 'At least one scraping job is required',
+            path: ['jobs'],
+          }),
+        ]),
+      );
+    });
+  });
+});

--- a/src/main/CLAUDE.md
+++ b/src/main/CLAUDE.md
@@ -89,6 +89,17 @@ Include `tenantId`, `requestId`, and operation details in log calls.
 - `src/main/scrapers/` — multi-store scraping architecture with enrichment pipeline.
 - See `src/main/scrapers/CLAUDE.md` for scraper-specific patterns (extraction, storage, analytics, attributes, LLM integration).
 
+### Cron Module
+
+- `src/main/cron/` — automated scraping scheduler. See `.claude/skills/cron-scheduler/SKILL.md` for agent instructions.
+- **StoreRegistry** (`store-registry.ts`): in-memory `Map<storeKey, IStoreConfig>`. Each store module calls `register()` at bootstrap; the scheduler resolves `store → queueName` via `get()`. Stores also publish a `jobSchema` (field descriptors) so the admin dashboard can render dynamic forms per store.
+- **CronSchedulerService** (`services/scheduler.service.ts`): node-cron runtime. Maintains a `Map<scheduleId, ScheduledTask>`. On tick: resolves store → queue, enqueues each job with error isolation, best-effort updates `lastRunAt`. Uses `require('node-cron')` with an inline type cast — the `.d.ts` at `src/main/types/node-cron.d.ts` works for `tsc` but not `ts-node-dev`.
+- **ScheduleService** (`services/schedule.service.ts`): CRUD orchestration. Every write (create/update/delete/toggle) syncs the in-memory scheduler immediately — no restart needed.
+- **ScheduleController**: REST endpoints at `/api/admin/scraping-schedules` and `/api/admin/stores`. All `SUPER_ADMIN` only. Endpoint details are in `swagger.json` (tag: `Admin - Scraping Schedules`).
+- **ScrapingSchedule** model (Prisma): `name`, `store`, `cron`, `enabled`, `jobs` (JSON array — opaque to the scheduler, each store interprets its own shape), `lastRunAt`. No tenant isolation (no `accountId`).
+- **DI**: 6 symbols in `types.container.ts` + bindings in `container.ts` (`StoreRegistry`, `CronSchedulerService`, `ScheduleService`, `ScheduleRepository`, `ScheduleController`, `StoreInfoController`).
+- **Adding a store**: create `scrapers/<store>/index.ts` with a `register<Store>Store(container)` function that calls `storeRegistry.register(key, config)`. Call it in `app.ts` before `scheduler.initialize()`.
+
 ## Creating New Components
 
 1. Add Symbol to `types.container.ts`
@@ -141,4 +152,4 @@ After developing and passing tests, ALWAYS run `npm run docs:generate`. This reg
 
 ### Path aliases
 
-`@users/*`, `@alarms/*`, `@shared/*`, `@admin/*`, `@scrapers/*`, `@config/*`, `@utils/*`
+`@users/*`, `@alarms/*`, `@shared/*`, `@admin/*`, `@scrapers/*`, `@config/*`, `@utils/*`, `@cron/*`

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -18,6 +18,8 @@ import prisma from '@users/custom-prisma-client';
 import { BotService } from '@bots/services/bot.service';
 import { LinkCodeService } from '@bots/services/link-code.service';
 import { BotRateLimitService } from '@bots/services/rate-limit.service';
+import { CronSchedulerService } from '@cron/services/scheduler.service';
+import { registerRevolicoStore } from '@scrapers/revolico/index';
 
 const PORT = process.env.PORT || 3000;
 
@@ -33,6 +35,11 @@ export class App {
     _dashboard.setup();
     await _db.dbConnect();
     await _tenantDb.dbConnect();
+
+    // Register stores for cron scheduler + start automated scraping
+    registerRevolicoStore(container);
+    const scheduler = container.get<CronSchedulerService>(TYPES.CronSchedulerService);
+    await scheduler.initialize();
 
     // Start bot providers if enabled
     const botService = container.get<BotService>(TYPES.BotService);
@@ -87,6 +94,7 @@ export class App {
    */
   public async close(): Promise<void> {
     await container.get<BotService>(TYPES.BotService).stop();
+    await container.get<CronSchedulerService>(TYPES.CronSchedulerService).shutdown();
     await container.get<QueueContext>(QueueContext).shutdown();
     await container.get<PgDBContext>(TYPES.TenantDB).end();
     await prisma.$disconnect();

--- a/src/main/cron/controllers/schedule.controller.ts
+++ b/src/main/cron/controllers/schedule.controller.ts
@@ -1,0 +1,158 @@
+import { Request, Response } from 'express';
+import { controller, httpGet, httpPost, httpPut, httpDelete, httpPatch, request, response, requestParam } from 'inversify-express-utils';
+import { inject } from 'inversify';
+import { TYPES } from '@shared/types.container';
+import { AuthMiddleware } from '@shared/middleware/auth.middleware';
+import { ResponseHandler } from '@shared/response-handler';
+import { ValidateRequestMiddleware } from '@shared/middleware/validate-request.middleware';
+import { ILogger } from '@shared/logger.interface';
+import { ScheduleService } from '@cron/services/schedule.service';
+import { StoreRegistry } from '@cron/store-registry';
+import { CreateScheduleDTO, UpdateScheduleDTO } from '@cron/services/dto';
+import { ScheduleNotFoundError } from '@cron/errors';
+
+/**
+ * SUPER_ADMIN-only CRUD for scraping schedule management.
+ *
+ * Endpoints:
+ *   GET    /api/admin/scraping-schedules              — list all schedules
+ *   GET    /api/admin/scraping-schedules/:id           — get one schedule
+ *   POST   /api/admin/scraping-schedules               — create a new schedule
+ *   PUT    /api/admin/scraping-schedules/:id           — update a schedule
+ *   DELETE /api/admin/scraping-schedules/:id           — delete a schedule
+ *   PATCH  /api/admin/scraping-schedules/:id/toggle    — toggle enabled flag
+ */
+@controller('/api/admin/scraping-schedules')
+export class ScheduleController {
+  public constructor(
+    @inject(TYPES.ScheduleService) private readonly _service: ScheduleService,
+    @inject(TYPES.Logger) private readonly _log: ILogger,
+  ) {
+    this._log.context = ScheduleController.name;
+  }
+
+  /**
+   * Lists all scraping schedules.
+   */
+  @httpGet('/', AuthMiddleware.forRoles('SUPER_ADMIN'))
+  public async list(@response() res: Response): Promise<void> {
+    try {
+      const schedules = await this._service.list();
+      ResponseHandler.ok(res, { schedules });
+    } catch (err) {
+      this._log.error('Failed to list scraping schedules', { error: err });
+      ResponseHandler.error(res, 'Failed to list scraping schedules', 500);
+    }
+  }
+
+  /**
+   * Returns a single scraping schedule by its id.
+   */
+  @httpGet('/:id', AuthMiddleware.forRoles('SUPER_ADMIN'))
+  public async findOne(@requestParam('id') id: string, @response() res: Response): Promise<void> {
+    try {
+      const schedule = await this._service.findOne(id);
+      ResponseHandler.ok(res, { schedule });
+    } catch (err) {
+      if (err instanceof ScheduleNotFoundError) {
+        ResponseHandler.notFound(res, err.message);
+        return;
+      }
+      this._log.error('Failed to get scraping schedule', { scheduleId: id, error: err });
+      ResponseHandler.error(res, 'Failed to get scraping schedule', 500);
+    }
+  }
+
+  /**
+   * Creates a new scraping schedule.
+   */
+  @httpPost('/', AuthMiddleware.forRoles('SUPER_ADMIN'), ValidateRequestMiddleware.with(CreateScheduleDTO))
+  public async create(@request() req: Request, @response() res: Response): Promise<void> {
+    try {
+      const dto = req.body as CreateScheduleDTO;
+      const schedule = await this._service.create(dto);
+      ResponseHandler.created(res, 'Scraping schedule created', { schedule });
+    } catch (err) {
+      this._log.error('Failed to create scraping schedule', { error: err });
+      ResponseHandler.error(res, 'Failed to create scraping schedule', 500);
+    }
+  }
+
+  /**
+   * Updates an existing scraping schedule.
+   */
+  @httpPut('/:id', AuthMiddleware.forRoles('SUPER_ADMIN'), ValidateRequestMiddleware.with(UpdateScheduleDTO))
+  public async update(@requestParam('id') id: string, @request() req: Request, @response() res: Response): Promise<void> {
+    try {
+      const dto = req.body as UpdateScheduleDTO;
+      const schedule = await this._service.update(id, dto);
+      ResponseHandler.ok(res, { schedule });
+    } catch (err) {
+      if (err instanceof ScheduleNotFoundError) {
+        ResponseHandler.notFound(res, err.message);
+        return;
+      }
+      this._log.error('Failed to update scraping schedule', { scheduleId: id, error: err });
+      ResponseHandler.error(res, 'Failed to update scraping schedule', 500);
+    }
+  }
+
+  /**
+   * Deletes a scraping schedule.
+   */
+  @httpDelete('/:id', AuthMiddleware.forRoles('SUPER_ADMIN'))
+  public async delete(@requestParam('id') id: string, @response() res: Response): Promise<void> {
+    try {
+      await this._service.delete(id);
+      ResponseHandler.deleted(res);
+    } catch (err) {
+      if (err instanceof ScheduleNotFoundError) {
+        ResponseHandler.notFound(res, err.message);
+        return;
+      }
+      this._log.error('Failed to delete scraping schedule', { scheduleId: id, error: err });
+      ResponseHandler.error(res, 'Failed to delete scraping schedule', 500);
+    }
+  }
+
+  /**
+   * Toggles the enabled flag of a scraping schedule.
+   */
+  @httpPatch('/:id/toggle', AuthMiddleware.forRoles('SUPER_ADMIN'))
+  public async toggle(@requestParam('id') id: string, @response() res: Response): Promise<void> {
+    try {
+      const schedule = await this._service.toggle(id);
+      ResponseHandler.ok(res, { schedule });
+    } catch (err) {
+      if (err instanceof ScheduleNotFoundError) {
+        ResponseHandler.notFound(res, err.message);
+        return;
+      }
+      this._log.error('Failed to toggle scraping schedule', { scheduleId: id, error: err });
+      ResponseHandler.error(res, 'Failed to toggle scraping schedule', 500);
+    }
+  }
+}
+
+/**
+ * SUPER_ADMIN-only endpoint that lists registered store configurations.
+ *
+ * Endpoints:
+ *   GET    /api/admin/stores   — list all registered stores
+ */
+@controller('/api/admin')
+export class StoreInfoController {
+  public constructor(@inject(TYPES.StoreRegistry) private readonly _stores: StoreRegistry) {}
+
+  /**
+   * Lists all registered stores with their queue names and job schemas.
+   */
+  @httpGet('/stores', AuthMiddleware.forRoles('SUPER_ADMIN'))
+  public async listStores(@response() res: Response): Promise<void> {
+    try {
+      ResponseHandler.ok(res, { stores: this._stores.list() });
+    } catch {
+      ResponseHandler.error(res, 'Failed to list stores', 500);
+    }
+  }
+}

--- a/src/main/cron/errors/index.ts
+++ b/src/main/cron/errors/index.ts
@@ -1,0 +1,1 @@
+export { ScheduleNotFoundError } from './schedule-not-found.error';

--- a/src/main/cron/errors/schedule-not-found.error.ts
+++ b/src/main/cron/errors/schedule-not-found.error.ts
@@ -1,0 +1,10 @@
+/**
+ * Domain error thrown when a scraping schedule is not found.
+ */
+export class ScheduleNotFoundError extends Error {
+  public constructor(public readonly scheduleId: string) {
+    super(`Scraping schedule not found for id="${scheduleId}"`);
+    this.name = 'ScheduleNotFoundError';
+    Object.setPrototypeOf(this, ScheduleNotFoundError.prototype);
+  }
+}

--- a/src/main/cron/mappers/index.ts
+++ b/src/main/cron/mappers/index.ts
@@ -1,0 +1,2 @@
+export { toScheduleResponseDTO } from './schedule.mapper';
+export type { IScheduleResponseDTO, IScheduleJobEntry } from './schedule.mapper';

--- a/src/main/cron/mappers/schedule.mapper.ts
+++ b/src/main/cron/mappers/schedule.mapper.ts
@@ -1,0 +1,40 @@
+import { ScrapingSchedule as ScheduleModel } from '@prisma/client';
+
+/**
+ * A single job entry stored in the `jobs` JSON array of a
+ * {@link ScrapingSchedule}. The shape is store-specific and opaque to the
+ * scheduler — it is passed through to the store's scraping queue as-is.
+ */
+export type IScheduleJobEntry = Record<string, unknown>;
+
+/**
+ * API response shape for a scraping schedule.
+ */
+export interface IScheduleResponseDTO {
+  id: string;
+  name: string;
+  store: string;
+  cron: string;
+  enabled: boolean;
+  jobs: IScheduleJobEntry[];
+  lastRunAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * Pure mapper: {@link ScheduleModel} → {@link IScheduleResponseDTO}.
+ */
+export function toScheduleResponseDTO(model: ScheduleModel): IScheduleResponseDTO {
+  return {
+    id: model.id,
+    name: model.name,
+    store: model.store,
+    cron: model.cron,
+    enabled: model.enabled,
+    jobs: model.jobs as IScheduleJobEntry[],
+    lastRunAt: model.lastRunAt?.toISOString() ?? null,
+    createdAt: model.createdAt.toISOString(),
+    updatedAt: model.updatedAt.toISOString(),
+  };
+}

--- a/src/main/cron/repositories/schedule.repository.ts
+++ b/src/main/cron/repositories/schedule.repository.ts
@@ -1,0 +1,88 @@
+import { PrismaClient, ScrapingSchedule } from '@prisma/client';
+import { TYPES } from '@shared/types.container';
+import { inject, injectable } from 'inversify';
+
+type JsonArray = any[];
+
+export interface ICreateScheduleInput {
+  name: string;
+  store: string;
+  cron: string;
+  enabled: boolean;
+  jobs: JsonArray;
+}
+
+export interface IUpdateScheduleInput {
+  name?: string;
+  store?: string;
+  cron?: string;
+  enabled?: boolean;
+  jobs?: JsonArray;
+}
+
+@injectable()
+export class ScheduleRepository {
+  public constructor(@inject(TYPES.PrismaClient) private readonly prisma: PrismaClient) {}
+
+  /**
+   * Retrieves all scraping schedules ordered by creation date ascending.
+   * @returns A promise resolving to an array of ScrapingSchedule models.
+   */
+  public async findAll(): Promise<ScrapingSchedule[]> {
+    return this.prisma.scrapingSchedule.findMany({
+      orderBy: { createdAt: 'asc' },
+    });
+  }
+
+  /**
+   * Finds a scraping schedule by its unique identifier.
+   * @param id - The unique identifier of the schedule.
+   * @returns A promise resolving to the ScrapingSchedule model if found, null otherwise.
+   */
+  public async findById(id: string): Promise<ScrapingSchedule | null> {
+    return this.prisma.scrapingSchedule.findUnique({
+      where: { id },
+    });
+  }
+
+  /**
+   * Creates a new scraping schedule.
+   * @param data - The input data for the new schedule.
+   * @returns A promise resolving to the newly created ScrapingSchedule model.
+   */
+  public async create(data: ICreateScheduleInput): Promise<ScrapingSchedule> {
+    return this.prisma.scrapingSchedule.create({ data });
+  }
+
+  /**
+   * Partially updates an existing scraping schedule by id.
+   * @param id - The unique identifier of the schedule to update.
+   * @param data - The partial fields to update.
+   * @returns A promise resolving to the updated ScrapingSchedule model.
+   * @throws Error if the schedule does not exist.
+   */
+  public async update(id: string, data: IUpdateScheduleInput): Promise<ScrapingSchedule> {
+    return this.prisma.scrapingSchedule.update({ where: { id }, data });
+  }
+
+  /**
+   * Deletes a scraping schedule by id.
+   * @param id - The unique identifier of the schedule to delete.
+   * @throws Error if the schedule does not exist.
+   */
+  public async delete(id: string): Promise<void> {
+    await this.prisma.scrapingSchedule.delete({ where: { id } });
+  }
+
+  /**
+   * Updates the lastRunAt timestamp of a scraping schedule to the current date.
+   * @param id - The unique identifier of the schedule to update.
+   * @throws Error if the schedule does not exist.
+   */
+  public async updateLastRunAt(id: string): Promise<void> {
+    await this.prisma.scrapingSchedule.update({
+      where: { id },
+      data: { lastRunAt: new Date() },
+    });
+  }
+}

--- a/src/main/cron/services/dto/create-schedule.dto.ts
+++ b/src/main/cron/services/dto/create-schedule.dto.ts
@@ -1,0 +1,48 @@
+import { z } from 'zod';
+import { ValidationError } from '@shared/errors/validation.error';
+
+export const CreateScheduleSchema = z.object({
+  name: z.string().min(1, 'Name is required').max(100),
+  store: z.string().min(1, 'Store is required'),
+  cron: z.string().min(1, 'Cron expression is required'),
+  enabled: z.boolean().optional().default(true),
+  jobs: z.array(z.object({}).passthrough()).min(1, 'At least one scraping job is required'),
+});
+
+export type CreateScheduleType = z.infer<typeof CreateScheduleSchema>;
+
+/**
+ * DTO for creating a new scraping schedule.
+ *
+ * `jobs` is a store-specific JSON array — each entry is validated as a
+ * non-empty object but the fields are opaque to the API layer. The target
+ * store module interprets them.
+ */
+export class CreateScheduleDTO {
+  public readonly name: string;
+  public readonly store: string;
+  public readonly cron: string;
+  public readonly enabled: boolean;
+  public readonly jobs: Record<string, unknown>[];
+
+  private constructor(data: CreateScheduleType) {
+    this.name = data.name;
+    this.store = data.store;
+    this.cron = data.cron;
+    this.enabled = data.enabled;
+    this.jobs = data.jobs as Record<string, unknown>[];
+  }
+
+  /** Parses and validates the request body. */
+  public static from(body: unknown): CreateScheduleDTO {
+    try {
+      const parsed = CreateScheduleSchema.parse(body);
+      return new CreateScheduleDTO(parsed);
+    } catch (err) {
+      if (err instanceof z.ZodError) {
+        throw new ValidationError(err.issues.map(({ code, message, path }) => ({ code, message, path })));
+      }
+      throw err;
+    }
+  }
+}

--- a/src/main/cron/services/dto/index.ts
+++ b/src/main/cron/services/dto/index.ts
@@ -1,0 +1,3 @@
+export { CreateScheduleSchema, CreateScheduleType, CreateScheduleDTO } from './create-schedule.dto';
+
+export { UpdateScheduleSchema, UpdateScheduleType, UpdateScheduleDTO } from './update-schedule.dto';

--- a/src/main/cron/services/dto/update-schedule.dto.ts
+++ b/src/main/cron/services/dto/update-schedule.dto.ts
@@ -1,0 +1,41 @@
+import { z } from 'zod';
+import { ValidationError } from '@shared/errors/validation.error';
+
+export const UpdateScheduleSchema = z.object({
+  name: z.string().min(1).max(100).optional(),
+  store: z.string().min(1).optional(),
+  cron: z.string().min(1).optional(),
+  enabled: z.boolean().optional(),
+  jobs: z.array(z.object({}).passthrough()).min(1, 'At least one scraping job is required').optional(),
+});
+
+export type UpdateScheduleType = z.infer<typeof UpdateScheduleSchema>;
+
+/**
+ * DTO for updating an existing scraping schedule. All fields are optional
+ * — only the provided fields are updated (partial update).
+ */
+export class UpdateScheduleDTO {
+  public readonly name?: string;
+  public readonly store?: string;
+  public readonly cron?: string;
+  public readonly enabled?: boolean;
+  public readonly jobs?: Record<string, unknown>[];
+
+  private constructor(data: UpdateScheduleType) {
+    Object.assign(this, data);
+  }
+
+  /** Parses and validates the request body. */
+  public static from(body: unknown): UpdateScheduleDTO {
+    try {
+      const parsed = UpdateScheduleSchema.parse(body);
+      return new UpdateScheduleDTO(parsed);
+    } catch (err) {
+      if (err instanceof z.ZodError) {
+        throw new ValidationError(err.issues.map(({ code, message, path }) => ({ code, message, path })));
+      }
+      throw err;
+    }
+  }
+}

--- a/src/main/cron/services/schedule.service.ts
+++ b/src/main/cron/services/schedule.service.ts
@@ -1,0 +1,131 @@
+import { injectable, inject } from 'inversify';
+import { TYPES } from '@shared/types.container';
+import { ILogger } from '@shared/logger.interface';
+import { ScheduleRepository } from '@cron/repositories/schedule.repository';
+import { CronSchedulerService } from '@cron/services/scheduler.service';
+import { CreateScheduleDTO, UpdateScheduleDTO } from '@cron/services/dto';
+import { toScheduleResponseDTO, IScheduleResponseDTO } from '@cron/mappers';
+import { ScheduleNotFoundError } from '@cron/errors';
+
+/**
+ * Business logic for scraping schedule CRUD.
+ *
+ * All write operations synchronise the in-memory CronSchedulerService so that
+ * running schedules pick up changes immediately.
+ */
+@injectable()
+export class ScheduleService {
+  public constructor(
+    @inject(TYPES.ScheduleRepository) private readonly _repo: ScheduleRepository,
+    @inject(TYPES.CronSchedulerService) private readonly _scheduler: CronSchedulerService,
+    @inject(TYPES.Logger) private readonly _log: ILogger,
+  ) {
+    this._log.context = ScheduleService.name;
+  }
+
+  /**
+   * Returns all scraping schedules.
+   * @returns {Promise<IScheduleResponseDTO[]>} Mapped schedule list.
+   */
+  public async list(): Promise<IScheduleResponseDTO[]> {
+    const rows = await this._repo.findAll();
+    return rows.map(toScheduleResponseDTO);
+  }
+
+  /**
+   * Returns a single scraping schedule by its id.
+   * @param {string} id - The schedule unique identifier.
+   * @returns {Promise<IScheduleResponseDTO>} The mapped schedule.
+   * @throws {ScheduleNotFoundError} If the id does not exist.
+   */
+  public async findOne(id: string): Promise<IScheduleResponseDTO> {
+    const row = await this._repo.findById(id);
+    if (!row) throw new ScheduleNotFoundError(id);
+    return toScheduleResponseDTO(row);
+  }
+
+  /**
+   * Creates a new scraping schedule and registers it with the cron scheduler.
+   * @param {CreateScheduleDTO} dto - The validated creation payload.
+   * @returns {Promise<IScheduleResponseDTO>} The created schedule.
+   */
+  public async create(dto: CreateScheduleDTO): Promise<IScheduleResponseDTO> {
+    const row = await this._repo.create({
+      name: dto.name,
+      store: dto.store,
+      cron: dto.cron,
+      enabled: dto.enabled,
+      jobs: dto.jobs,
+    });
+    this._scheduler.register(row);
+    this._log.info('Scraping schedule created', {
+      scheduleId: row.id,
+      store: row.store,
+      cron: row.cron,
+      enabled: row.enabled,
+    });
+    return toScheduleResponseDTO(row);
+  }
+
+  /**
+   * Updates an existing scraping schedule and re-registers it with the cron
+   * scheduler. Only the fields present in the DTO are applied (partial update).
+   * @param {string} id - The schedule unique identifier.
+   * @param {UpdateScheduleDTO} dto - The validated partial payload.
+   * @returns {Promise<IScheduleResponseDTO>} The updated schedule.
+   * @throws {ScheduleNotFoundError} If the id does not exist.
+   */
+  public async update(id: string, dto: UpdateScheduleDTO): Promise<IScheduleResponseDTO> {
+    const existing = await this._repo.findById(id);
+    if (!existing) throw new ScheduleNotFoundError(id);
+
+    const updateData: Record<string, unknown> = {};
+    if (dto.name !== undefined) updateData.name = dto.name;
+    if (dto.store !== undefined) updateData.store = dto.store;
+    if (dto.cron !== undefined) updateData.cron = dto.cron;
+    if (dto.enabled !== undefined) updateData.enabled = dto.enabled;
+    if (dto.jobs !== undefined) updateData.jobs = dto.jobs;
+
+    const row = await this._repo.update(id, updateData);
+    this._scheduler.register(row);
+    this._log.info('Scraping schedule updated', {
+      scheduleId: row.id,
+      changes: Object.keys(updateData),
+    });
+    return toScheduleResponseDTO(row);
+  }
+
+  /**
+   * Deletes a scraping schedule and unregisters it from the cron scheduler.
+   * @param {string} id - The schedule unique identifier.
+   * @throws {ScheduleNotFoundError} If the id does not exist.
+   */
+  public async delete(id: string): Promise<void> {
+    const existing = await this._repo.findById(id);
+    if (!existing) throw new ScheduleNotFoundError(id);
+
+    await this._repo.delete(id);
+    this._scheduler.unregister(id);
+    this._log.info('Scraping schedule deleted', { scheduleId: id });
+  }
+
+  /**
+   * Toggles the `enabled` flag of a scraping schedule and re-registers it
+   * with the cron scheduler (the scheduler respects the flag internally).
+   * @param {string} id - The schedule unique identifier.
+   * @returns {Promise<IScheduleResponseDTO>} The updated schedule.
+   * @throws {ScheduleNotFoundError} If the id does not exist.
+   */
+  public async toggle(id: string): Promise<IScheduleResponseDTO> {
+    const existing = await this._repo.findById(id);
+    if (!existing) throw new ScheduleNotFoundError(id);
+
+    const row = await this._repo.update(id, { enabled: !existing.enabled });
+    this._scheduler.register(row);
+    this._log.info('Scraping schedule toggled', {
+      scheduleId: id,
+      enabled: row.enabled,
+    });
+    return toScheduleResponseDTO(row);
+  }
+}

--- a/src/main/cron/services/scheduler.service.ts
+++ b/src/main/cron/services/scheduler.service.ts
@@ -1,6 +1,16 @@
 import { inject, injectable } from 'inversify';
 import { ScrapingSchedule } from '@prisma/client';
-import cron from 'node-cron';
+
+// node-cron v3 ships with no bundled types and there is no @types/node-cron.
+// The .d.ts at src/main/types/node-cron.d.ts is found by tsc but not by
+// ts-node-dev (on-demand compilation).  Using require() with an inline type
+// cast ensures both compilers work.
+type CronScheduledTask = { start(): void; stop(): void };
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const cron = require('node-cron') as {
+  schedule(expression: string, func: () => void, options?: { scheduled?: boolean; timezone?: string }): CronScheduledTask;
+};
 import { ILogger } from '@shared/logger.interface';
 import { QueueContext } from '@shared/queue/queue-context';
 import { StoreRegistry } from '@cron/store-registry';
@@ -29,7 +39,7 @@ import { TYPES } from '@shared/types.container';
  */
 @injectable()
 export class CronSchedulerService {
-  private readonly _tasks = new Map<string, cron.IScheduledTask>();
+  private readonly _tasks = new Map<string, CronScheduledTask>();
 
   public constructor(
     @inject(TYPES.Logger) private readonly _log: ILogger,

--- a/src/main/cron/services/scheduler.service.ts
+++ b/src/main/cron/services/scheduler.service.ts
@@ -1,0 +1,176 @@
+import { inject, injectable } from 'inversify';
+import { ScrapingSchedule } from '@prisma/client';
+import cron from 'node-cron';
+import { ILogger } from '@shared/logger.interface';
+import { QueueContext } from '@shared/queue/queue-context';
+import { StoreRegistry } from '@cron/store-registry';
+import { ScheduleRepository } from '@cron/repositories/schedule.repository';
+import { TYPES } from '@shared/types.container';
+
+/**
+ * Runtime cron scheduler that reads `ScrapingSchedule` rows from the database
+ * and registers each enabled one with node-cron.
+ *
+ * On each tick the scheduler:
+ * 1. Resolves the target BullMQ queue name from the {@link StoreRegistry}.
+ * 2. Enqueues every job listed in the schedule's `jobs` JSON array.
+ * 3. Best-effort updates the schedule's `lastRunAt` timestamp.
+ *
+ * Invalid cron expressions are caught and logged — they do not crash the
+ * process or prevent other schedules from running.
+ *
+ * @example
+ * ```typescript
+ * const scheduler = container.get(CronSchedulerService);
+ * await scheduler.initialize();
+ * // Later, on shutdown:
+ * scheduler.shutdown();
+ * ```
+ */
+@injectable()
+export class CronSchedulerService {
+  private readonly _tasks = new Map<string, cron.IScheduledTask>();
+
+  public constructor(
+    @inject(TYPES.Logger) private readonly _log: ILogger,
+    @inject(TYPES.ScheduleRepository) private readonly _repo: ScheduleRepository,
+    @inject(TYPES.StoreRegistry) private readonly _storeRegistry: StoreRegistry,
+    @inject(QueueContext) private readonly _qContext: QueueContext,
+  ) {
+    this._log.context = CronSchedulerService.name;
+  }
+
+  /**
+   * Loads all scraping schedules from the database and registers each
+   * enabled one with node-cron. Disabled schedules are skipped.
+   * Idempotent — running tasks are stopped and replaced.
+   */
+  public async initialize(): Promise<void> {
+    const schedules = await this._repo.findAll();
+    this._log.info(`Initializing ${schedules.length} scraping schedule(s)`);
+    for (const schedule of schedules) {
+      this.register(schedule);
+    }
+  }
+
+  /**
+   * Registers (or re-registers) a single schedule with node-cron.
+   *
+   * If a task already exists for this schedule id it is stopped before the
+   * new task is created. Disabled schedules are unregistered if previously
+   * running and then skipped.
+   *
+   * An invalid cron expression is caught, logged, and does not throw.
+   *
+   * @param schedule - The schedule model from the database.
+   */
+  public register(schedule: ScrapingSchedule): void {
+    this.unregister(schedule.id);
+
+    if (!schedule.enabled) {
+      this._log.info(`Schedule "${schedule.name}" (${schedule.id}) is disabled — skipping`);
+      return;
+    }
+
+    try {
+      this._register(schedule);
+    } catch (err) {
+      this._log.error(
+        `Failed to register schedule "${schedule.name}" (${schedule.id}) — ` + `invalid cron expression "${schedule.cron}"`,
+        err,
+      );
+    }
+  }
+
+  /**
+   * Stops and removes the running task for the given schedule id.
+   * No-op if no task is registered for that id.
+   *
+   * @param id - The scraping schedule id.
+   */
+  public unregister(id: string): void {
+    const existing = this._tasks.get(id);
+    if (existing) {
+      existing.stop();
+      this._tasks.delete(id);
+      this._log.debug(`Unregistered cron task for schedule "${id}"`);
+    }
+  }
+
+  /**
+   * Stops all running cron tasks and clears the internal task map.
+   * Idempotent — safe to call even if already stopped.
+   */
+  public shutdown(): void {
+    this._log.info('Shutting down all cron tasks');
+    for (const [id, task] of this._tasks) {
+      task.stop();
+      this._log.debug(`Stopped cron task for schedule "${id}"`);
+    }
+    this._tasks.clear();
+  }
+
+  /**
+   * Creates a node-cron scheduled task and stores it in the internal map.
+   * Called by {@link register} after the enabled check and after stopping
+   * any previous task for the same id.
+   *
+   * @param schedule - The schedule to register.
+   * @throws {Error} If the cron expression is syntactically invalid.
+   */
+  private _register(schedule: ScrapingSchedule): void {
+    const task = cron.schedule(
+      schedule.cron,
+      async () => {
+        await this._onTick(schedule);
+      },
+      { scheduled: true },
+    );
+
+    this._tasks.set(schedule.id, task);
+    this._log.info(`Registered cron task "${schedule.name}" (${schedule.id}) — ` + `"${schedule.cron}" for store "${schedule.store}"`);
+  }
+
+  /**
+   * Fired by node-cron on each tick of the schedule.
+   *
+   * Resolves the target queue from the store registry, enqueues every job
+   * in the schedule's `jobs` array, and best-effort writes the new
+   * `lastRunAt` timestamp.
+   */
+  private async _onTick(schedule: ScrapingSchedule): Promise<void> {
+    const { id, name, store: storeKey } = schedule;
+
+    // 1. Resolve queue name from the store registry
+    let queueName: string;
+    try {
+      const config = this._storeRegistry.get(storeKey);
+      queueName = config.scrapingQueue;
+    } catch (err) {
+      this._log.error(`Tick for schedule "${name}" (${id}): unknown store "${storeKey}" — skipping`, err);
+      return;
+    }
+
+    // 2. Enqueue each job
+    const jobs = schedule.jobs as Array<Record<string, unknown>>;
+
+    for (let i = 0; i < jobs.length; i++) {
+      try {
+        await this._qContext.enqueue(queueName, jobs[i], {
+          attempts: 2,
+          backoff: 5000,
+        });
+        this._log.debug(`Enqueued job #${i} for schedule "${name}" on queue "${queueName}"`);
+      } catch (err) {
+        this._log.error(`Failed to enqueue job #${i} for schedule "${name}" (${id})`, err);
+      }
+    }
+
+    // 3. Best-effort: persist lastRunAt — failure is non-critical
+    try {
+      await this._repo.updateLastRunAt(id);
+    } catch {
+      // silently ignored
+    }
+  }
+}

--- a/src/main/cron/store-registry.ts
+++ b/src/main/cron/store-registry.ts
@@ -1,0 +1,68 @@
+/**
+ * Describes a single field in a store's job schema, used by the admin
+ * dashboard to dynamically render scraping-job forms per store.
+ */
+export interface IFieldSchema {
+  name: string;
+  type: 'string' | 'number' | 'boolean';
+  required: boolean;
+  label: string;
+  placeholder?: string;
+}
+
+/**
+ * Configuration a store module publishes at bootstrap so the cron scheduler
+ * (and the admin API) know how to route scraping jobs and render their forms.
+ */
+export interface IStoreConfig {
+  /** Human-readable label shown in the admin UI (e.g. "Revolico"). */
+  displayName: string;
+  /** BullMQ queue name where scraping jobs for this store are enqueued. */
+  scrapingQueue: string;
+  /** Field descriptors for the admin dashboard dynamic form. */
+  jobSchema: {
+    fields: IFieldSchema[];
+  };
+}
+
+/**
+ * In-memory registry that maps a store key (e.g. "revolico") to its
+ * {@link IStoreConfig}. Each store module calls {@link StoreRegistry.register}
+ * at bootstrap. The cron scheduler and the admin stores endpoint read from
+ * this registry.
+ */
+export class StoreRegistry {
+  private readonly _stores = new Map<string, IStoreConfig>();
+
+  /**
+   * Registers a store. Throws if the key is already registered.
+   *
+   * @param storeKey  Unique store identifier (e.g. "revolico").
+   * @param config    Queue name, display name, and job form schema.
+   */
+  public register(storeKey: string, config: IStoreConfig): void {
+    if (this._stores.has(storeKey)) {
+      throw new Error(`Store "${storeKey}" is already registered`);
+    }
+    this._stores.set(storeKey, config);
+  }
+
+  /**
+   * Returns the {@link IStoreConfig} for a given key, or throws if unknown.
+   */
+  public get(storeKey: string): IStoreConfig {
+    const config = this._stores.get(storeKey);
+    if (!config) {
+      throw new Error(`Unknown store: "${storeKey}"`);
+    }
+    return config;
+  }
+
+  /** Lists all registered stores with their keys. */
+  public list(): Array<{ key: string } & IStoreConfig> {
+    return Array.from(this._stores.entries()).map(([key, config]) => ({
+      key,
+      ...config,
+    }));
+  }
+}

--- a/src/main/docs/modules/scheduling.paths.ts
+++ b/src/main/docs/modules/scheduling.paths.ts
@@ -1,0 +1,76 @@
+import { OpenAPIRegistry } from '@asteasolutions/zod-to-openapi';
+import { z } from 'zod';
+import { endpoint } from '../helpers/path-builder';
+import { TAG } from '../tags';
+import { Schemas } from '../schema-registry';
+
+export function registerSchedulingPaths(registry: OpenAPIRegistry): void {
+  endpoint('get', '/api/admin/stores')
+    .tag(TAG.ADMIN_SCHEDULES)
+    .summary('List registered stores with job schemas')
+    .operationId('adminListStores')
+    .security('bearerAuth')
+    .response(200, 'List of registered stores', z.object({ stores: z.array(Schemas.StoreInfoDTO) }))
+    .errors(401, 403)
+    .register(registry);
+
+  endpoint('get', '/api/admin/scraping-schedules')
+    .tag(TAG.ADMIN_SCHEDULES)
+    .summary('List all scraping schedules')
+    .operationId('adminListSchedules')
+    .security('bearerAuth')
+    .response(200, 'List of all schedules', z.object({ schedules: z.array(Schemas.ScrapingScheduleResponseDTO) }))
+    .errors(401, 403)
+    .register(registry);
+
+  endpoint('get', '/api/admin/scraping-schedules/{id}')
+    .tag(TAG.ADMIN_SCHEDULES)
+    .summary('Get a single scraping schedule by ID')
+    .operationId('adminGetSchedule')
+    .security('bearerAuth')
+    .pathParam('id', 'Schedule unique identifier')
+    .response(200, 'Schedule detail', z.object({ schedule: Schemas.ScrapingScheduleResponseDTO }))
+    .errors(401, 403, 404)
+    .register(registry);
+
+  endpoint('post', '/api/admin/scraping-schedules')
+    .tag(TAG.ADMIN_SCHEDULES)
+    .summary('Create a new scraping schedule')
+    .operationId('adminCreateSchedule')
+    .security('bearerAuth')
+    .requestBody(Schemas.CreateScrapingScheduleDTO, 'Schedule creation data')
+    .response(201, 'Schedule created', z.object({ schedule: Schemas.ScrapingScheduleResponseDTO }))
+    .errors(400, 401, 403, 409)
+    .register(registry);
+
+  endpoint('put', '/api/admin/scraping-schedules/{id}')
+    .tag(TAG.ADMIN_SCHEDULES)
+    .summary('Update an existing scraping schedule')
+    .operationId('adminUpdateSchedule')
+    .security('bearerAuth')
+    .pathParam('id', 'Schedule unique identifier')
+    .requestBody(Schemas.UpdateScrapingScheduleDTO, 'Schedule update data (partial)')
+    .response(200, 'Schedule updated', z.object({ schedule: Schemas.ScrapingScheduleResponseDTO }))
+    .errors(400, 401, 403, 404)
+    .register(registry);
+
+  endpoint('delete', '/api/admin/scraping-schedules/{id}')
+    .tag(TAG.ADMIN_SCHEDULES)
+    .summary('Delete a scraping schedule')
+    .operationId('adminDeleteSchedule')
+    .security('bearerAuth')
+    .pathParam('id', 'Schedule unique identifier')
+    .response204('Schedule deleted')
+    .errors(401, 403, 404)
+    .register(registry);
+
+  endpoint('patch', '/api/admin/scraping-schedules/{id}/toggle')
+    .tag(TAG.ADMIN_SCHEDULES)
+    .summary('Toggle schedule enabled/disabled')
+    .operationId('adminToggleSchedule')
+    .security('bearerAuth')
+    .pathParam('id', 'Schedule unique identifier')
+    .response(200, 'Schedule toggled', z.object({ schedule: Schemas.ScrapingScheduleResponseDTO }))
+    .errors(401, 403, 404)
+    .register(registry);
+}

--- a/src/main/docs/path-registry.ts
+++ b/src/main/docs/path-registry.ts
@@ -10,6 +10,7 @@ import { registerScrapingPaths } from './modules/scraping.paths';
 import { registerAdminPaths } from './modules/admin.paths';
 import { registerScraperConfigsPaths } from './modules/scraper-configs.paths';
 import { registerBotsPaths } from './modules/bots.paths';
+import { registerSchedulingPaths } from './modules/scheduling.paths';
 
 export function registerAllPaths(registry: OpenAPIRegistry): void {
   registerAuthPaths(registry);
@@ -23,4 +24,5 @@ export function registerAllPaths(registry: OpenAPIRegistry): void {
   registerAdminPaths(registry);
   registerScraperConfigsPaths(registry);
   registerBotsPaths(registry);
+  registerSchedulingPaths(registry);
 }

--- a/src/main/docs/schema-registry.ts
+++ b/src/main/docs/schema-registry.ts
@@ -263,4 +263,61 @@ export function registerAllSchemas(registry: OpenAPIRegistry): void {
         .openapi({ description: 'Non-empty array of values (replaces existing)', example: ['apple', 'samsung', 'xiaomi'] }),
     }),
   );
+
+  // Scraping schedules
+  const ScrapingScheduleResponse = z.object({
+    id: uuid('Schedule unique identifier'),
+    name: z.string().openapi({ description: 'Human-readable schedule name', example: 'Daily morning scrape' }),
+    store: z.string().openapi({ description: 'Store key this schedule targets', example: 'revolico' }),
+    cron: z.string().openapi({ description: 'Cron expression', example: '0 6 * * *' }),
+    enabled: z.boolean().openapi({ description: 'Whether the schedule is active', example: true }),
+    jobs: z.array(z.object({}).passthrough()).openapi({ description: 'Array of store-specific scraping job descriptors' }),
+    lastRunAt: z.string().nullable().openapi({ description: 'ISO timestamp of last execution' }),
+    createdAt: timestamp('Creation timestamp'),
+    updatedAt: timestamp('Last update timestamp'),
+  });
+  Schemas.ScrapingScheduleResponseDTO = registry.register('ScrapingScheduleResponse', ScrapingScheduleResponse);
+
+  Schemas.CreateScrapingScheduleDTO = registry.register(
+    'CreateScrapingSchedule',
+    z.object({
+      name: z.string().min(1).max(100).openapi({ description: 'Unique schedule name', example: 'Daily morning scrape' }),
+      store: z.string().min(1).openapi({ description: 'Store key', example: 'revolico' }),
+      cron: z.string().min(1).openapi({ description: 'Cron expression', example: '0 6 * * *' }),
+      enabled: z.boolean().optional().openapi({ description: 'Enable on creation (defaults to true)', example: true }),
+      jobs: z
+        .array(z.object({}).passthrough())
+        .min(1)
+        .openapi({ description: 'Array of job descriptors', example: [{ category: 'celulares' }] }),
+    }),
+  );
+
+  Schemas.UpdateScrapingScheduleDTO = registry.register(
+    'UpdateScrapingSchedule',
+    z.object({
+      name: z.string().min(1).max(100).optional(),
+      store: z.string().min(1).optional(),
+      cron: z.string().min(1).optional(),
+      enabled: z.boolean().optional(),
+      jobs: z.array(z.object({}).passthrough()).min(1).optional(),
+    }),
+  );
+
+  const StoreInfoResponse = z.object({
+    key: z.string().openapi({ description: 'Store key', example: 'revolico' }),
+    displayName: z.string().openapi({ description: 'Human-readable store name', example: 'Revolico' }),
+    scrapingQueue: z.string().openapi({ description: 'BullMQ queue name', example: 'PRODUCTS_SCRAPING' }),
+    jobSchema: z.object({
+      fields: z.array(
+        z.object({
+          name: z.string(),
+          type: z.enum(['string', 'number', 'boolean']),
+          required: z.boolean(),
+          label: z.string(),
+          placeholder: z.string().optional(),
+        }),
+      ),
+    }),
+  });
+  Schemas.StoreInfoDTO = registry.register('StoreInfo', StoreInfoResponse);
 }

--- a/src/main/docs/tags.ts
+++ b/src/main/docs/tags.ts
@@ -16,6 +16,7 @@ export const TAG = {
   ADMIN_ACCOUNTS: 'Admin - Accounts',
   ADMIN_ROLES: 'Admin - Roles',
   ADMIN_RULES: 'Admin - Rules',
+  ADMIN_SCHEDULES: 'Admin - Scraping Schedules',
 } as const;
 
 export const API_TAGS = [
@@ -35,4 +36,5 @@ export const API_TAGS = [
   { name: TAG.ADMIN_ACCOUNTS, description: 'Admin account management' },
   { name: TAG.ADMIN_ROLES, description: 'Admin role management' },
   { name: TAG.ADMIN_RULES, description: 'Admin rule-based extractor pattern management' },
+  { name: TAG.ADMIN_SCHEDULES, description: 'Admin automated scraping schedule management' },
 ];

--- a/src/main/scrapers/CLAUDE.md
+++ b/src/main/scrapers/CLAUDE.md
@@ -12,6 +12,7 @@ src/main/scrapers/
 ├── services/                          # Shared enrichment (attribute-extractor/)
 │   └── attribute-extractor/           # Rules → cache → LLM pipeline
 └── revolico/                          # Store-specific scraper
+    ├── index.ts                       # StoreRegistry registration for cron scheduler
     ├── controllers/                   # Admin API for expressions, configs
     ├── services/
     │   ├── scraping/                  # DOM fetch, JSONata execution, config registry
@@ -210,7 +211,32 @@ These are accumulated in `recordLlmCall()`. The endpoint calculates rates and es
 Examples: DeepSeek = 0.14, OpenAI = 2.50, Anthropic = 3.00.
 If unset, `estimatedSavingsUSD` is always 0.
 
-## 8. Cross-references
+## 8. Store registration for cron scheduler
+
+Each store module must register itself in the `StoreRegistry` at bootstrap so the cron scheduler can route scraping jobs to the correct queue. Create an `index.ts` at the store root:
+
+```typescript
+// src/main/scrapers/revolico/index.ts
+export function registerRevolicoStore(container: Container): void {
+  const registry = container.get<StoreRegistry>(TYPES.StoreRegistry);
+  registry.register('revolico', {
+    displayName: 'Revolico',
+    scrapingQueue: QUEUE_NAME.products_scraping,
+    jobSchema: {
+      fields: [
+        { name: 'category', type: 'string', required: true, label: 'Categoría' },
+        // ... store-specific fields
+      ],
+    },
+  });
+}
+```
+
+Call it in `app.ts` before `scheduler.initialize()`. The `jobSchema` fields drive dynamic forms in the admin dashboard — each store defines what parameters its scraping jobs accept.
+
+When adding a new store, follow this same pattern: create the `index.ts`, register the store, and call it in `app.ts`.
+
+## 9. Cross-references
 
 - `.claude/skills/revolico-scraper/SKILL.md` -- Revolico-specific gotchas: IIFE wrapper, CSS Modules selectors, JSONata expression administration (3 write paths, cache invalidation rules), `isPromoted` service vs expression, `JsonataExtractionError` code catalog
 - `src/main/scrapers/revolico/README.md` -- Human documentation: full architecture flow, curl/SQL transcripts, "adding a new scraper" recipe
@@ -218,8 +244,10 @@ If unset, `estimatedSavingsUSD` is always 0.
 - `.claude/skills/testing/SKILL.md` -- Jest patterns, MongoMemoryServer, Prisma mocks, ALS mocks, ESM `jose` workaround
 - `src/main/shared/container.ts` -- DI registrations for all scraper services
 - `src/main/shared/types.container.ts` -- Symbol definitions (`TYPES.ScraperConfigRegistry`, `TYPES.AnalyticsService`, etc.)
+- `.claude/skills/cron-scheduler/SKILL.md` -- Cron scheduler agent instructions (StoreRegistry, CronSchedulerService, store registration)
+- `src/main/cron/store-registry.ts` -- Store registry interface (`IStoreConfig`, `IFieldSchema`)
 
-## 9. Coding constraints
+## 10. Coding constraints
 
 All constraints from `src/main/CLAUDE.md` apply, plus:
 

--- a/src/main/scrapers/revolico/index.ts
+++ b/src/main/scrapers/revolico/index.ts
@@ -1,0 +1,49 @@
+import { Container } from 'inversify';
+import { StoreRegistry } from '@cron/store-registry';
+import { TYPES } from '@shared/types.container';
+import { QUEUE_NAME } from './queues';
+
+/**
+ * Registers the Revolico store in the {@link StoreRegistry} so the cron
+ * scheduler knows which queue to route scraping jobs to and the admin
+ * dashboard can render job forms dynamically.
+ */
+export function registerRevolicoStore(container: Container): void {
+  const registry = container.get<StoreRegistry>(TYPES.StoreRegistry);
+  registry.register('revolico', {
+    displayName: 'Revolico',
+    scrapingQueue: QUEUE_NAME.products_scraping,
+    jobSchema: {
+      fields: [
+        {
+          name: 'category',
+          type: 'string',
+          required: true,
+          label: 'Categoría',
+          placeholder: 'ej. celulares',
+        },
+        {
+          name: 'subcategory',
+          type: 'string',
+          required: false,
+          label: 'Subcategoría',
+          placeholder: 'ej. telefonos',
+        },
+        {
+          name: 'pageNumber',
+          type: 'number',
+          required: false,
+          label: 'Página inicial',
+          placeholder: '1',
+        },
+        {
+          name: 'totalPages',
+          type: 'number',
+          required: false,
+          label: 'Total de páginas',
+          placeholder: '3',
+        },
+      ],
+    },
+  });
+}

--- a/src/main/shared/container.ts
+++ b/src/main/shared/container.ts
@@ -86,6 +86,14 @@ import { RuleRepository } from '@scrapers/services/attribute-extractor/repositor
 import { RuleRegistryService } from '@scrapers/services/attribute-extractor/rule-registry.service';
 import { RuleService } from '@admin/services/rule.service';
 import { RuleBasedExtractorService } from '@scrapers/services/attribute-extractor/rule-based-extractor.service';
+
+// Cron module
+import { StoreRegistry } from '@cron/store-registry';
+import { CronSchedulerService } from '@cron/services/scheduler.service';
+import { ScheduleRepository } from '@cron/repositories/schedule.repository';
+import { ScheduleService } from '@cron/services/schedule.service';
+import { ScheduleController } from '@cron/controllers/schedule.controller';
+import { StoreInfoController } from '@cron/controllers/schedule.controller';
 import { AttributeExtractorService } from '@scrapers/services/attribute-extractor/attribute-extractor.service';
 import { KeywordsCache } from '@scrapers/services/attribute-extractor/keywords-cache';
 import { EnrichmentMetricsService } from '@scrapers/services/enrichment-metrics.service';
@@ -205,6 +213,14 @@ container.bind(TYPES.ScraperConfigRepository).to(ScraperConfigRepository);
 container.bind<RuleRepository>(TYPES.RuleRepository).to(RuleRepository).inSingletonScope();
 container.bind<RuleRegistryService>(TYPES.RuleRegistry).to(RuleRegistryService).inSingletonScope();
 container.bind<RuleService>(TYPES.RuleService).to(RuleService).inSingletonScope();
+
+// Cron module — automated scraping scheduler
+container.bind<StoreRegistry>(TYPES.StoreRegistry).to(StoreRegistry).inSingletonScope();
+container.bind<CronSchedulerService>(TYPES.CronSchedulerService).to(CronSchedulerService).inSingletonScope();
+container.bind<ScheduleRepository>(TYPES.ScheduleRepository).to(ScheduleRepository).inSingletonScope();
+container.bind<ScheduleService>(TYPES.ScheduleService).to(ScheduleService).inSingletonScope();
+container.bind<ScheduleController>(TYPES.ScheduleController).to(ScheduleController);
+container.bind<StoreInfoController>(TYPES.StoreInfoController).to(StoreInfoController);
 
 // JSONata-driven scraping
 container.bind<JsonataRunnerService>(TYPES.JsonataRunner).to(JsonataRunnerService).inSingletonScope();

--- a/src/main/shared/types.container.ts
+++ b/src/main/shared/types.container.ts
@@ -96,4 +96,11 @@ export const TYPES = {
   AccountAdminService: Symbol.for('AccountAdminService'),
   RoleController: Symbol.for('RoleController'),
   RoleService: Symbol.for('RoleService'),
+  // Cron module (scraping schedules)
+  StoreRegistry: Symbol.for('StoreRegistry'),
+  CronSchedulerService: Symbol.for('CronSchedulerService'),
+  ScheduleService: Symbol.for('ScheduleService'),
+  ScheduleRepository: Symbol.for('ScheduleRepository'),
+  ScheduleController: Symbol.for('ScheduleController'),
+  StoreInfoController: Symbol.for('StoreInfoController'),
 };

--- a/src/main/types/node-cron.d.ts
+++ b/src/main/types/node-cron.d.ts
@@ -1,0 +1,23 @@
+/**
+ * Minimal type declarations for `node-cron` v3.
+ *
+ * The package ships with no bundled types and there is no
+ * `@types/node-cron`.  This declaration covers the subset of the
+ * public API used by the project.
+ */
+declare module 'node-cron' {
+  interface IScheduledTask {
+    start(): void;
+    stop(): void;
+  }
+
+  /**
+   * Creates a scheduled task.
+   *
+   * @param expression  Cron expression (e.g. "every 5 minutes" = `"/5 * * * *"`).
+   * @param func        Callback invoked when the cron expression fires.
+   * @param options     `scheduled: false` creates a paused task; `timezone`
+   *                    sets the timezone for the expression.
+   */
+  function schedule(expression: string, func: () => void, options?: { scheduled?: boolean; timezone?: string }): IScheduledTask;
+}

--- a/swagger.json
+++ b/swagger.json
@@ -75,6 +75,10 @@
     {
       "name": "Admin - Rules",
       "description": "Admin rule-based extractor pattern management"
+    },
+    {
+      "name": "Admin - Scraping Schedules",
+      "description": "Admin automated scraping schedule management"
     }
   ],
   "security": [
@@ -1881,6 +1885,217 @@
         },
         "required": [
           "values"
+        ]
+      },
+      "ScrapingScheduleResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Schedule unique identifier",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "name": {
+            "type": "string",
+            "description": "Human-readable schedule name",
+            "example": "Daily morning scrape"
+          },
+          "store": {
+            "type": "string",
+            "description": "Store key this schedule targets",
+            "example": "revolico"
+          },
+          "cron": {
+            "type": "string",
+            "description": "Cron expression",
+            "example": "0 6 * * *"
+          },
+          "enabled": {
+            "type": "boolean",
+            "description": "Whether the schedule is active",
+            "example": true
+          },
+          "jobs": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {}
+            },
+            "description": "Array of store-specific scraping job descriptors"
+          },
+          "lastRunAt": {
+            "type": "string",
+            "nullable": true,
+            "description": "ISO timestamp of last execution"
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "Creation timestamp",
+            "example": "2024-01-01T00:00:00.000Z"
+          },
+          "updatedAt": {
+            "type": "string",
+            "description": "Last update timestamp",
+            "example": "2024-01-01T00:00:00.000Z"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "store",
+          "cron",
+          "enabled",
+          "jobs",
+          "lastRunAt",
+          "createdAt",
+          "updatedAt"
+        ]
+      },
+      "CreateScrapingSchedule": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 100,
+            "description": "Unique schedule name",
+            "example": "Daily morning scrape"
+          },
+          "store": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Store key",
+            "example": "revolico"
+          },
+          "cron": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Cron expression",
+            "example": "0 6 * * *"
+          },
+          "enabled": {
+            "type": "boolean",
+            "description": "Enable on creation (defaults to true)",
+            "example": true
+          },
+          "jobs": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {}
+            },
+            "minItems": 1,
+            "description": "Array of job descriptors",
+            "example": [
+              {
+                "category": "celulares"
+              }
+            ]
+          }
+        },
+        "required": [
+          "name",
+          "store",
+          "cron",
+          "jobs"
+        ]
+      },
+      "UpdateScrapingSchedule": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 100
+          },
+          "store": {
+            "type": "string",
+            "minLength": 1
+          },
+          "cron": {
+            "type": "string",
+            "minLength": 1
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "jobs": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {}
+            },
+            "minItems": 1
+          }
+        }
+      },
+      "StoreInfo": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "Store key",
+            "example": "revolico"
+          },
+          "displayName": {
+            "type": "string",
+            "description": "Human-readable store name",
+            "example": "Revolico"
+          },
+          "scrapingQueue": {
+            "type": "string",
+            "description": "BullMQ queue name",
+            "example": "PRODUCTS_SCRAPING"
+          },
+          "jobSchema": {
+            "type": "object",
+            "properties": {
+              "fields": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "string",
+                        "number",
+                        "boolean"
+                      ]
+                    },
+                    "required": {
+                      "type": "boolean"
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "placeholder": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "name",
+                    "type",
+                    "required",
+                    "label"
+                  ]
+                }
+              }
+            },
+            "required": [
+              "fields"
+            ]
+          }
+        },
+        "required": [
+          "key",
+          "displayName",
+          "scrapingQueue",
+          "jobSchema"
         ]
       },
       "AuthResponseDTO": {
@@ -13887,6 +14102,1353 @@
           },
           "403": {
             "description": "Forbidden - insufficient role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/stores": {
+      "get": {
+        "tags": [
+          "Admin - Scraping Schedules"
+        ],
+        "summary": "List registered stores with job schemas",
+        "operationId": "adminListStores",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of registered stores",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "stores": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/StoreInfo"
+                      }
+                    }
+                  },
+                  "required": [
+                    "stores"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - missing or invalid token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden - insufficient role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/scraping-schedules": {
+      "get": {
+        "tags": [
+          "Admin - Scraping Schedules"
+        ],
+        "summary": "List all scraping schedules",
+        "operationId": "adminListSchedules",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of all schedules",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "schedules": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/ScrapingScheduleResponse"
+                      }
+                    }
+                  },
+                  "required": [
+                    "schedules"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - missing or invalid token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden - insufficient role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Admin - Scraping Schedules"
+        ],
+        "summary": "Create a new scraping schedule",
+        "operationId": "adminCreateSchedule",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "description": "Schedule creation data",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateScrapingSchedule"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Schedule created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "schedule": {
+                      "$ref": "#/components/schemas/ScrapingScheduleResponse"
+                    }
+                  },
+                  "required": [
+                    "schedule"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - missing or invalid token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden - insufficient role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/scraping-schedules/{id}": {
+      "get": {
+        "tags": [
+          "Admin - Scraping Schedules"
+        ],
+        "summary": "Get a single scraping schedule by ID",
+        "operationId": "adminGetSchedule",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Schedule unique identifier"
+            },
+            "required": true,
+            "description": "Schedule unique identifier",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Schedule detail",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "schedule": {
+                      "$ref": "#/components/schemas/ScrapingScheduleResponse"
+                    }
+                  },
+                  "required": [
+                    "schedule"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - missing or invalid token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden - insufficient role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Admin - Scraping Schedules"
+        ],
+        "summary": "Update an existing scraping schedule",
+        "operationId": "adminUpdateSchedule",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Schedule unique identifier"
+            },
+            "required": true,
+            "description": "Schedule unique identifier",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "description": "Schedule update data (partial)",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateScrapingSchedule"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Schedule updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "schedule": {
+                      "$ref": "#/components/schemas/ScrapingScheduleResponse"
+                    }
+                  },
+                  "required": [
+                    "schedule"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - missing or invalid token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden - insufficient role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Admin - Scraping Schedules"
+        ],
+        "summary": "Delete a scraping schedule",
+        "operationId": "adminDeleteSchedule",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Schedule unique identifier"
+            },
+            "required": true,
+            "description": "Schedule unique identifier",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Schedule deleted"
+          },
+          "401": {
+            "description": "Unauthorized - missing or invalid token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden - insufficient role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/scraping-schedules/{id}/toggle": {
+      "patch": {
+        "tags": [
+          "Admin - Scraping Schedules"
+        ],
+        "summary": "Toggle schedule enabled/disabled",
+        "operationId": "adminToggleSchedule",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Schedule unique identifier"
+            },
+            "required": true,
+            "description": "Schedule unique identifier",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Schedule toggled",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "schedule": {
+                      "$ref": "#/components/schemas/ScrapingScheduleResponse"
+                    }
+                  },
+                  "required": [
+                    "schedule"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - missing or invalid token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden - insufficient role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
             "content": {
               "application/json": {
                 "schema": {


### PR DESCRIPTION
## Summary

Adds a cron-based automated scraping scheduler that supports multiple stores with flexible, store-specific job parameters.

## Architecture

- **`src/main/cron/`** — new module with StoreRegistry, CronSchedulerService, ScheduleService, ScheduleController
- **`ScrapingSchedule`** — Prisma model with name, store, cron expression, enabled flag, generic JSON jobs array
- **node-cron** — already in `package.json`, now used for the first time
- **7 REST endpoints** at `/api/admin/scraping-schedules` + `/api/admin/stores`

## Key Design Decisions

| Decision | Choice |
|----------|--------|
| Store → Queue resolution | StoreRegistry (in-memory Map) |
| Job parameters | Generic JSON (passthrough Zod) |
| Scheduling engine | node-cron |
| Auth | SUPER_ADMIN only |
| Frontend forms | jobSchema metadata per store |

## Changes

- `prisma/schema.prisma` — ScrapingSchedule model + migration
- `src/main/cron/` — 13 new files (controllers, services, repositories, mappers, errors, store-registry)
- `src/main/scrapers/revolico/index.ts` — store registration
- `src/main/shared/container.ts` + `types.container.ts` — 6 DI bindings
- `src/main/app.ts` — bootstrap + shutdown integration
- `src/main/docs/` — OpenAPI schemas + 7 path entries
- `swagger.json` — regenerated

## Verification

- ✅ TypeScript compiles with 0 errors
- ✅ ESLint clean
- ✅ All 71 test suites, 729 tests passing
- ✅ OpenAPI swagger.json generated (47 schemas, 52 paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)