### PR TITLE
fix(auth): log warnings on Redis connection failures

### DIFF
--- a/src/main/shared/container.ts
+++ b/src/main/shared/container.ts
@@ -298,21 +298,23 @@ container.bind(TYPES.AccountManagementController).to(AccountManagementController
 // Redis client (shared by rate limiter and JWT blacklist)
 container
   .bind<Redis>(TYPES.RedisClient)
-  .toDynamicValue(() => {
+  .toDynamicValue(ctx => {
     const redisUrl = process.env.REDIS_URL ?? 'redis://localhost:6379';
+    const log = ctx.container.get<ILogger>(TYPES.Logger);
     const redis = new Redis(redisUrl, {
       maxRetriesPerRequest: null,
       lazyConnect: true,
       connectTimeout: 2000,
       maxLoadingRetryTime: 2000,
       enableOfflineQueue: false,
-      retryStrategy(): number | null {
-        // Never retry — AuthMiddleware and rate limiter both fail-open
+      retryStrategy(times: number): number | null {
+        log.warn('Redis unavailable — JWT blacklist and rate limiting disabled', { attempt: times });
         return null;
       },
     });
-    // Prevent unhandled error events when Redis is unavailable
-    redis.on('error', () => {});
+    redis.on('error', (err: Error) => {
+      log.error('Redis connection error', { error: err.message });
+    });
     return redis;
   })
   .inSingletonScope();

--- a/src/main/users/services/login-rate-limit.service.ts
+++ b/src/main/users/services/login-rate-limit.service.ts
@@ -40,6 +40,7 @@ export class LoginRateLimitService {
   public constructor(@inject(TYPES.Logger) private readonly _log: ILogger) {
     this._log.context = LoginRateLimitService.name;
 
+    const log = this._log;
     const redisUrl = process.env.REDIS_URL ?? 'redis://localhost:6379';
     this._redis = new Redis(redisUrl, {
       maxRetriesPerRequest: null,
@@ -47,13 +48,16 @@ export class LoginRateLimitService {
       connectTimeout: 2000,
       maxLoadingRetryTime: 2000,
       enableOfflineQueue: false,
-      retryStrategy(): number | null {
-        // Never retry — fail-open kicks in immediately when Redis is down
+      retryStrategy(times: number): number | null {
+        // Fail-open: give up immediately so callers can fall back
+        log.warn('Redis unavailable for rate limiting — login will not be rate-limited', { attempt: times });
         return null;
       },
     });
-    // Prevent unhandled error events when Redis is unavailable
-    this._redis.on('error', () => {});
+    // Log Redis errors so they are visible in production monitoring
+    this._redis.on('error', (err: Error) => {
+      log.error('Redis connection error in rate limiter', { error: err.message });
+    });
   }
 
   /**


### PR DESCRIPTION
Cambia los handlers silenciosos de Redis por logs estructurados:

- `retryStrategy`: emite un `warn` antes de rendirse
- `.on('error')`: emite un `error` con el mensaje del error

El comportamiento fail-open no cambia — solo se añade visibilidad para producción.