### PR TITLE
fix(auth): suppress unhandled ioredis error events when Redis is down

### DIFF
--- a/src/main/shared/container.ts
+++ b/src/main/shared/container.ts
@@ -300,7 +300,7 @@ container
   .bind<Redis>(TYPES.RedisClient)
   .toDynamicValue(() => {
     const redisUrl = process.env.REDIS_URL ?? 'redis://localhost:6379';
-    return new Redis(redisUrl, {
+    const redis = new Redis(redisUrl, {
       maxRetriesPerRequest: null,
       lazyConnect: true,
       connectTimeout: 2000,
@@ -311,5 +311,8 @@ container
         return null;
       },
     });
+    // Prevent unhandled error events when Redis is unavailable
+    redis.on('error', () => {});
+    return redis;
   })
   .inSingletonScope();

--- a/src/main/users/services/login-rate-limit.service.ts
+++ b/src/main/users/services/login-rate-limit.service.ts
@@ -52,6 +52,8 @@ export class LoginRateLimitService {
         return null;
       },
     });
+    // Prevent unhandled error events when Redis is unavailable
+    this._redis.on('error', () => {});
   }
 
   /**


### PR DESCRIPTION
ioredis emits `connect ETIMEDOUT` errors even when `retryStrategy` returns `null`. Without an error listener, Node.js logs them as unhandled events during tests. Added `.on('error', () => {})` to both the shared RedisClient and LoginRateLimitService instances. Non-functional change — only suppresses noise.