### PR TITLE
docs(admin-web): document architecture and feature scaffold for Super Admin SPA

### DIFF
--- a/.claude/rules/admin-web-feature-scaffold.md
+++ b/.claude/rules/admin-web-feature-scaffold.md
@@ -1,0 +1,467 @@
+# Admin Web — Feature Scaffold Procedure
+
+Step-by-step recipe for adding a new feature module under `apps/admin-web/src/features/<module>/`. Follow these steps **in order**. Each step builds on the previous one.
+
+Conventions enforced here come from `apps/admin-web/CLAUDE.md`, `DESIGN.md`, and `.claude/rules/admin-web-ui.md`. Read those first.
+
+---
+
+## Example: Accounts Feature
+
+The examples below use a fictional `accounts` feature (CRUD list + drawer detail) so you can see the exact shape of every file. Replace `accounts` with your module name and adjust types accordingly.
+
+### Step 0: Define API contract
+
+Before writing any code, identify which endpoints this feature consumes. For accounts:
+
+| Endpoint | Method | Purpose |
+|---|---|---|
+| `/api/admin/accounts` | `GET` | List with pagination/filters |
+| `/api/admin/accounts/:id` | `GET` | Single account detail |
+| `/api/admin/accounts/:id` | `PUT` | Update account |
+| `/api/admin/accounts/:id` | `DELETE` | Delete account |
+
+---
+
+### Step 1: Create folder structure
+
+```
+features/accounts/
+├── components/
+│   ├── accounts-table.tsx
+│   ├── accounts-filters.tsx
+│   └── account-detail-drawer.tsx
+├── hooks/
+│   ├── query-keys.ts
+│   ├── useGetAccounts.ts
+│   ├── useGetAccount.ts
+│   ├── useUpdateAccount.ts
+│   └── useDeleteAccount.ts
+├── services/
+│   └── accounts-service.ts
+├── mappers/
+│   └── account-mapper.ts
+├── schemas/
+│   └── account-schemas.ts
+├── view-models/
+│   └── account-view-model.ts
+└── index.ts
+```
+
+Only create subfolders that will contain files. If a feature has no forms (e.g., a read-only dashboard widget), skip `schemas/`.
+
+---
+
+### Step 2: Define ViewModels
+
+**File**: `features/accounts/view-models/account-view-model.ts`
+
+```typescript
+// What the UI consumes. Never raw API DTOs.
+export interface AccountViewModel {
+  id: string;
+  name: string;
+  status: AccountStatus;
+  userCount: number;
+  planName: string;
+  createdAt: Date; // Parsed from ISO string
+}
+
+export enum AccountStatus {
+  Active = 'active',
+  Suspended = 'suspended',
+  Deleted = 'deleted',
+}
+
+// What the table/drawer needs as a flat list item
+export interface AccountListViewModel extends AccountViewModel {
+  // Additional computed fields for list rendering
+  statusBadge: { label: string; variant: 'success' | 'danger' | 'warning' };
+}
+```
+
+**Rules**:
+- ViewModels are UI-oriented. They can include derived fields, formatted dates, badge configs.
+- Enums and union types preferred over raw strings.
+- Dates are `Date` objects, not ISO strings — the mapper parses them.
+- No API concerns leak in (no `accountId`, no `created_at` snake_case).
+
+---
+
+### Step 3: Create API service
+
+**File**: `features/accounts/services/accounts-service.ts`
+
+```typescript
+import { apiClient } from '@/shared/api/api-client';
+import type { AccountDTO, AccountListResponseDTO } from './types'; // local, not from swagger
+
+// Raw HTTP calls. No transformation, no error handling beyond the interceptor.
+export const accountsService = {
+  list(params: { page: number; limit: number; search?: string; status?: string }) {
+    return apiClient.get<AccountListResponseDTO>('/api/admin/accounts', { params, signal: params.signal });
+  },
+
+  getById(id: string) {
+    return apiClient.get<AccountDTO>(`/api/admin/accounts/${id}`);
+  },
+
+  update(id: string, data: UpdateAccountDTO) {
+    return apiClient.put<AccountDTO>(`/api/admin/accounts/${id}`, data);
+  },
+
+  delete(id: string) {
+    return apiClient.delete(`/api/admin/accounts/${id}`);
+  },
+};
+```
+
+**Rules**:
+- `DTO` types are file-local or in a sibling `types.ts`. Never import from `src/main/` or `swagger.json`.
+- `signal` is passed through to `apiClient` for cancelability.
+- The service returns the axios response — the hook unwraps `.data`.
+- One file per resource. If a module has 3 resources (e.g., accounts, subscriptions, plans), that's 3 service files.
+
+---
+
+### Step 4: Create mappers
+
+**File**: `features/accounts/mappers/account-mapper.ts`
+
+```typescript
+import type { AccountDTO } from '../services/types';
+import { AccountViewModel, AccountStatus } from '../view-models/account-view-model';
+
+// Pure function. No side effects. No API calls. No logger.
+export function mapAccountDTOToViewModel(dto: AccountDTO): AccountViewModel {
+  return {
+    id: dto.id,
+    name: dto.name,
+    status: dto.deletedAt
+      ? AccountStatus.Deleted
+      : dto.suspendedAt
+        ? AccountStatus.Suspended
+        : AccountStatus.Active,
+    userCount: dto._count?.users ?? 0,
+    planName: dto.subscription?.plan?.name ?? 'No plan',
+    createdAt: new Date(dto.createdAt),
+  };
+}
+```
+
+**Rules**:
+- Pure functions only. They receive a DTO, return a ViewModel.
+- Date strings are parsed to `Date` here.
+- Derived fields (status badge configs, display names) are computed here, not in the component.
+- No `try/catch` — if the DTO is malformed, let it throw so the error boundary catches it.
+- If the transformation is trivial (1:1 field mapping), the mapper can be a one-liner. Still keep it in `mappers/`.
+
+---
+
+### Step 5: Define query key factory
+
+**File**: `features/accounts/hooks/query-keys.ts`
+
+```typescript
+export const accountKeys = {
+  all: ['accounts'] as const,
+  list: (filters: Record<string, unknown>) => ['accounts', 'list', filters] as const,
+  detail: (id: string) => ['accounts', 'detail', id] as const,
+};
+```
+
+**Rules**:
+- Structured keys enable granular cache invalidation.
+- `as const` ensures TypeScript infers the literal tuple type.
+- Filters object is spread into the key — changing filters auto-triggers a refetch.
+- Keep the factory in `hooks/` — it's part of the query layer, not the service layer.
+
+---
+
+### Step 6: Create hooks
+
+**File**: `features/accounts/hooks/useGetAccounts.ts`
+
+```typescript
+import { useQuery } from '@tanstack/react-query';
+import { accountsService } from '../services/accounts-service';
+import { mapAccountDTOToViewModel } from '../mappers/account-mapper';
+import { accountKeys } from './query-keys';
+import type { AccountListViewModel } from '../view-models/account-view-model';
+
+interface UseGetAccountsParams {
+  page: number;
+  limit: number;
+  search?: string;
+  status?: string;
+}
+
+export function useGetAccounts(params: UseGetAccountsParams) {
+  return useQuery({
+    queryKey: accountKeys.list(params),
+    queryFn: async ({ signal }) => {
+      const response = await accountsService.list({ ...params, signal });
+      return {
+        items: response.data.items.map(mapAccountDTOToViewModel),
+        total: response.data.total,
+      };
+    },
+    staleTime: 5 * 60 * 1000, // standard tier
+    placeholderData: (prev) => prev, // keep previous data while refetching
+  });
+}
+```
+
+**File**: `features/accounts/hooks/useUpdateAccount.ts`
+
+```typescript
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { accountsService } from '../services/accounts-service';
+import { accountKeys } from './query-keys';
+
+export function useUpdateAccount() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, data }: { id: string; data: UpdateAccountDTO }) =>
+      accountsService.update(id, data),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: accountKeys.list({}) });
+      queryClient.invalidateQueries({ queryKey: accountKeys.detail(variables.id) });
+      toast.success('Account updated');
+    },
+    onError: (error: ApiError) => {
+      toast.error(error.message, { action: { label: 'Retry', onClick: () => {} } });
+    },
+  });
+}
+```
+
+**File**: `features/accounts/hooks/useDeleteAccount.ts`
+
+```typescript
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { accountsService } from '../services/accounts-service';
+import { accountKeys } from './query-keys';
+
+export function useDeleteAccount() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => accountsService.delete(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: accountKeys.all });
+      toast.success('Account permanently deleted');
+    },
+    onError: (error: ApiError) => {
+      toast.error(error.message, { action: { label: 'Retry', onClick: () => {} } });
+    },
+  });
+}
+```
+
+**Rules**:
+- `useGet<Resource>` — one per list query. Returns `{ items, total }` or just the ViewModel for detail.
+- `useCreate<Resource>`, `useUpdate<Resource>`, `useDelete<Resource>` — one per mutation.
+- Hooks are the ONLY place `useQuery` / `useMutation` are called. Components import hooks, never `@tanstack/react-query`.
+- `staleTime` matches the tier defined in `CLAUDE.md` (standard = 5 min for accounts/users/products).
+- `placeholderData: (prev) => prev` prevents layout shift on refetch.
+- Toast on success (4s) and error (sticky with Retry). 401/403 are handled by the API client interceptor — do NOT toast them here.
+- Mutation keys follow the invalidation rules: create → invalidate list, update → invalidate list + detail, delete → invalidate all.
+
+---
+
+### Step 7: Build components
+
+**File**: `features/accounts/components/accounts-table.tsx`
+
+```typescript
+import { useGetAccounts } from '../hooks/useGetAccounts';
+import { useDeleteAccount } from '../hooks/useDeleteAccount';
+import { TableSkeleton } from '@/shared/ui/skeletons/table-skeleton';
+import { EmptyState } from '@/shared/ui/empty-state';
+import { ErrorState } from '@/shared/ui/error-state';
+import { DataTable } from '@/shared/ui/data-table'; // shadcn/ui + TanStack Table wrapper
+import { columns } from './accounts-columns'; // column definitions in sibling file
+
+export function AccountsTable() {
+  const { data, isLoading, isError, error, refetch, isFetching } = useGetAccounts({
+    page: 1,
+    limit: 20,
+  });
+  const deleteMutation = useDeleteAccount();
+
+  // 1. Initial load — shape-matched skeleton
+  if (isLoading) {
+    return <TableSkeleton rows={20} cols={6} />;
+  }
+
+  // 2. Error — per-component error boundary
+  if (isError) {
+    return <ErrorState message={error.message} onRetry={() => refetch()} />;
+  }
+
+  // 3. Empty — centered icon + message
+  if (!data || data.items.length === 0) {
+    return (
+      <EmptyState
+        icon="Building2"
+        title="No accounts yet"
+        description="Accounts will appear here once tenants sign up."
+      />
+    );
+  }
+
+  // 4. Data — the happy path
+  return (
+    <div>
+      {isFetching && <div className="h-0.5 bg-primary/20 animate-pulse" />}
+      <DataTable
+        columns={columns}
+        data={data.items}
+        total={data.total}
+        onDelete={(id) => deleteMutation.mutate(id)}
+      />
+    </div>
+  );
+}
+```
+
+**Rules**:
+- Every data component handles **four states in this exact order**: loading → error → empty → data.
+- Loading = skeleton that matches the final layout geometry. Never a spinner.
+- Error = `ErrorState` component with message + Retry button.
+- Empty = `EmptyState` component with icon, title, description, optional CTA.
+- Data = normal render. `isFetching` shows a 2px progress bar; existing data is NOT cleared.
+- Mutations are wired in the component but defined in hooks.
+- Column definitions are extracted to a sibling file (`accounts-columns.tsx`) to keep the table component focused.
+
+---
+
+### Step 8: Add route
+
+**File**: `App.tsx` (or routes config)
+
+```typescript
+const AccountsPage = React.lazy(() =>
+  import('@/features/accounts').then((m) => ({ default: m.AccountsPage }))
+);
+
+// Inside route config:
+{
+  path: '/accounts',
+  element: (
+    <RequirePermission permissions={[Permission.VIEW_ACCOUNTS]}>
+      <Suspense fallback={<PageSkeleton />}>
+        <AccountsPage />
+      </Suspense>
+    </RequirePermission>
+  ),
+}
+```
+
+**Rules**:
+- Every feature page is lazy-loaded via `React.lazy()`.
+- `Suspense` fallback is a page-level skeleton, not a spinner.
+- `RequirePermission` wraps the route with the required `Permission[]`.
+- 403 is handled by `RequirePermission` internally (full-page Forbidden view, no toast).
+
+---
+
+### Step 9: Add NavItem
+
+**File**: navigation config (wherever `NavItem[]` is defined)
+
+```typescript
+{
+  id: 'accounts',
+  label: 'Accounts',
+  icon: Building2,
+  path: '/accounts',
+  permissions: [Permission.VIEW_ACCOUNTS],
+  badge: undefined, // or { count: pendingCount, variant: 'warning' }
+}
+```
+
+**Rules**:
+- Every NavItem declares `permissions[]`. Items are auto-filtered by `useHasPermission()`.
+- `badge` is optional: `{ count: number, variant: 'danger' | 'warning' | 'info' }`.
+- `featureFlag` is optional: gates the item behind a flag without modifying the component.
+- Icon comes from `lucide-react`.
+
+---
+
+### Step 10: Add Storybook stories
+
+**File**: `stories/accounts-table.stories.tsx`
+
+```typescript
+import type { Meta, StoryObj } from '@storybook/react';
+import { AccountsTable } from '../src/features/accounts/components/accounts-table';
+
+const meta: Meta<typeof AccountsTable> = {
+  title: 'Features/Accounts/AccountsTable',
+  component: AccountsTable,
+  parameters: { layout: 'padded' },
+};
+export default meta;
+
+type Story = StoryObj<typeof AccountsTable>;
+
+export const Loading: Story = {
+  parameters: { mockData: { isLoading: true } },
+};
+
+export const Empty: Story = {
+  parameters: { mockData: { items: [], total: 0 } },
+};
+
+export const WithData: Story = {
+  parameters: { mockData: { items: mockAccounts, total: 3 } },
+};
+
+export const Error: Story = {
+  parameters: { mockData: { isError: true, error: new Error('Failed to fetch') } },
+};
+```
+
+**Rules**:
+- One story file per component (not per feature).
+- Every data component must have stories for: Loading, Empty, Data, Error.
+- Use `parameters.mockData` or MSW handlers to supply mock data.
+- Stories live in `apps/admin-web/stories/` and mirror the `features/` structure.
+
+---
+
+## Scaffold Checklist
+
+Before marking a feature as complete, verify every item:
+
+- [ ] All 10 steps above executed in order
+- [ ] No `axios` or `@tanstack/react-query` imports in component files
+- [ ] No DTOs passed directly to components — all go through a mapper
+- [ ] No raw hex colors — all classes from DESIGN.md tokens
+- [ ] No `useEffect` for data fetching
+- [ ] Loading state is a skeleton, never a spinner
+- [ ] Empty state has icon + title + description
+- [ ] Error state has Retry button
+- [ ] Delete actions have AlertDialog confirmation
+- [ ] Icon-only buttons have `aria-label`
+- [ ] Table has `<caption>` (visually hidden is fine)
+- [ ] Query keys are structured for granular invalidation
+- [ ] `staleTime` matches the tier in CLAUDE.md
+- [ ] AbortSignal is passed through to `apiClient`
+- [ ] Toast only on mutations (200/201 = success 4s, 5xx = error sticky + Retry; never toast 401/403)
+
+---
+
+## Cross-References
+
+| File | Covers |
+|---|---|
+| `apps/admin-web/CLAUDE.md` | Architecture, state strategy, permissions, auth, coding constraints |
+| `apps/admin-web/DESIGN.md` | Visual design: palette, typography, spacing, components |
+| `.claude/rules/admin-web-ui.md` | Behavioral conventions: tables, async states, toasts, destructive actions |
+| `.claude/rules/compliance-checklist.md` | Project-wide pre-commit quality gates |

--- a/apps/admin-web/CLAUDE.md
+++ b/apps/admin-web/CLAUDE.md
@@ -1,35 +1,300 @@
 # Super Admin SPA — `apps/admin-web/`
 
-React 18 + Vite 5 SPA that consumes the `bazaarsentinel` API (`src/main/`). Currently design-only: no code scaffolded yet. Two docs govern the future UI work — read both before touching anything.
+React 18 + Vite 5 SPA that consumes the `bazaarsentinel` API (`src/main/`). Currently in **pre-implementation phase**: architecture and development plan approved, ready to begin Fase 0 (Developer Experience).
 
-@./DESIGN.md
-@../../.claude/rules/admin-web-ui.md
+## Governing Documents
+
+Read these before any UI work — they form a hierarchy:
+
+1. `@./DESIGN.md` — visual identity (brand book: palette, typography, depth, shape, component recipes)
+2. `@../../.claude/rules/admin-web-ui.md` — behavioral & code conventions (layout, tables, charts, async states, toasts, destructive actions)
+3. `@../../.claude/plans/oye-comenzamos-con-otra-wobbly-snowflake.md` — development plan (7 phases, architectural decisions, DoD per phase)
+4. `@../../.plans/super-admin-dashboard-plan.md` — mirror copy of the development plan
+5. This file — architectural constraints, patterns, and how the SPA is wired together
 
 ## Status
 
-This directory is in **design phase only**. There is no `package.json`, no `vite.config.ts`, no source code. The only deliverables so far are:
-
-- `design.md` — the complete design system (mandatory reading before any UI work).
+Architecture and design approved. No code scaffolded yet. The only deliverables so far are:
+- `DESIGN.md` — the complete design system (mandatory reading before any UI work).
 - `CLAUDE.md` — this file (auto-loaded when working in this directory).
+- Development plan with 7 phases (Fase 0–7).
 
-When implementation starts, the recommended stack is:
+## Stack
 
-- React 18 + Vite 5
-- TanStack Query v5, TanStack Table v8
-- shadcn/ui (Radix + Tailwind), Recharts, Tremor (optional)
-- React Hook Form + Zod
-- `sonner` for toasts
-- MSW for offline dev (until the API gaps in the swagger are closed)
+| Layer | Technology |
+|---|---|
+| Framework | React 18 + Vite 5 |
+| Language | TypeScript (strict mode, target ES2022) |
+| Routing | React Router v6 (lazy loading per feature) |
+| Server State | TanStack Query v5 |
+| Tables | TanStack Table v8 |
+| Forms | React Hook Form + Zod |
+| UI Primitives | shadcn/ui (Radix + Tailwind) |
+| Charts | Recharts (+ Tremor optional for KPI delta cards) |
+| Toasts | sonner |
+| Command Palette | cmdk |
+| Icons | lucide-react |
+| Testing | Vitest + React Testing Library |
+| Mock API | MSW (Mock Service Worker) |
+| Dev Docs | Storybook |
+| Dates | date-fns + date-fns-tz |
 
-## Conventions
+## Commands (from monorepo root)
 
-- All visual and behavioral rules are defined in `@./design.md`. Read it first.
-- Folder layout (when code lands): `src/features/<module>/{components,hooks,schemas,index.ts}`.
-- All API calls go through custom hooks. Components MUST NOT import from `@tanstack/react-query` or `axios`.
-- This directory will eventually be wired into a monorepo with npm workspaces (`workspaces: ["apps/*"]` in the root `package.json`). Until then, treat it as an isolated folder.
+| Command | Purpose |
+|---|---|
+| `npm run dev -w apps/admin-web` | Start Vite dev server |
+| `npm run build -w apps/admin-web` | Production build |
+| `npm run test -w apps/admin-web` | Run Vitest tests |
+| `npm run lint -w apps/admin-web` | ESLint |
+| `npm run storybook -w apps/admin-web` | Start Storybook |
+| `npm run typecheck -w apps/admin-web` | tsc --noEmit |
+
+## Architecture
+
+### Monorepo
+
+This directory lives inside an npm workspaces monorepo (`workspaces: ["apps/*"]` in root `package.json`). The SPA is an independent application — it does NOT depend on backend types, Zod schemas, or DTOs. `packages/` at the monorepo root is reserved for truly shared code (UI components, utilities, config, stable enums) extracted when the need arises organically.
+
+### Contracts
+
+The frontend defines its **own** DTOs, ViewModels, and Zod schemas. `swagger.json` is documentation only (`/api-docs`) — never a source for code generation. The API Client layer is the single boundary between frontend and backend.
+
+### Feature Folder Structure (canonical)
+
+```
+features/<module>/
+├── components/           # Presentational React components
+├── hooks/                # useGetX, useCreateX, useUpdateX, useDeleteX + query keys
+├── services/             # Raw API calls (no transformation), one file per resource
+├── mappers/              # Pure DTO → ViewModel transformation functions
+├── schemas/              # Zod schemas (form validation + inferred types)
+├── view-models/          # UI-oriented types (what components receive)
+└── index.ts              # Public surface of the module
+```
+
+Do NOT create empty subfolders. Add `hooks/`, `services/`, `mappers/`, `schemas/`, or `view-models/` only when the first file of that type exists.
+
+### Adding a New Feature Module
+
+Follow this procedure in order when creating a new module under `features/<module>/`. See rule `@../../.claude/rules/admin-web-feature-scaffold.md` for the expanded version with code snippets.
+
+1. **Create folder structure** — only subfolders that will contain files: `components/`, `hooks/`, `services/`, `mappers/`, `schemas/`, `view-models/`
+2. **Define ViewModels** in `view-models/` — what the UI needs, not what the API returns
+3. **Create API service** in `services/<module>-service.ts` — raw HTTP calls, no transformation
+4. **Create mappers** in `mappers/` — pure DTO → ViewModel functions
+5. **Define query key factory** in `hooks/query-keys.ts` — structured keys for cache granularity
+6. **Create hooks** — `useGet*`, `useCreate*`, `useUpdate*`, `useDelete*` using TanStack Query
+7. **Build components** — every data component handles: skeleton (loading), empty, error, data states
+8. **Add route** in `App.tsx` — lazy-loaded via `React.lazy()`, wrapped in `RequirePermission`
+9. **Add NavItem** to SideNav config — declare `permissions[]` on the navigation item
+10. **Add Storybook stories** — one story per component variant, covering all states
+
+### State Strategy (Three Layers)
+
+```
+Server State  → TanStack Query v5  (queries, mutations, cache, invalidation)
+UI State      → React Context      (auth, feature flags, nav, drawer, notifications)
+Local State   → useState/useReducer (forms via React Hook Form, filters, dialogs)
+```
+
+**Decision rule**: if the backend serves it → TanStack Query. If 3+ unrelated features need it → Context. Otherwise → local state.
+
+**Stale time tiers**:
+| Tier | Stale Time | Applies to |
+|---|---|---|
+| `realtime` | 30s | Queue stats, health, enrichment metrics |
+| `standard` | 5 min | Products, users, accounts, dashboard KPIs |
+| `static` | 30 min | Roles, stores, feature flags |
+
+**Mutation patterns**:
+- Create (201) → invalidate list → refetch
+- Update (200) → invalidate list + detail. Toggle → optimistic update + rollback on error
+- Delete (204) → wait for 204 → invalidate. AlertDialog required. Never optimistic
+- Background refetch → 2px progress bar, atomic replacement (never clear existing data)
+- Prefetch → detail on row hover (onMouseEnter)
+
+Cache invalidation is always granular (specific query keys, never global).
+
+### DTO → ViewModel Transformation
+
+Every feature has a `mappers/` layer. Components receive ViewModels, never raw API responses. API responses are transformed outside components, keeping adaptation logic centralized and testable.
+
+```typescript
+// features/accounts/services/accounts-service.ts  → calls API, returns DTO
+// features/accounts/mappers/account-mapper.ts      → AccountDTO → AccountViewModel (pure)
+// features/accounts/hooks/useGetAccounts.ts         → useQuery + mapper, returns ViewModel[]
+// features/accounts/components/accounts-table.tsx   → receives ViewModel[], renders JSX
+```
+
+### Async Cancelability
+
+All API calls support `AbortSignal`. TanStack Query's `signal` is passed through to the API Client. `queryClient.cancelQueries()` is used when filters change or the user navigates away, preventing race conditions.
+
+## Authentication
+
+### Architecture Layers
+
+```
+Components: useCurrentUser()  useIsAuthenticated()  useHasPermission()  useLogin()  useLogout()
+              │
+AuthProvider:  exposes { session, isLoading, isAuthenticated } — does NOT call the API
+              │
+SessionManager:  session lifecycle owner — expiry timer, auto-refresh, clear, logout policy
+              │
+AuthService (IAuthService):  login() → AuthSession, refresh() → AuthSession, logout()
+              │
+ITokenStorage (interchangeable):  get/set/clear access & refresh tokens
+              ├── InMemoryStorage (current — closure variables, no XSS surface)
+              └── CookieStorage (future — if backend migrates to HttpOnly cookies)
+```
+
+### AuthSession
+
+```typescript
+interface AuthSession {
+  userId: string;
+  accountId: string;
+  roles: RoleType[];          // Enum, not string[]
+  expiresAt: number;          // Unix timestamp ms
+}
+// isExpiring is computed by SessionManager, not stored
+```
+
+### Token Strategy
+
+- **Access Token**: JWT, in-memory via `ITokenStorage`. TTL: 1 day (configurable via `JWT_EXPIRATION`).
+- **Refresh Token**: opaque 96-hex-char string, in-memory via `ITokenStorage`. TTL: 30 days. Rotation with theft detection (token family).
+- **Why in-memory**: eliminates XSS attack surface. Trade-off: page refresh forces re-login — acceptable for an admin operations console (desktop, long sessions).
+- **Future HttpOnly cookies**: if the backend migrates, only `ITokenStorage` changes. `SessionManager` and `AuthService` are unaffected.
+
+### Prerequisite
+
+`POST /api/auth/refresh` in the backend is currently broken (always returns 400). Extending `rotateRefreshToken()` to return user context is a **blocking prerequisite** for Fase 1.
+
+## Permissions
+
+The frontend works with **atomic permissions**, not raw roles:
+
+```typescript
+enum Permission {
+  VIEW_DASHBOARD = 'dashboard:view',
+  VIEW_HEALTH = 'health:view',
+  VIEW_ACCOUNTS = 'accounts:view',
+  MANAGE_ACCOUNTS = 'accounts:manage',
+  VIEW_USERS = 'users:view',
+  MANAGE_USERS = 'users:manage',
+  VIEW_PRODUCTS = 'products:view',
+  MANAGE_PRODUCTS = 'products:manage',
+  VIEW_SCRAPERS = 'scrapers:view',
+  MANAGE_SCRAPERS = 'scrapers:manage',
+  VIEW_RULES = 'rules:view',
+  MANAGE_RULES = 'rules:manage',
+  VIEW_QUEUES = 'queues:view',
+  VIEW_ROLES = 'roles:view',
+  MANAGE_ROLES = 'roles:manage',
+  VIEW_LOGS = 'logs:view',
+  VIEW_SETTINGS = 'settings:view',
+}
+```
+
+Roles are resolved to permissions via `ROLE_PERMISSIONS` map. `useHasPermission(p: Permission): boolean` is the **only** public API. `useHasRole()` does not exist. Components and navigation never reference roles directly.
+
+### Double-Layer Protection
+
+| Layer | Mechanism |
+|---|---|
+| **Navigation** | `NavItem.permissions: Permission[]` — items not in the user's set are not rendered |
+| **Routes** | `ProtectedRoute` + `RequirePermission` — blocks direct URL access |
+
+## Layout
+
+```
+TopBar (h-12, sticky, bg-surface)
+  [Logo] [⌘K Global Search] [NotificationCenter 🔔] [CurrentAccount] [UserMenu 👤]
+
+SideNav (w-60, collapsible to w-12, bg-surface-container-low)
+  Sections: Platform → Data → Operations
+  Each item: { id, label, icon, path?, permissions[], badge?, featureFlag?, children?[] }
+
+Content Area (flex-1, scroll, p-4, bg-surface)
+  └── Page Title / Breadcrumb* (*only at depth 2+)
+
+Global Right Drawer (reusable detail panel)
+Toasts (sonner, bottom-right, max 3)
+```
+
+### Navigation Rules
+
+- SideNav is a pure function: `(items, permissions, flags) → JSX`. No business logic inside.
+- Active route indicator: `primary` tint background + left border.
+- Badges support: `{ count, variant: 'danger' | 'warning' | 'info' }`.
+- Feature flags gate items without modifying the component.
+
+## API Client
+
+Located at `src/shared/api/`. Single axios instance with:
+
+- **Request interceptor**: attaches `Authorization: Bearer <token>` from `ITokenStorage`
+- **Response interceptor**: on 401 → `AuthService.refresh()` → retry original request. On refresh failure → `SessionManager.clear()` → redirect `/login`
+- **AbortSignal**: every request accepts an optional `AbortSignal`. TanStack Query's `signal` is threaded through
+- **Error normalization**: transforms axios errors into typed `ApiError` objects
+
+Components and hooks never import `axios` directly. Only `services/` files within each feature call the API Client.
+
+## Coding Constraints
+
+- [ ] Public methods require JSDoc with `@param`, `@returns`, `@throws`
+- [ ] Explicit access modifiers on all class/property members
+- [ ] No `any` unless justified with a one-line comment
+- [ ] No `console.log` — use structured logging or toasts
+- [ ] No `useEffect` for data fetching — always TanStack Query
+- [ ] No inline `style={{ }}` — use Tailwind classes or `cn()` helper
+- [ ] No raw hex colors in components — use semantic Tailwind tokens from DESIGN.md
+- [ ] No full-page spinners or loading overlays — skeletons only
+- [ ] No `localStorage`/`sessionStorage` for tokens — use `ITokenStorage`
+- [ ] No direct `axios` imports in components or hooks — go through `services/`
+- [ ] No hardcoded route paths — use `@/config/routes`
+- [ ] No emoji as icons — use `lucide-react`
+- [ ] `dangerouslySetInnerHTML` requires explicit sanitization
+- [ ] Icon-only buttons require `aria-label`
+- [ ] Tables require `<caption>` (visually hidden acceptable)
+
+### Imports
+
+- **Order**: types → interfaces → implementations (alphabetical within each group)
+- **Path aliases**: `@/` maps to `src/`. Within a feature, relative imports are fine. Across features, use `@features/<module>/` barrel exports
+- **No circular dependencies**
+
+## Development Phases
+
+| Phase | Name | Key Deliverable |
+|---|---|---|
+| **Fase 0** | Developer Experience | Monorepo scaffold, Vite, TS, Tailwind, Vitest, Storybook, MSW, CI |
+| **Fase 1** | Auth + Layout | Login, AuthProvider, SessionManager, ITokenStorage, TopBar, SideNav |
+| **Fase 2** | Design System Validation | shadcn/ui components in Storybook, study referents, incremental DESIGN.md updates |
+| **Fase 3** | Dashboard Overview | KPIs, health, enrichment, rules summary. First Design System consumer |
+| **Fase 4** | Core CRUD | Accounts + Users + Roles with consolidated table/filter/bulk/drawer pattern |
+| **Fase 5** | Marketplace Management | Products catalog + history, multi-marketplace scrapers (stores, schedules, configs) |
+| **Fase 6** | Rules Engine | Professional multi-engine editor (Monaco/CodeMirror), real-time validation, test panel, version history |
+| **Fase 7** | Complementary Features | Queues, Logs, Settings, Notification Center, Global Right Drawer, ⌘K |
+
+See the development plan for detailed DoD per phase, prerequisite tasks, and API endpoint mapping.
+
+## Pre-commit Checklist
+
+```bash
+npm run lint          # Zero errors
+npm run format        # Clean diff
+npm run test          # Vitest: all green
+npm run typecheck     # tsc --noEmit clean
+npm run build         # Compiles without errors
+```
 
 ## Related
 
-- API spec: `swagger.json` at the repo root.
-- Backend module pattern reference: `src/main/CLAUDE.md`.
-- Design system audit: see the plan file under `~/.claude/plans/`.
+- API spec: `swagger.json` at the repo root (documentation only — not a code-generation source).
+- Backend patterns: `src/main/CLAUDE.md`.
+- Design system audit & dev plan: `~/.claude/plans/oye-comenzamos-con-otra-wobbly-snowflake.md`.
+- Project-wide compliance: `../../.claude/rules/compliance-checklist.md`.
+- Git workflow: `../../.claude/rules/git-workflow.md`.


### PR DESCRIPTION
## What

Expand `apps/admin-web/CLAUDE.md` from a design-phase stub into a comprehensive architecture reference and add a feature scaffold rule with concrete code examples.

## Changes

### `apps/admin-web/CLAUDE.md` (rewritten, +280 lines)
- **Commands**: monorepo workspace commands (`npm run dev -w apps/admin-web`, etc.)
- **Architecture**: monorepo isolation, contracts, canonical feature folder structure, 10-step feature scaffold checklist
- **State strategy**: three-layer (TanStack Query → React Context → useState) with stale time tiers and mutation patterns
- **DTO→ViewModel**: transformation layer, mappers, async cancelability
- **Auth**: layered architecture (Components → AuthProvider → SessionManager → AuthService → ITokenStorage)
- **Permissions**: `Permission` enum, double-layer protection (nav + routes), `useHasPermission()`
- **Layout**: TopBar, SideNav, Global Right Drawer, command palette
- **API Client**: interceptors, AbortSignal, error normalization
- **Coding constraints**: 15-item checklist
- **Roadmap**: 7-phase development table

### `.claude/rules/admin-web-feature-scaffold.md` (new, 467 lines)
- 10-step recipe for creating new feature modules
- Concrete code examples for every step: ViewModels, API services, mappers, query key factories, TanStack Query hooks, four-state components, route wiring, NavItem config, Storybook stories
- 18-item scaffold checklist
- Cross-references to CLAUDE.md, DESIGN.md, and admin-web-ui.md

## Why

The admin-web directory had no actionable agent instructions. Any agent working here needed to rediscover architecture from scratch. Now the CLAUDE.md covers all architectural decisions made during the brainstorming session, and the scaffold rule provides an exact mold for creating new features consistently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)