### PR TITLE
feat(scraper): make LLM keyword extraction prompt runtime-manageable

### DIFF
--- a/.claude/skills/revolico-scraper/SKILL.md
+++ b/.claude/skills/revolico-scraper/SKILL.md
@@ -136,23 +136,43 @@ overwritten by the scraper — only the admin API modifies it.
 
 `ScraperConfig` (Postgres table, Prisma model) supports `storeKey` values
 with the `llm:` prefix. These keys skip JSONata expression validation in
-`ScraperConfigRegistry` because they store raw LLM prompts, not
-expressions.
+`ScraperConfigRepository.upsert()` because they store raw LLM prompts, not
+JSONata expressions.
 
 | Key | Purpose | Content |
 |---|---|---|
-| `llm:keyword-extraction-prompt` | System prompt for the LLM extractor | Instructions telling the LLM how to extract product attributes from a page |
+| `llm:keyword-extraction-prompt` | System prompt for the LLM extractor | Instructions telling the LLM how to extract keywords from a description |
 
-`llm:*` keys are read by `LlmExtractorService` (part of the attribute
-extraction pipeline). They are editable via the same
+### Prompt resolution chain
+
+`AttributeExtractorService._loadSystemPrompt()` resolves the prompt in three
+tiers:
+
+```
+1. DB (ScraperConfig llm:keyword-extraction-prompt)
+     ↓ fallback
+2. Env var (LLM_KEYWORD_EXTRACTION_PROMPT)
+     ↓ fallback
+3. Hardcoded FALLBACK_SYSTEM_PROMPT (in llm-extractor.service.ts)
+```
+
+- **DB**: manageable at runtime via `PUT/POST /api/revolicos/scraper-configs`.
+  Cache is invalidated on write — change takes effect immediately.
+- **Env var**: configurable at deploy time. No restart needed between deployments.
+- **Hardcoded**: safety net. An `[ALERT]` warning is logged when reached.
+
+### Editing `llm:*` keys
+
+`llm:*` keys are editable via the same
 `PUT/POST /api/revolicos/scraper-configs/:storeKey` API as expression
-keys. The API path invalidates the cache on write just like expression
-keys, but the consumer is the LLM service rather than the JSONata runner.
+keys. The `storeKey.startsWith('llm:')` guard in the repository skips
+JSONata validation, so plain-text prompts pass through. The API write
+invalidates the cache immediately.
 
 Future `llm:*` keys (e.g. `llm:category-classifier-prompt`,
 `llm:condition-evaluator-prompt`) follow the same pattern: store the
-prompt text in `ScraperConfig.value`, name it `llm:<purpose>`, and let
-the relevant service read it through `ScraperConfigRegistry`.
+prompt text in `ScraperConfig.expression`, name it `llm:<purpose>`, and
+let the relevant service read it through `ScraperConfigRegistry`.
 
 ## 11. Enrichment metrics
 

--- a/.env.example
+++ b/.env.example
@@ -99,6 +99,10 @@ LLM_TEMPERATURE=0
 # Enable DeepSeek-style thinking/reasoning mode. Default: true.
 # Set to false on simple extraction tasks to save tokens (~65% fewer tokens).
 LLM_ENABLE_REASONING=true
+# Custom system prompt for keyword extraction. Optional — if set, overrides
+# the hardcoded fallback but is overridden by the DB-stored prompt
+# (ScraperConfig with storeKey="llm:keyword-extraction-prompt").
+# LLM_KEYWORD_EXTRACTION_PROMPT=
 # Number of days before a cached keyword entry expires from MongoDB.
 # Default: 30. Set to 0 to disable cache expiry.
 LLM_CACHE_TTL_DAYS=30

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -68,9 +68,41 @@ const REVOLICO_DETAIL_EXPRESSION = `(
   }|
 )`;
 
+// Keep in sync with FALLBACK_SYSTEM_PROMPT in:
+// src/main/scrapers/services/attribute-extractor/llm-extractor.service.ts
+const LLM_KEYWORD_EXTRACTION_PROMPT =
+  'You are a classified-ad keyword extraction assistant for Cuban marketplaces (e.g. Revolico). ' +
+  'Extract relevant keywords that represent the product being advertised.\n\n' +
+  'STRICT RULES:\n' +
+  '- Only include information EXPLICITLY present in the description.\n' +
+  '- Do not invent brands, prices, locations, or features not written in the text.\n' +
+  '- Prefer short 1–3 word phrases (e.g. "casa independiente", "iphone 14").\n' +
+  '- Include: product type, brand/model, location, condition, ' +
+  'distinctive features (bedrooms, bathrooms, garage, storage, color, etc.).\n' +
+  '- Omit sales filler words: "se vende", "vendo", "venta de", "precio", "oferta".\n' +
+  '- Order keywords by relevance (most distinctive first).\n' +
+  '- Respond in the SAME LANGUAGE as the input description.\n\n' +
+  'EXAMPLE 1:\n' +
+  'Description: "Apartamento en Miramar 3 cuartos 2 baños excelente estado"\n' +
+  'Keywords: ["apartamento", "miramar", "3 cuartos", "2 baños", "excelente estado"]\n\n' +
+  'EXAMPLE 2:\n' +
+  'Description: "iPhone 14 Pro Max 256GB negro como nuevo con garantía"\n' +
+  'Keywords: ["iphone 14 pro max", "256gb", "negro", "como nuevo", "con garantía"]\n\n' +
+  'EXAMPLE 3:\n' +
+  'Description: "Casa independiente biplanta en Playa con garaje 4 cuartos"\n' +
+  'Keywords: ["casa independiente", "playa", "biplanta", "garaje", "4 cuartos"]\n\n' +
+  'EXAMPLE 4:\n' +
+  'Description: "Vendo Laptop Dell Inspiron 15 3000 Series 8GB RAM"\n' +
+  'Keywords: ["laptop", "dell inspiron", "15 pulgadas", "8gb ram", "laptop dell"]\n\n' +
+  'EXAMPLE 5:\n' +
+  'Description: "Se vende auto Hyundai Accent 2018 azul impecable"\n' +
+  'Keywords: ["hyundai accent", "2018", "azul", "impecable", "auto"]\n\n' +
+  'Output ONLY the JSON object { "keywords": [...] }. Nothing else.';
+
 const SCRAPER_CONFIGS = [
   { storeKey: 'revolico:listing', expression: REVOLICO_LISTING_EXPRESSION },
   { storeKey: 'revolico:detail', expression: REVOLICO_DETAIL_EXPRESSION },
+  { storeKey: 'llm:keyword-extraction-prompt', expression: LLM_KEYWORD_EXTRACTION_PROMPT },
 ] as const;
 
 async function main(): Promise<void> {

--- a/src/__tests__/integration/scraper-config-api.test.ts
+++ b/src/__tests__/integration/scraper-config-api.test.ts
@@ -27,6 +27,7 @@ let superAdminToken: string;
 
 const TEST_STORE_KEY = 'test:scraper-config:integration';
 const SECOND_STORE_KEY = 'test:scraper-config:list';
+const LLM_TEST_STORE_KEY = 'llm:test-prompt:integration';
 
 beforeAll(async () => {
   appInstance = new App();
@@ -72,7 +73,11 @@ beforeAll(async () => {
 afterAll(async () => {
   try {
     // Remove any ScraperConfig rows this test created (regardless of success)
-    await pgDb.query(`DELETE FROM public."ScraperConfig" WHERE "storeKey" IN ($1, $2)`, [TEST_STORE_KEY, SECOND_STORE_KEY]);
+    await pgDb.query(`DELETE FROM public."ScraperConfig" WHERE "storeKey" IN ($1, $2, $3)`, [
+      TEST_STORE_KEY,
+      SECOND_STORE_KEY,
+      LLM_TEST_STORE_KEY,
+    ]);
     // Delete bot-related FK tables first (each in its own try/catch — migration may not have run yet)
     try {
       await pgDb.query('DELETE FROM public."bot_link_audit" WHERE "accountId" = $1', [testAccountId]);
@@ -164,6 +169,28 @@ describe('POST /api/revolicos/scraper-configs', () => {
     expect(res.body.message.toLowerCase()).toContain('invalid jsonata');
   });
 
+  it('creates an llm: prefixed config with plain-text prompt (skips JSONata validation)', async () => {
+    const promptText = 'You are a helpful keyword extraction assistant for classified ads.';
+    const res = await request(app)
+      .post('/api/revolicos/scraper-configs')
+      .set('Authorization', `Bearer ${superAdminToken}`)
+      .send({ storeKey: LLM_TEST_STORE_KEY, expression: promptText });
+
+    expect(res.status).toBe(201);
+    expect(res.body.data.config).toMatchObject({
+      storeKey: LLM_TEST_STORE_KEY,
+      expression: promptText,
+      enabled: true,
+    });
+
+    // Verify it landed in Postgres
+    const dbRes = await pgDb.query(`SELECT "expression" FROM public."ScraperConfig" WHERE "storeKey" = $1`, [LLM_TEST_STORE_KEY]);
+    expect(dbRes.rows[0].expression).toBe(promptText);
+
+    // Cleanup the llm test row
+    await pgDb.query(`DELETE FROM public."ScraperConfig" WHERE "storeKey" = $1`, [LLM_TEST_STORE_KEY]);
+  });
+
   it('returns 400 when the body is missing required fields', async () => {
     const res = await request(app)
       .post('/api/revolicos/scraper-configs')
@@ -250,7 +277,7 @@ describe('PUT /api/revolicos/scraper-configs/:storeKey', () => {
   });
 
   afterEach(async () => {
-    await pgDb.query(`DELETE FROM public."ScraperConfig" WHERE "storeKey" = $1`, [TEST_STORE_KEY]);
+    await pgDb.query(`DELETE FROM public."ScraperConfig" WHERE "storeKey" IN ($1, $2)`, [TEST_STORE_KEY, LLM_TEST_STORE_KEY]);
   });
 
   it('updates the expression and the response reflects the new value', async () => {
@@ -290,5 +317,27 @@ describe('PUT /api/revolicos/scraper-configs/:storeKey', () => {
       .set('Authorization', `Bearer ${memberToken}`)
       .send({ expression: '$.foo' });
     expect(res.status).toBe(403);
+  });
+
+  it('accepts plain-text prompt for llm: prefixed keys (skips JSONata validation)', async () => {
+    // Seed the llm test row
+    const now = new Date();
+    await pgDb.query(
+      `INSERT INTO public."ScraperConfig" ("id", "storeKey", "expression", "version", "createdAt", "updatedAt") VALUES ($1, $2, 'Old prompt', 1, $3, $3) ON CONFLICT ("storeKey") DO NOTHING`,
+      [uuidv4(), LLM_TEST_STORE_KEY, now],
+    );
+
+    const newPrompt = 'You are an improved assistant. Extract only the most relevant keywords.';
+    const res = await request(app)
+      .put(`/api/revolicos/scraper-configs/${LLM_TEST_STORE_KEY}`)
+      .set('Authorization', `Bearer ${superAdminToken}`)
+      .send({ expression: newPrompt });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.config.expression).toBe(newPrompt);
+
+    // Verify it landed in Postgres
+    const dbRes = await pgDb.query(`SELECT "expression" FROM public."ScraperConfig" WHERE "storeKey" = $1`, [LLM_TEST_STORE_KEY]);
+    expect(dbRes.rows[0].expression).toBe(newPrompt);
   });
 });

--- a/src/__tests__/unit/attribute-extractor.service.test.ts
+++ b/src/__tests__/unit/attribute-extractor.service.test.ts
@@ -4,9 +4,11 @@ import { KeywordsCache } from '@scrapers/services/attribute-extractor/keywords-c
 import { EnrichmentMetricsService } from '@scrapers/services/enrichment-metrics.service';
 import { ILogger } from '@shared/logger.interface';
 
-// Mock the standalone LLM function
+// Mock the standalone LLM function — must export FALLBACK_SYSTEM_PROMPT
+// so _loadSystemPrompt() can fall back to it when DB + env var are missing.
 jest.mock('@scrapers/services/attribute-extractor/llm-extractor.service', () => ({
   extractKeywords: jest.fn(),
+  FALLBACK_SYSTEM_PROMPT: 'You are a classified-ad keyword extraction assistant — MOCK FALLBACK',
 }));
 
 import { extractKeywords } from '@scrapers/services/attribute-extractor/llm-extractor.service';
@@ -62,6 +64,125 @@ describe('AttributeExtractorService', () => {
       metricsMock,
       makeLogger() as unknown as ILogger,
     );
+  });
+
+  describe('_loadSystemPrompt resolution chain', () => {
+    const envBackup = process.env.LLM_KEYWORD_EXTRACTION_PROMPT;
+
+    afterEach(() => {
+      delete process.env.LLM_KEYWORD_EXTRACTION_PROMPT;
+      if (envBackup) process.env.LLM_KEYWORD_EXTRACTION_PROMPT = envBackup;
+    });
+
+    it('uses DB prompt when ScraperConfig row exists', async () => {
+      const dbPrompt = 'Custom DB prompt — you are a keyword extraction assistant.';
+
+      // Rebuild service with a registry that returns the DB prompt
+      const promptRegistryMock = {
+        get: jest.fn().mockResolvedValue({ expression: dbPrompt }),
+      } as any;
+
+      const srv = new AttributeExtractorService(
+        rulesMock as RuleBasedExtractorService,
+        cacheMock,
+        promptRegistryMock,
+        {
+          recordRuleHighConfidence: jest.fn(),
+          recordCacheHit: jest.fn(),
+          recordCacheMiss: jest.fn(),
+          recordLlmCall: jest.fn(),
+          recordLlmFailure: jest.fn(),
+        } as unknown as EnrichmentMetricsService,
+        makeLogger() as unknown as ILogger,
+      );
+
+      rulesMock.extract.mockReturnValue({ attributes: {}, confidence: 0, matchedCount: 0 });
+      cacheMock.get.mockResolvedValue(null);
+      mockExtractKeywords.mockResolvedValue({ keywords: ['test'] });
+
+      await srv.extract('some product');
+
+      // The 3rd argument to extractKeywords is the resolved system prompt
+      const systemPromptArg = mockExtractKeywords.mock.calls[0][2];
+      expect(systemPromptArg).toBe(dbPrompt);
+    });
+
+    it('falls back to LLM_KEYWORD_EXTRACTION_PROMPT env var when DB is missing', async () => {
+      const envPrompt = 'Custom env prompt — you are an env-based assistant.';
+      process.env.LLM_KEYWORD_EXTRACTION_PROMPT = envPrompt;
+
+      // Rebuild service with a registry that throws (simulating DB missing)
+      const promptRegistryMock = {
+        get: jest.fn().mockRejectedValue(new Error('CONFIG_MISSING')),
+      } as any;
+
+      const log = makeLogger();
+      const srv = new AttributeExtractorService(
+        rulesMock as RuleBasedExtractorService,
+        cacheMock,
+        promptRegistryMock,
+        {
+          recordRuleHighConfidence: jest.fn(),
+          recordCacheHit: jest.fn(),
+          recordCacheMiss: jest.fn(),
+          recordLlmCall: jest.fn(),
+          recordLlmFailure: jest.fn(),
+        } as unknown as EnrichmentMetricsService,
+        log as unknown as ILogger,
+      );
+
+      rulesMock.extract.mockReturnValue({ attributes: {}, confidence: 0, matchedCount: 0 });
+      cacheMock.get.mockResolvedValue(null);
+      mockExtractKeywords.mockResolvedValue({ keywords: ['test'] });
+
+      await srv.extract('some product');
+
+      const systemPromptArg = mockExtractKeywords.mock.calls[0][2];
+      expect(systemPromptArg).toBe(envPrompt);
+      expect(log.info).toHaveBeenCalledWith('Using LLM_KEYWORD_EXTRACTION_PROMPT from environment');
+    });
+
+    it('falls back to hardcoded FALLBACK_SYSTEM_PROMPT when DB and env var are both missing', async () => {
+      // Ensure env var is not set
+      const savedEnv = process.env.LLM_KEYWORD_EXTRACTION_PROMPT;
+      delete process.env.LLM_KEYWORD_EXTRACTION_PROMPT;
+
+      try {
+        // Rebuild service with a registry that throws (simulating DB missing)
+        const promptRegistryMock = {
+          get: jest.fn().mockRejectedValue(new Error('CONFIG_MISSING')),
+        } as any;
+
+        const log = makeLogger();
+        const localCache = makeCache();
+        const srv = new AttributeExtractorService(
+          rulesMock as RuleBasedExtractorService,
+          localCache,
+          promptRegistryMock,
+          {
+            recordRuleHighConfidence: jest.fn(),
+            recordCacheHit: jest.fn(),
+            recordCacheMiss: jest.fn(),
+            recordLlmCall: jest.fn(),
+            recordLlmFailure: jest.fn(),
+          } as unknown as EnrichmentMetricsService,
+          log as unknown as ILogger,
+        );
+
+        rulesMock.extract.mockReturnValue({ attributes: {}, confidence: 0, matchedCount: 0 });
+        mockExtractKeywords.mockResolvedValue({ keywords: ['test'] });
+
+        await srv.extract('some product');
+
+        // Verify extractKeywords was called with the fallback prompt as 3rd argument
+        expect(mockExtractKeywords).toHaveBeenCalled();
+        const systemPromptArg = mockExtractKeywords.mock.calls[0][2];
+        expect(systemPromptArg).toContain('MOCK FALLBACK');
+        expect(log.warn).toHaveBeenCalledWith(expect.stringContaining('[ALERT]'));
+      } finally {
+        if (savedEnv) process.env.LLM_KEYWORD_EXTRACTION_PROMPT = savedEnv;
+      }
+    });
   });
 
   describe('orchestration', () => {

--- a/src/__tests__/unit/llm-extractor.service.test.ts
+++ b/src/__tests__/unit/llm-extractor.service.test.ts
@@ -47,6 +47,21 @@ describe('extractKeywords (Vercel AI SDK)', () => {
       expect(mockGenerateText).toHaveBeenCalledTimes(1);
     });
 
+    it('accepts more than 5 keywords when LLM returns them', async () => {
+      mockGenerateText.mockResolvedValueOnce({
+        text: '{"keywords": ["casa", "miramar", "3 cuartos", "garaje", "independiente", "planta alta", "patio"]}',
+        usage: undefined,
+      } as any);
+
+      const log = makeLogger();
+      const result = await extractKeywords('Casa en Miramar 3 cuartos garaje independiente planta alta patio', log);
+
+      // All 7 keywords are preserved — no artificial truncation
+      expect(result.keywords).toHaveLength(7);
+      expect(result.keywords).toEqual(['casa', 'miramar', '3 cuartos', 'garaje', 'independiente', 'planta alta', 'patio']);
+      expect(log.warn).not.toHaveBeenCalled();
+    });
+
     it('returns usage when provider reports token data', async () => {
       mockGenerateText.mockResolvedValueOnce({
         text: '{"keywords": ["iphone", "14 pro"]}',

--- a/src/__tests__/unit/scraper-config.repository.test.ts
+++ b/src/__tests__/unit/scraper-config.repository.test.ts
@@ -115,6 +115,30 @@ describe('ScraperConfigRepository', () => {
         update: { expression: '{ "a": 1 }' },
       });
     });
+
+    it('skips JSONata validation for storeKeys starting with "llm:"', async () => {
+      const promptText = 'You are a helpful assistant. Extract keywords.';
+      const persisted = makeConfig({ storeKey: 'llm:keyword-extraction-prompt', expression: promptText, version: 1 });
+      prismaMock.scraperConfig.upsert.mockResolvedValueOnce(persisted);
+
+      const result = await repo.upsert('llm:keyword-extraction-prompt', promptText);
+
+      expect(result).toEqual(persisted);
+      expect(runnerMock.validate).not.toHaveBeenCalled();
+      expect(prismaMock.scraperConfig.upsert).toHaveBeenCalledWith({
+        where: { storeKey: 'llm:keyword-extraction-prompt' },
+        create: { storeKey: 'llm:keyword-extraction-prompt', expression: promptText },
+        update: { expression: promptText },
+      });
+    });
+
+    it('still validates JSONata for non-llm storeKeys', async () => {
+      runnerMock.validate.mockReturnValueOnce({ ok: false, error: 'Syntax error at position 1' });
+
+      await expect(repo.upsert('revolico:listing', ')(')).rejects.toThrow(/invalid jsonata/i);
+      expect(runnerMock.validate).toHaveBeenCalledWith(')(');
+      expect(prismaMock.scraperConfig.upsert).not.toHaveBeenCalled();
+    });
   });
 
   describe('findAll', () => {

--- a/src/main/docs/schema-registry.ts
+++ b/src/main/docs/schema-registry.ts
@@ -88,7 +88,7 @@ const ScraperConfigResponseSchema = z.object({
     example: 'revolico:listing',
   }),
   expression: z.string().openapi({
-    description: 'JSONata expression evaluated against the scraped DOM tree',
+    description: 'JSONata expression (or plain-text prompt for storeKeys prefixed with "llm:")',
     example: '$ ~> | $ | { "products": $ | [*] } |',
   }),
   version: z.number().int().openapi({ description: 'Monotonic version counter', example: 1 }),
@@ -103,14 +103,14 @@ const ScraperConfigCreateSchema = z.object({
     example: 'revolico:listing',
   }),
   expression: z.string().min(1).openapi({
-    description: 'JSONata expression to persist',
+    description: 'JSONata expression to persist (or plain-text prompt for storeKeys prefixed with "llm:")',
     example: '$ ~> | $ | { "products": $ | [*] } |',
   }),
 });
 
 const ScraperConfigUpdateSchema = z.object({
   expression: z.string().min(1).openapi({
-    description: 'New JSONata expression',
+    description: 'New JSONata expression (or plain-text prompt for storeKeys prefixed with "llm:")',
     example: '$ ~> | $ | { "products": $ | [*] } |',
   }),
 });

--- a/src/main/scrapers/CLAUDE.md
+++ b/src/main/scrapers/CLAUDE.md
@@ -7,22 +7,7 @@ applyTo: 'src/main/scrapers/**'
 
 ## 1. Module structure
 
-```
-src/main/scrapers/
-├── services/                          # Shared enrichment (attribute-extractor/)
-│   └── attribute-extractor/           # Rules → cache → LLM pipeline
-└── revolico/                          # Store-specific scraper
-    ├── index.ts                       # StoreRegistry registration for cron scheduler
-    ├── controllers/                   # Admin API for expressions, configs
-    ├── services/
-    │   ├── scraping/                  # DOM fetch, JSONata execution, config registry
-    │   └── analytics.service.ts       # Pure computed metrics
-    ├── repositories/
-    ├── models/                        # Mongoose Product schema
-    ├── errors/                        # JsonataExtractionError catalog
-    ├── queues.ts                      # IQueueModule wiring
-    └── README.md                      # Full flow, curl/SQL, "adding a scraper" recipe
-```
+See `src/main/scrapers/README.md` for the full directory tree. Key rules for agents:
 
 - **`scrapers/services/`** is shared across all stores. Currently contains only `attribute-extractor/` (keyword enrichment). Do NOT put store-specific logic here.
 - **`scrapers/<store>/`** is store-specific. Each store implements the queue module and its own scraping services. Add new stores at this level (e.g. `scrapers/wallapop/`).
@@ -42,81 +27,41 @@ Located in `scrapers/services/attribute-extractor/`. Pipeline: rules first, then
 
 Depends on: `RuleBasedExtractorService`, `KeywordsCache`, `ScraperConfigRegistryService`, `ILogger`.
 
-### 2.2 RuleBasedExtractorService
+### 2.2 Rule-based extraction
 
-`rule-based-extractor.service.ts`. Deterministic regex patterns for Spanish classified-ad descriptions. 13 pattern categories:
+`rule-based-extractor.service.ts` + `rule-registry.service.ts`. Deterministic regex patterns for Spanish classified-ad descriptions.
 
-- **6 word-list categories** (brands, conditions, colors, propertyTypes, locations, warrantyKeywords) are read from `RuleRegistryService` — an in-memory cache backed by the `Rule` table in PostgreSQL. Editable at runtime via `PUT /api/admin/rules/:ruleKey` (SUPER_ADMIN). Falls back to hardcoded `FALLBACK_RULES` when the DB is unreachable.
-- **7 regex categories** (rooms, bathrooms, garage, floors, storage, RAM, originalPrice) remain as inline code.
+- **13 categories**: 6 word-lists (brands, conditions, colors, propertyTypes, locations, warrantyKeywords) from `RuleRegistryService` + 7 inline regex (rooms, bathrooms, garage, floors, storage, RAM, originalPrice).
+- **Confidence** = `matchedCount / 13`. Threshold 0.4. Accent-stripping applied.
+- **Purely synchronous, no I/O** — `RuleRegistryService.get()` reads from an in-memory `Map`. Falls back to hardcoded `FALLBACK_RULES` when the DB is unreachable.
+- **Runtime editable** via `PUT /api/admin/rules/:ruleKey` (SUPER_ADMIN). See `.claude/skills/revolico-scraper/SKILL.md` §12 for the write-path contract (API invalidates cache; seed/SQL do not).
+- Canonical fallback values in `rule-fallbacks.ts` (also used by `prisma/seed.ts`).
 
-Confidence = `matchedCount / 13`. Threshold is 0.4 in the orchestrator. Accent-stripping applied to all input so `súper` matches `super`. Purely synchronous, no I/O — `RuleRegistryService.get()` reads from an in-memory `Map`.
-
-### 2.3 RuleRegistryService
-
-`rule-registry.service.ts`. In-memory cache for the six word-list categories used by `RuleBasedExtractorService`.
-
-- **Bootstrap**: Populates the cache with `FALLBACK_RULES` on construction (synchronous, sub-millisecond).
-- **DB warm**: Async load from `Rule` table replaces entries when complete. Logs a warning and keeps fallbacks on failure.
-- **Invalidation**: Called by `RuleService` after every API write (create/update). Evicts the key and re-fetches from DB.
-- **TTL**: 30 seconds. On expiry, returns stale values while triggering a background refresh.
-
-See `rule-fallbacks.ts` for the canonical fallback values (also used by `prisma/seed.ts`).
-
-### 2.4 extractKeywords() (LLM)
+### 2.3 extractKeywords() (LLM)
 
 `llm-extractor.service.ts`. Standalone async function (not a class). Uses Vercel AI SDK (`generateText` from `ai`) with `@ai-sdk/openai-compatible` provider and `response_format: json_object` injected via custom fetch (compatible with DeepSeek thinking mode). JSON output is parsed and Zod-validated manually.
 
-Three env vars drive it: `LLM_BASE_URL`, `LLM_MODEL`, `LLM_API_KEY`. If any is missing, returns `{ keywords: [] }` silently (logs a warning). Supports any OpenAI-compatible endpoint (DeepSeek, OpenAI, custom base URL). An optional `LLM_ENABLE_REASONING` env var controls DeepSeek-style thinking mode (defaults to `true`; set to `false` to save tokens on simple extraction tasks).
+Provider-agnostic — driven by `LLM_BASE_URL`, `LLM_MODEL`, `LLM_API_KEY`. See `src/main/scrapers/README.md` for the full env var table. Uses `LLM_ENABLE_REASONING` to control DeepSeek thinking mode (defaults to `true`).
 
-Output validated by Zod schema: `{ keywords: z.array(z.string()).max(5) }`. Temperature 0. Returns `{ keywords: [] }` on any failure (network, timeout, bad response, malformed JSON). Never throw.
+Output validated by `z.array(z.string())` — no artificial keyword limit; the LLM decides how many keywords are relevant. Returns `{ keywords: [] }` on any failure. Never throws. See Section 6 for prompt management.
 
 ### 2.4 KeywordsCache
 
-`keywords-cache.ts`. Two-layer cache:
-
-- **Layer 1 (memory)**: `Map<string, string[]>` -- sub-millisecond lookup, lives for the process lifetime.
-- **Layer 2 (MongoDB)**: `keyword_cache` collection with TTL index on `createdAt` (default 30 days, configured by `LLM_CACHE_TTL_DAYS` env var).
-
-Key: MD5 hex of `description.trim().toLowerCase()`. Mongo hits auto-promote to memory. Mongo write failures are silently swallowed (cache is best-effort). Instantiated directly (bind to self in container).
+`keywords-cache.ts`. Two-layer cache (memory `Map` + MongoDB `keyword_cache` collection, TTL via `LLM_CACHE_TTL_DAYS`). Key: MD5 of `description.trim().toLowerCase()`. Mongo hits auto-promote to memory. Write failures silently swallowed. Bind to self in container.
 
 ### 2.5 DI registration pattern
 
-All four classes (`AttributeExtractorService`, `RuleBasedExtractorService`, `KeywordsCache`, `RuleRegistryService`) are registered in `src/main/shared/container.ts`. They bind to themselves (class-as-token) because they have no interfaces:
-
-```typescript
-container.bind<RuleBasedExtractorService>(RuleBasedExtractorService).to(RuleBasedExtractorService).inSingletonScope();
-container.bind<AttributeExtractorService>(AttributeExtractorService).to(AttributeExtractorService).inSingletonScope();
-```
-
-`AnalyticsService` is registered via a Symbol: `container.bind<AnalyticsService>(TYPES.AnalyticsService).to(AnalyticsService).inSingletonScope()`.
-
-When adding a new shared service: bind to self (class token) unless a store-specific implementation is expected (then use a `TYPES.Symbol` in `types.container.ts`).
+Shared enrichment services bind to themselves (class-as-token) in `src/main/shared/container.ts`. Use `TYPES.Symbol` only for store-specific implementations. `AnalyticsService` is the exception — it uses a Symbol. All singletons.
 
 ## 3. Analytics service
 
 `revolico/services/analytics.service.ts`. Pure computation -- **no DB, no I/O, no side effects**. The caller persists results to MongoDB.
 
-5 metrics derived from history arrays:
-
-| Metric | Method | Window | Formula |
-|--------|--------|--------|---------|
-| `viewsPerDay` | `_computeViewsPerDay` | all-time | views / days since first scrape |
-| `priceTrend` | `_computePriceTrend` | last 5 points | linear regression; slope > 2% avg = upward, < -2% = downward |
-| `priceVolatility` | `_computePriceVolatility` | last 10 points | CV = stddev / mean |
-| `priceChanges` | (inline) | all-time | max(0, history.length - 1) |
-| `hotScore` | `_computeHotScore` | all-time | viewsPerDay * outstandingBonus * priceDropBonus |
-
-Returns `null` when the product has zero price history entries. The `hotScore` formula: `viewsPerDay * (isOutstanding ? 2.0 : 1.0) * (lastPrice < prevPrice ? 1.5 : 1.0)`, rounded to 2 decimals.
+5 metrics derived from history arrays — see `src/main/scrapers/README.md` for the full table. Returns `null` when the product has zero price history entries. The `hotScore` formula: `viewsPerDay * (isOutstanding ? 2.0 : 1.0) * (lastPrice < prevPrice ? 1.5 : 1.0)`, rounded to 2 decimals.
 
 ## 4. Queue flow
 
-Defined in `revolico/queues.ts`. Three queues registered via `IQueueModule`:
-
-```
-PRODUCTS_SCRAPING  ──(scrape listing page)──▶  PRODUCT_STORAGE  ──(upsert products)──▶  (enrichment hooks)
-                                                                                       │
-PRODUCT_SCRAPING   ◀──(fan-out detail pages)────────────────────────────────────────────┘
-```
+Defined in `revolico/queues.ts`. Three queues registered via `IQueueModule`. See `src/main/scrapers/README.md` for the full pipeline diagram.
 
 1. **PRODUCTS_SCRAPING**: JSONata-driven listing scraper (`GenericListingScraperService`). Expression from `ScraperConfig` `"revolico:listing"`. Emits `ProductDataFromListDTO[]`.
 2. **PRODUCT_STORAGE**: Upserts products via `ProductService`. Runs enrichment hooks (attribute extraction, analytics) here. Fans out per-product `PRODUCT_SCRAPING` jobs for detail scraping.
@@ -128,88 +73,38 @@ Failed-job listener logs at error level with `jobId`, `jobName`, `reason`, `data
 
 ## 5. MongoDB product model
 
-`revolico/models/product.model.ts`. Collection: `products` (Mongoose pluralizes `Product`).
+`revolico/models/product.model.ts`. Collection: `products` (Mongoose pluralizes `Product`). See `src/main/scrapers/README.md` for the full field table (core, detail, history arrays, enrichment).
 
-Key fields:
-
-| Field | Type | Notes |
-|-------|------|-------|
-| `url` | string | Unique, upsert key |
-| `ID` | string | Unique, internal listing ID |
-| `price` | number | Current price |
-| `currency` | string | CUP, USD, etc. |
-| `description` | string | Raw listing text -- input for enrichment |
-| `isOutstanding` | boolean | Set by expression (`attrs.title = "Anuncio destacado"`) |
-| `isPromoted` | boolean | Set by **service** (`_mapRow`), NOT the expression. Promoted rows come from `result.promoted` array. |
-| `category` / `subcategory` | string | Listing taxonomy |
-| `location` | { state, municipality } | Extracted during scraping |
-| `seller` | { name, phone, email, whatsapp } | Extracted from listing |
-| `views` | number | Current view count |
-| `priceHistory` | [{ value, updatedAt }] | Appended on every upsert when price changes |
-| `viewsHistory` | [{ value, updatedAt }] | Appended when views change |
-| `isOutstandingHistory` | [{ value, updatedAt }] | Appended when outstanding status changes |
-| `isPromotedHistory` | [{ value, updatedAt }] | Appended when promoted status changes |
-| `locationHistory` | [{ value, updatedAt }] | Appended when location changes |
-
-Timestamps: `createdAt` / `updatedAt` via Mongoose `{ timestamps: true }`.
-
-**No tenant isolation** on MongoDB product data. Scraped products are shared across all tenants. Prisma tenant extensions do NOT apply here.
+Agent-critical notes:
+- **`isPromoted`** is set by the **service** (`_mapRow`), NOT the JSONata expression. Promoted rows come from `result.promoted` array.
+- **`isOutstanding`** IS set by the expression (`attrs.title = "Anuncio destacado"`).
+- History arrays use `$push` on upsert: `priceHistory`, `viewsHistory`, `isOutstandingHistory`, `isPromotedHistory`, `locationHistory`. Each entry is `{ value, updatedAt }`.
+- Timestamps: `createdAt` / `updatedAt` via Mongoose `{ timestamps: true }`.
+- **No tenant isolation** on MongoDB product data. Scraped products are shared across all tenants. Prisma tenant extensions do NOT apply here.
 
 ## 6. LLM prompt management
 
-The system prompt for keyword extraction is stored in the `ScraperConfig` database table (PostgreSQL, via Prisma), not hardcoded.
+Resolved in `AttributeExtractorService._loadSystemPrompt()` via three-tier chain:
+**DB** (`ScraperConfig llm:keyword-extraction-prompt`) → **env var** (`LLM_KEYWORD_EXTRACTION_PROMPT`) → **hardcoded** (`FALLBACK_SYSTEM_PROMPT`).
 
-- **Store key**: `llm:keyword-extraction-prompt`
-- **Field**: `expression` (string column, reused from JSONata expression storage)
-- **CRUD**: Existing `ScraperConfig` API at `PUT/POST/DELETE /api/revolicos/scraper-configs/:storeKey`
-- **Seed**: `npm run seed` inserts the canonical prompt into `ScraperConfig`
-- **Fallback**: `FALLBACK_SYSTEM_PROMPT` constant in `llm-extractor.service.ts` (~600 tokens, Spanish-language few-shot). Used ONLY when the DB prompt is missing or unreachable.
+### `llm:` prefix convention
 
-When the fallback is used, `AttributeExtractorService._loadSystemPrompt()` logs an `[ALERT]`-prefixed warning at warn level. This is a signal to the operator that the DB prompt is missing -- it should be seeded or set via API. The fallback ensures the pipeline never breaks on a missing config.
+`ScraperConfigRepository.upsert()` skips JSONata validation when
+`storeKey.startsWith('llm:')`. Plain-text prompts pass through the same API
+that validates JSONata for `revolico:*` keys. Future `llm:*` keys
+(e.g. `llm:category-classifier`) follow the same pattern.
 
-The `ScraperConfigRegistry` (in `revolico/services/scraping/`) caches each `storeKey` for 30 seconds. API writes invalidate the cache. Seed and raw SQL do NOT -- the worker picks up the new value on TTL expiry or process restart.
+### Managing the prompt
+
+- **API**: `PUT /api/revolicos/scraper-configs/llm:keyword-extraction-prompt` (runtime, no restart). Cache invalidates immediately.
+- **Env var**: `LLM_KEYWORD_EXTRACTION_PROMPT` (deploy-time). Used when DB row missing.
+- **Seed**: `npm run seed` inserts canonical prompt. Keep in sync with `FALLBACK_SYSTEM_PROMPT`.
+
+See `src/main/scrapers/README.md` for curl examples and `.claude/skills/revolico-scraper/SKILL.md` §10 for the full write-path contract.
 
 ## 7. Enrichment metrics
 
-`enrichment-metrics.service.ts`. In-memory singleton (no persistence) that accumulates counters across the enrichment pipeline. Exposed via admin API at `GET /api/admin/dashboard/enrichment` (`SUPER_ADMIN` only).
-
-### 7.1 Counters
-
-Every decision point in the 4-layer pipeline increments a counter:
-
-| Recorder | When | Layer |
-|----------|------|-------|
-| `recordEnrichment()` | Every `enrichProduct()` call | entry |
-| `recordEnrichmentHashSkip()` | Description unchanged since last enrichment | enrichmentHash guard |
-| `recordRuleHighConfidence()` | Rule confidence >= 0.4 | rule-based extractor |
-| `recordCacheHit()` | KeywordsCache hit (memory or MongoDB) | cache |
-| `recordCacheMiss()` | KeywordsCache miss (proceeds to LLM) | cache |
-| `recordLlmCall(usage)` | LLM returned successfully | LLM |
-| `recordLlmFailure()` | LLM threw (network, timeout, etc.) | LLM |
-
-### 7.2 LLM provider usage
-
-`extractKeywords()` now returns `ExtractKeywordsResult` which includes `usage?: LlmUsage` from the AI SDK `generateText` response. `LlmUsage` carries:
-- `promptCacheHitTokens` — tokens served from the provider's prompt cache
-- `promptCacheMissTokens` — tokens recomputed by the provider
-- `completionTokens` — tokens generated in the response
-
-These are accumulated in `recordLlmCall()`. The endpoint calculates rates and estimated savings.
-
-### 7.3 Admin endpoint
-
-`GET /api/admin/dashboard/enrichment` — `SUPER_ADMIN` only. Returns `EnrichmentMetricsSnapshot`:
-- All raw counters
-- Computed rates (skip rate, cache hit rate, LLM failure rate, LLM cache hit rate)
-- Token totals (prompt cache hit/miss, completion)
-- `estimatedSavingsUSD` — `(promptCacheHitTokens / 1e6) * LLM_COST_PER_MILLION_TOKENS`
-- `costPerMillionTokens` — value read from env var (0 if unset)
-
-### 7.4 Env var
-
-`LLM_COST_PER_MILLION_TOKENS` — price per 1M input tokens in USD. Optional.
-Examples: DeepSeek = 0.14, OpenAI = 2.50, Anthropic = 3.00.
-If unset, `estimatedSavingsUSD` is always 0.
+`enrichment-metrics.service.ts`. In-memory singleton (no persistence) that accumulates counters across the enrichment pipeline. See `src/main/scrapers/README.md` for the full counter table and admin endpoint response shape.
 
 ## 8. Store registration for cron scheduler
 
@@ -238,14 +133,17 @@ When adding a new store, follow this same pattern: create the `index.ts`, regist
 
 ## 9. Cross-references
 
-- `.claude/skills/revolico-scraper/SKILL.md` -- Revolico-specific gotchas: IIFE wrapper, CSS Modules selectors, JSONata expression administration (3 write paths, cache invalidation rules), `isPromoted` service vs expression, `JsonataExtractionError` code catalog
-- `src/main/scrapers/revolico/README.md` -- Human documentation: full architecture flow, curl/SQL transcripts, "adding a new scraper" recipe
-- `src/main/CLAUDE.md` -- General code patterns: DI, layers, queue system, logging, TDD workflow, coding constraints
-- `.claude/skills/testing/SKILL.md` -- Jest patterns, MongoMemoryServer, Prisma mocks, ALS mocks, ESM `jose` workaround
-- `src/main/shared/container.ts` -- DI registrations for all scraper services
-- `src/main/shared/types.container.ts` -- Symbol definitions (`TYPES.ScraperConfigRegistry`, `TYPES.AnalyticsService`, etc.)
-- `.claude/skills/cron-scheduler/SKILL.md` -- Cron scheduler agent instructions (StoreRegistry, CronSchedulerService, store registration)
-- `src/main/cron/store-registry.ts` -- Store registry interface (`IStoreConfig`, `IFieldSchema`)
+| File | Covers |
+|------|--------|
+| `src/main/scrapers/README.md` | Pipeline diagram, data model tables, env vars, enrichment metrics, prompt curl examples |
+| `src/main/scrapers/revolico/README.md` | Revolico architecture flow, curl/SQL transcripts, adding-a-scraper recipe |
+| `.claude/skills/revolico-scraper/SKILL.md` | IIFE wrapper, CSS Modules selectors, JSONata 3 write-paths, `isPromoted` vs expression, `JsonataExtractionError` catalog, `llm:*` keys, rule write-paths |
+| `src/main/CLAUDE.md` | DI, layers, queue system, logging, TDD workflow, coding constraints |
+| `.claude/skills/testing/SKILL.md` | Jest, MongoMemoryServer, Prisma mocks, ALS mocks, ESM `jose` workaround |
+| `.claude/skills/cron-scheduler/SKILL.md` | StoreRegistry, CronSchedulerService, store registration |
+| `src/main/shared/container.ts` | DI bindings |
+| `src/main/shared/types.container.ts` | Symbol definitions |
+| `src/main/cron/store-registry.ts` | `IStoreConfig`, `IFieldSchema` |
 
 ## 10. Coding constraints
 

--- a/src/main/scrapers/README.md
+++ b/src/main/scrapers/README.md
@@ -160,15 +160,44 @@ Three required env vars, one optional:
 | `LLM_MODEL` | Model identifier (e.g. `deepseek-v4-flash`) |
 | `LLM_API_KEY` | API key for the provider |
 | `LLM_ENABLE_REASONING` | (optional) Enables DeepSeek thinking mode. Defaults to `true`. Set to `false` to save tokens. |
+| `LLM_KEYWORD_EXTRACTION_PROMPT` | (optional) Custom system prompt for keyword extraction. Overrides the hardcoded fallback but is overridden by the DB-stored prompt. |
 
-If any variable is missing, LLM extraction is skipped silently and returns
-`{ keywords: [] }`. The system prompt is stored in the `ScraperConfig` table
-under store key `llm:keyword-extraction-prompt` and managed via the same
-CRUD API as scraper expressions. A hardcoded fallback prompt (~600 tokens,
-Spanish few-shot with 5 examples) is used when the DB prompt is unavailable.
+If any of `LLM_BASE_URL`, `LLM_MODEL`, or `LLM_API_KEY` is missing, LLM
+extraction is skipped silently and returns `{ keywords: [] }`.
 
-Output is validated by Zod (`z.array(z.string()).max(5)`) with `temperature:
-0`. Any failure (network, timeout, bad response) returns `{ keywords: [] }`.
+### Prompt management
+
+The system prompt for keyword extraction is resolved via a three-tier chain:
+
+```
+DB (ScraperConfig llm:keyword-extraction-prompt)
+  → Env var (LLM_KEYWORD_EXTRACTION_PROMPT)
+    → Hardcoded FALLBACK_SYSTEM_PROMPT
+```
+
+- **DB**: manageable at runtime via the ScraperConfig REST API — no restart
+  needed. The `llm:` prefix on the `storeKey` signals the repository to skip
+  JSONata validation, so plain-text prompts are accepted.
+- **Env var**: configurable at deploy time. Useful for ephemeral environments
+  or CI where seeding the DB is impractical.
+- **Hardcoded**: ~600-token Spanish few-shot with 5 examples. Safety net that
+  guarantees the pipeline never breaks on a missing config.
+
+To update the prompt at runtime:
+
+```bash
+curl -X PUT http://localhost:3000/api/revolicos/scraper-configs/llm:keyword-extraction-prompt \
+  -H "Authorization: Bearer <super-admin-token>" \
+  -H "Content-Type: application/json" \
+  -d '{"expression": "You are a keyword extraction assistant. ..."}'
+```
+
+The change takes effect immediately (the registry cache is invalidated on API
+write). Seed the prompt via `npm run seed` to persist it across database resets.
+
+Output is validated by Zod (`z.array(z.string())` — no artificial keyword
+limit) with `temperature: 0`. Any failure (network, timeout, bad response)
+returns `{ keywords: [] }`.
 
 ## Adding a new store
 

--- a/src/main/scrapers/revolico/services/scraping/repositories/scraper-config.repository.ts
+++ b/src/main/scrapers/revolico/services/scraping/repositories/scraper-config.repository.ts
@@ -66,22 +66,28 @@ export class ScraperConfigRepository {
 
   /**
    * Insert-or-update a row. Defense-in-depth: parses the expression via
-   * `JsonataRunnerService.validate` BEFORE persisting. Throws if invalid so a
-   * broken expression cannot land in the table and poison the next job.
+   * `JsonataRunnerService.validate` BEFORE persisting, unless the `storeKey`
+   * starts with `llm:` (those entries store natural-language prompts, not
+   * JSONata). Throws if a non-llm expression is invalid so a broken expression
+   * cannot land in the table and poison the next job.
    *
    * On update, the row's `version` is left untouched — the Prisma schema
    * bumps `updatedAt` automatically. Callers that need optimistic concurrency
    * should compare `version` outside this method.
    *
    * @param {string} storeKey - The ScraperConfig key.
-   * @param {string} expression - JSONata source.
+   * @param {string} expression - JSONata source, or plain-text prompt for `llm:*` keys.
    * @returns {Promise<ScraperConfigModel>} The persisted row.
-   * @throws {Error} If `runner.validate` returns `{ ok: false }`.
+   * @throws {Error} If `runner.validate` returns `{ ok: false }` for a non-llm key.
    */
   public async upsert(storeKey: string, expression: string): Promise<ScraperConfigModel> {
-    const validation = this._runner.validate(expression);
-    if (!validation.ok) {
-      throw new Error(`Invalid JSONata expression for storeKey="${storeKey}": ${validation.error}`);
+    // llm:* storeKeys hold natural-language prompts, not JSONata expressions.
+    // Skip JSONata validation so they can be managed via the ScraperConfig API.
+    if (!storeKey.startsWith('llm:')) {
+      const validation = this._runner.validate(expression);
+      if (!validation.ok) {
+        throw new Error(`Invalid JSONata expression for storeKey="${storeKey}": ${validation.error}`);
+      }
     }
     return this._prisma.scraperConfig.upsert({
       where: { storeKey },

--- a/src/main/scrapers/services/attribute-extractor/attribute-extractor.service.ts
+++ b/src/main/scrapers/services/attribute-extractor/attribute-extractor.service.ts
@@ -68,19 +68,37 @@ export class AttributeExtractorService {
 
   // ---- private -------------------------------------------------------------
 
-  /** Reads the LLM system prompt from ScraperConfig (DB), falling back to the hardcoded one. */
+  /**
+   * Resolves the LLM system prompt with a three-tier fallback chain:
+   *
+   * 1. **DB** (`ScraperConfig` with `storeKey = "llm:keyword-extraction-prompt"`)
+   *    — manageable at runtime via the ScraperConfig API, no restart needed.
+   * 2. **Env var** (`LLM_KEYWORD_EXTRACTION_PROMPT`) — configurable at deploy
+   *    time, useful for ephemeral environments or CI.
+   * 3. **Hardcoded** (`FALLBACK_SYSTEM_PROMPT`) — safety net, always available.
+   *
+   * @returns {Promise<string>} The resolved system prompt.
+   */
   private async _loadSystemPrompt(): Promise<string> {
+    // 1. DB (gestionable en runtime sin reinicio)
     try {
       const cfg = await this._promptRegistry.get('llm:keyword-extraction-prompt');
       if (cfg?.expression) return cfg.expression;
     } catch (err) {
-      this._log.warn('Failed to load LLM prompt from DB — using hardcoded fallback', (err as Error).message);
+      this._log.warn('Failed to load LLM prompt from DB', (err as Error).message);
     }
 
-    // ALERT: DB prompt is missing — admin should run `npm run seed` or set it via API.
+    // 2. Env var (configurable a nivel de deploy)
+    const envPrompt = process.env.LLM_KEYWORD_EXTRACTION_PROMPT?.trim();
+    if (envPrompt) {
+      this._log.info('Using LLM_KEYWORD_EXTRACTION_PROMPT from environment');
+      return envPrompt;
+    }
+
+    // 3. Hardcoded fallback (red de seguridad)
     this._log.warn(
-      '[ALERT] llm:keyword-extraction-prompt not found in ScraperConfig. ' +
-        'Using hardcoded fallback prompt. Seed the DB or POST /api/revolicos/scraper-configs ' +
+      '[ALERT] llm:keyword-extraction-prompt not in DB and LLM_KEYWORD_EXTRACTION_PROMPT not set. ' +
+        'Using hardcoded fallback prompt. Seed the DB, set the env var, or PUT /api/revolicos/scraper-configs ' +
         'with storeKey="llm:keyword-extraction-prompt" to customize.',
     );
     return FALLBACK_SYSTEM_PROMPT;

--- a/src/main/scrapers/services/attribute-extractor/llm-extractor.service.ts
+++ b/src/main/scrapers/services/attribute-extractor/llm-extractor.service.ts
@@ -5,7 +5,7 @@ import type { ILogger } from '@shared/logger.interface';
 
 // ---- Zod output schema -----------------------------------------------------
 const KeywordsOutputSchema = z.object({
-  keywords: z.array(z.string()).max(5).describe('Up to 5 relevant keywords extracted from the product description'),
+  keywords: z.array(z.string()).describe('Relevant keywords extracted from the product description'),
 });
 
 /**
@@ -51,7 +51,7 @@ function validateEnv(log?: Pick<ILogger, 'warn'>): {
 // Used when the DB-stored prompt (llm:keyword-extraction-prompt) is unavailable.
 export const FALLBACK_SYSTEM_PROMPT =
   'You are a classified-ad keyword extraction assistant for Cuban marketplaces (e.g. Revolico). ' +
-  'Extract up to 5 keywords that represent the product being advertised.\n\n' +
+  'Extract relevant keywords that represent the product being advertised.\n\n' +
   'STRICT RULES:\n' +
   '- Only include information EXPLICITLY present in the description.\n' +
   '- Do not invent brands, prices, locations, or features not written in the text.\n' +
@@ -81,13 +81,16 @@ export const FALLBACK_SYSTEM_PROMPT =
 // ---- public API ------------------------------------------------------------
 
 /**
- * Extracts up to 5 keywords from a product description using an LLM.
+ * Extracts relevant keywords from a product description using an LLM.
  *
  * Fully provider-agnostic — reads `LLM_BASE_URL`, `LLM_MODEL`, and
  * `LLM_API_KEY` from the environment. Works with any OpenAI-compatible
  * API (DeepSeek, OpenAI, Anthropic, custom proxies, etc.) via
  * `@ai-sdk/openai-compatible` and {@link generateText} with
  * `response_format: json_object` (injected via custom fetch).
+ *
+ * The LLM decides how many keywords to return based on the description
+ * content. No artificial limit is enforced.
  *
  * Returns `{ keywords: [] }` on any failure (missing env, network error,
  * timeout, bad response) — never throws.
@@ -96,7 +99,7 @@ export const FALLBACK_SYSTEM_PROMPT =
  * @param {Pick<ILogger, 'warn'>} [log] - Optional logger for diagnostics.
  * @param {string} [systemPrompt] - System prompt override (falls back to
  *   hardcoded prompt and finally to DB-stored llm:keyword-extraction-prompt).
- * @returns {Promise<ExtractKeywordsResult>} Up to 5 keywords plus optional LLM provider usage stats.
+ * @returns {Promise<ExtractKeywordsResult>} Keywords plus optional LLM provider usage stats.
  */
 export async function extractKeywords(
   description: string,

--- a/swagger.json
+++ b/swagger.json
@@ -788,7 +788,7 @@
           },
           "expression": {
             "type": "string",
-            "description": "JSONata expression evaluated against the scraped DOM tree",
+            "description": "JSONata expression (or plain-text prompt for storeKeys prefixed with \"llm:\")",
             "example": "$ ~> | $ | { \"products\": $ | [*] } |"
           },
           "version": {
@@ -834,7 +834,7 @@
           "expression": {
             "type": "string",
             "minLength": 1,
-            "description": "JSONata expression to persist",
+            "description": "JSONata expression to persist (or plain-text prompt for storeKeys prefixed with \"llm:\")",
             "example": "$ ~> | $ | { \"products\": $ | [*] } |"
           }
         },
@@ -849,7 +849,7 @@
           "expression": {
             "type": "string",
             "minLength": 1,
-            "description": "New JSONata expression",
+            "description": "New JSONata expression (or plain-text prompt for storeKeys prefixed with \"llm:\")",
             "example": "$ ~> | $ | { \"products\": $ | [*] } |"
           }
         },


### PR DESCRIPTION
## What

Three changes to make the LLM keyword extraction prompt manageable without code changes:

### 1. Three-tier prompt resolution (DB → env var → fallback)
- **API**: `PUT /api/revolicos/scraper-configs/llm:keyword-extraction-prompt` updates the prompt at runtime without restart. Cache invalidates immediately.
- **Env var**: `LLM_KEYWORD_EXTRACTION_PROMPT` for deploy-time configuration.
- **Hardcoded**: `FALLBACK_SYSTEM_PROMPT` as safety net.

### 2. Remove artificial keyword limit
The Zod schema no longer enforces `max(5)`. The LLM decides how many keywords are relevant. If the LLM returns more than expected, the result is preserved rather than discarded.

### 3. `llm:` prefix convention
`ScraperConfigRepository.upsert()` skips JSONata validation when `storeKey.startsWith('llm:')`. Plain-text prompts pass through the same API that validates JSONata for `revolico:*` keys.

### Also
- Seed `llm:keyword-extraction-prompt` in `prisma/seed.ts`
- Update README.md, CLAUDE.md (compact), SKILL.md (resolution chain)
- 7 new tests (repository, API integration, prompt resolution chain)

## Verification
- 79 suites, 826 tests — all green
- Lint clean
- `npm run docs:generate` produces no diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)