### PR TITLE
fix(auth): return user context from refresh token rotation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,6 @@
         "puppeteer-extra-plugin-stealth": "^2.11.2",
         "reflect-metadata": "^0.2.2",
         "swagger-ui-express": "^5.0.1",
-        "telegraf": "^4.16.3",
         "zod": "^3.25.67"
       },
       "devDependencies": {
@@ -3741,12 +3740,6 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "license": "MIT"
     },
-    "node_modules/@telegraf/types": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@telegraf/types/-/types-7.1.0.tgz",
-      "integrity": "sha512-kGevOIbpMcIlCDeorKGpwZmdH7kHbqlk/Yj6dEpJMKEQw5lk0KVQY0OLXaCswy8GqlIVLd5625OB+rAntP9xVw==",
-      "license": "MIT"
-    },
     "node_modules/@tokenizer/inflate": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
@@ -5222,22 +5215,6 @@
         "ieee754": "^1.1.13"
       }
     },
-    "node_modules/buffer-alloc": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
-      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-alloc-unsafe": "^1.1.0",
-        "buffer-fill": "^1.0.0"
-      }
-    },
-    "node_modules/buffer-alloc-unsafe": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
-      "license": "MIT"
-    },
     "node_modules/buffer-crc32": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
@@ -5251,12 +5228,6 @@
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
-    },
-    "node_modules/buffer-fill": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-      "integrity": "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==",
-      "license": "MIT"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -10288,15 +10259,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
-    "node_modules/mri": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
-      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -12561,15 +12523,6 @@
         }
       ]
     },
-    "node_modules/safe-compare": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/safe-compare/-/safe-compare-1.1.4.tgz",
-      "integrity": "sha512-b9wZ986HHCo/HbKrRpBJb2kqXMK9CEWIE1egeEvZsYn69ay3kdfl9nG3RyOcR+jInTDf7a86WQ1d4VJX7goSSQ==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-alloc": "^1.2.0"
-      }
-    },
     "node_modules/safe-stable-stringify": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
@@ -12583,15 +12536,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-    },
-    "node_modules/sandwich-stream": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/sandwich-stream/-/sandwich-stream-2.0.2.tgz",
-      "integrity": "sha512-jLYV0DORrzY3xaz/S9ydJL6Iz7essZeAfnAavsJ+zsJGZ1MOnsS52yRjU3uF3pJa/lla7+wisp//fxOwOH8SKQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">= 0.10"
-      }
     },
     "node_modules/sax": {
       "version": "1.6.0",
@@ -13382,60 +13326,6 @@
         "b4a": "^1.6.4",
         "fast-fifo": "^1.2.0",
         "streamx": "^2.15.0"
-      }
-    },
-    "node_modules/telegraf": {
-      "version": "4.16.3",
-      "resolved": "https://registry.npmjs.org/telegraf/-/telegraf-4.16.3.tgz",
-      "integrity": "sha512-yjEu2NwkHlXu0OARWoNhJlIjX09dRktiMQFsM678BAH/PEPVwctzL67+tvXqLCRQQvm3SDtki2saGO9hLlz68w==",
-      "license": "MIT",
-      "dependencies": {
-        "@telegraf/types": "^7.1.0",
-        "abort-controller": "^3.0.0",
-        "debug": "^4.3.4",
-        "mri": "^1.2.0",
-        "node-fetch": "^2.7.0",
-        "p-timeout": "^4.1.0",
-        "safe-compare": "^1.1.4",
-        "sandwich-stream": "^2.0.2"
-      },
-      "bin": {
-        "telegraf": "lib/cli.mjs"
-      },
-      "engines": {
-        "node": "^12.20.0 || >=14.13.1"
-      }
-    },
-    "node_modules/telegraf/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/telegraf/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
-    "node_modules/telegraf/node_modules/p-timeout": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-4.1.0.tgz",
-      "integrity": "sha512-+/wmHtzJuWii1sXn3HCuH/FTwGhrp4tmJTxSKJbfS+vkipci6osxXM5mY0jUiRzWKMTgUT8l7HFbeSwZAynqHw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/test-exclude": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3740,6 +3740,13 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "license": "MIT"
     },
+    "node_modules/@telegraf/types": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@telegraf/types/-/types-6.9.1.tgz",
+      "integrity": "sha512-bzqwhicZq401T0e09tu8b1KvGfJObPmzKU/iKCT5V466AsAZZWQrBYQ5edbmD1VZuHLEwopoOVY5wPP4HaLtug==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@tokenizer/inflate": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
@@ -5215,6 +5222,24 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/buffer-alloc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "buffer-alloc-unsafe": "^1.1.0",
+        "buffer-fill": "^1.0.0"
+      }
+    },
+    "node_modules/buffer-alloc-unsafe": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/buffer-crc32": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
@@ -5228,6 +5253,13 @@
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/buffer-fill": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+      "integrity": "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -10259,6 +10291,16 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -12523,6 +12565,16 @@
         }
       ]
     },
+    "node_modules/safe-compare": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/safe-compare/-/safe-compare-1.1.4.tgz",
+      "integrity": "sha512-b9wZ986HHCo/HbKrRpBJb2kqXMK9CEWIE1egeEvZsYn69ay3kdfl9nG3RyOcR+jInTDf7a86WQ1d4VJX7goSSQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "buffer-alloc": "^1.2.0"
+      }
+    },
     "node_modules/safe-stable-stringify": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
@@ -12536,6 +12588,16 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/sandwich-stream": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/sandwich-stream/-/sandwich-stream-2.0.2.tgz",
+      "integrity": "sha512-jLYV0DORrzY3xaz/S9ydJL6Iz7essZeAfnAavsJ+zsJGZ1MOnsS52yRjU3uF3pJa/lla7+wisp//fxOwOH8SKQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/sax": {
       "version": "1.6.0",
@@ -13328,6 +13390,64 @@
         "streamx": "^2.15.0"
       }
     },
+    "node_modules/telegraf": {
+      "version": "4.15.3",
+      "resolved": "https://registry.npmjs.org/telegraf/-/telegraf-4.15.3.tgz",
+      "integrity": "sha512-pm2ZQAisd0YlUvnq6xdymDfoQR++8wTalw0nfw7Tjy0va+V/0HaBLzM8kMNid8pbbt7GHTU29lEyA5CAAr8AqA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@telegraf/types": "^6.9.1",
+        "abort-controller": "^3.0.0",
+        "debug": "^4.3.4",
+        "mri": "^1.2.0",
+        "node-fetch": "^2.6.8",
+        "p-timeout": "^4.1.0",
+        "safe-compare": "^1.1.4",
+        "sandwich-stream": "^2.0.2"
+      },
+      "bin": {
+        "telegraf": "lib/cli.mjs"
+      },
+      "engines": {
+        "node": "^12.20.0 || >=14.13.1"
+      }
+    },
+    "node_modules/telegraf/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/telegraf/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/telegraf/node_modules/p-timeout": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-4.1.0.tgz",
+      "integrity": "sha512-+/wmHtzJuWii1sXn3HCuH/FTwGhrp4tmJTxSKJbfS+vkipci6osxXM5mY0jUiRzWKMTgUT8l7HFbeSwZAynqHw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -13768,7 +13888,7 @@
       "version": "5.5.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
       "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "puppeteer-extra-plugin-stealth": "^2.11.2",
         "reflect-metadata": "^0.2.2",
         "swagger-ui-express": "^5.0.1",
+        "telegraf": "^4.16.3",
         "zod": "^3.25.67"
       },
       "devDependencies": {
@@ -3741,11 +3742,10 @@
       "license": "MIT"
     },
     "node_modules/@telegraf/types": {
-      "version": "6.9.1",
-      "resolved": "https://registry.npmjs.org/@telegraf/types/-/types-6.9.1.tgz",
-      "integrity": "sha512-bzqwhicZq401T0e09tu8b1KvGfJObPmzKU/iKCT5V466AsAZZWQrBYQ5edbmD1VZuHLEwopoOVY5wPP4HaLtug==",
-      "license": "MIT",
-      "peer": true
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@telegraf/types/-/types-7.1.0.tgz",
+      "integrity": "sha512-kGevOIbpMcIlCDeorKGpwZmdH7kHbqlk/Yj6dEpJMKEQw5lk0KVQY0OLXaCswy8GqlIVLd5625OB+rAntP9xVw==",
+      "license": "MIT"
     },
     "node_modules/@tokenizer/inflate": {
       "version": "0.4.1",
@@ -5227,7 +5227,6 @@
       "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
       "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "buffer-alloc-unsafe": "^1.1.0",
         "buffer-fill": "^1.0.0"
@@ -5237,8 +5236,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
       "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/buffer-crc32": {
       "version": "0.2.13",
@@ -5258,8 +5256,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
       "integrity": "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -10296,7 +10293,6 @@
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
       "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -12570,7 +12566,6 @@
       "resolved": "https://registry.npmjs.org/safe-compare/-/safe-compare-1.1.4.tgz",
       "integrity": "sha512-b9wZ986HHCo/HbKrRpBJb2kqXMK9CEWIE1egeEvZsYn69ay3kdfl9nG3RyOcR+jInTDf7a86WQ1d4VJX7goSSQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "buffer-alloc": "^1.2.0"
       }
@@ -12594,7 +12589,6 @@
       "resolved": "https://registry.npmjs.org/sandwich-stream/-/sandwich-stream-2.0.2.tgz",
       "integrity": "sha512-jLYV0DORrzY3xaz/S9ydJL6Iz7essZeAfnAavsJ+zsJGZ1MOnsS52yRjU3uF3pJa/lla7+wisp//fxOwOH8SKQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">= 0.10"
       }
@@ -13391,17 +13385,16 @@
       }
     },
     "node_modules/telegraf": {
-      "version": "4.15.3",
-      "resolved": "https://registry.npmjs.org/telegraf/-/telegraf-4.15.3.tgz",
-      "integrity": "sha512-pm2ZQAisd0YlUvnq6xdymDfoQR++8wTalw0nfw7Tjy0va+V/0HaBLzM8kMNid8pbbt7GHTU29lEyA5CAAr8AqA==",
+      "version": "4.16.3",
+      "resolved": "https://registry.npmjs.org/telegraf/-/telegraf-4.16.3.tgz",
+      "integrity": "sha512-yjEu2NwkHlXu0OARWoNhJlIjX09dRktiMQFsM678BAH/PEPVwctzL67+tvXqLCRQQvm3SDtki2saGO9hLlz68w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@telegraf/types": "^6.9.1",
+        "@telegraf/types": "^7.1.0",
         "abort-controller": "^3.0.0",
         "debug": "^4.3.4",
         "mri": "^1.2.0",
-        "node-fetch": "^2.6.8",
+        "node-fetch": "^2.7.0",
         "p-timeout": "^4.1.0",
         "safe-compare": "^1.1.4",
         "sandwich-stream": "^2.0.2"
@@ -13418,7 +13411,6 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -13435,15 +13427,13 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/telegraf/node_modules/p-timeout": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-4.1.0.tgz",
       "integrity": "sha512-+/wmHtzJuWii1sXn3HCuH/FTwGhrp4tmJTxSKJbfS+vkipci6osxXM5mY0jUiRzWKMTgUT8l7HFbeSwZAynqHw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -13888,7 +13878,7 @@
       "version": "5.5.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
       "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
-      "devOptional": true,
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/__tests__/integration/refresh-token.test.ts
+++ b/src/__tests__/integration/refresh-token.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Integration tests for POST /api/auth/refresh
+ *
+ * Prerequisites: docker-compose up -d postgres (for real Postgres)
+ */
+jest.mock('@shared/security/provider-token-verifier');
+
+import request from 'supertest';
+import { v4 as uuidv4 } from 'uuid';
+import { App } from '../../main/app';
+import { container } from '@shared/container';
+import { TYPES } from '@shared/types.container';
+import { PgDBContext } from '@config/pg-db';
+import { TokenManagementService } from '@users/services/token-management.service';
+
+let app: any;
+let appInstance: App;
+let pgDb: PgDBContext;
+let tokenMgmt: TokenManagementService;
+
+const testAccountId = uuidv4();
+const testUserId = uuidv4();
+const testRoleId = uuidv4();
+const testUsername = `refreshtest_${Date.now()}`;
+const testEmail = `refresh_${Date.now()}@test.com`;
+
+beforeAll(async () => {
+  appInstance = new App();
+  app = await appInstance.setup();
+  pgDb = container.get<PgDBContext>(TYPES.TenantDB);
+  tokenMgmt = container.get<TokenManagementService>(TYPES.TokenManagementService);
+
+  // Create test data in the correct order (FK constraints)
+  await pgDb.query(
+    `INSERT INTO public."Account" ("id", "name", "createdAt", "updatedAt")
+     VALUES ($1, $2, NOW(), NOW())
+     ON CONFLICT ("id") DO NOTHING`,
+    [testAccountId, 'Refresh Test Account'],
+  );
+
+  await pgDb.query(
+    `INSERT INTO public."Role" ("id", "name", "accountId")
+     VALUES ($1, $2, $3)
+     ON CONFLICT DO NOTHING`,
+    [testRoleId, 'ACCOUNT_OWNER', testAccountId],
+  );
+
+  await pgDb.query(
+    `INSERT INTO public."User" ("id", "accountId", "username", "email", "passwordHash", "displayName", "createdAt", "updatedAt")
+     VALUES ($1, $2, $3, $4, $5, $6, NOW(), NOW())
+     ON CONFLICT ("id") DO NOTHING`,
+    [testUserId, testAccountId, testUsername, testEmail, 'some-hashed-password', 'Refresh Test User'],
+  );
+
+  // Link user to role (implicit M:N junction table)
+  await pgDb.query(
+    `INSERT INTO public."_UserRoles" ("A", "B")
+     VALUES ($1, $2)
+     ON CONFLICT DO NOTHING`,
+    [testRoleId, testUserId],
+  );
+});
+
+afterAll(async () => {
+  // Clean up in reverse FK order
+  try {
+    await pgDb.query(`DELETE FROM public."RefreshToken" WHERE "userId" = $1`, [testUserId]);
+    await pgDb.query(`DELETE FROM public."_UserRoles" WHERE "B" = $1`, [testUserId]);
+    await pgDb.query(`DELETE FROM public."User" WHERE "id" = $1`, [testUserId]);
+    await pgDb.query(`DELETE FROM public."Role" WHERE "id" = $1`, [testRoleId]);
+    await pgDb.query(`DELETE FROM public."Account" WHERE "id" = $1`, [testAccountId]);
+  } catch (err) {
+    console.error('Error cleaning up test data:', err);
+  }
+
+  await appInstance.close();
+});
+
+describe('POST /api/auth/refresh', () => {
+  let rawRefreshToken: string;
+
+  beforeAll(async () => {
+    // Issue a fresh refresh token to use in tests
+    rawRefreshToken = await tokenMgmt.issueRefreshToken(testUserId);
+  });
+
+  afterAll(async () => {
+    // Clean up any tokens created during tests
+    try {
+      await pgDb.query(`DELETE FROM public."RefreshToken" WHERE "userId" = $1`, [testUserId]);
+    } catch {
+      // best-effort
+    }
+  });
+
+  it('should return 200 with token, refreshToken, and user for a valid refresh token', async () => {
+    const res = await request(app).post('/api/auth/refresh').send({ refreshToken: rawRefreshToken });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveProperty('token');
+    expect(res.body.data).toHaveProperty('refreshToken');
+    expect(res.body.data).toHaveProperty('user');
+    expect(typeof res.body.data.token).toBe('string');
+    expect(res.body.data.token.length).toBeGreaterThan(0);
+    expect(typeof res.body.data.refreshToken).toBe('string');
+    expect(res.body.data.refreshToken.length).toBeGreaterThan(0);
+    expect(res.body.data.user).toHaveProperty('id', testUserId);
+    expect(res.body.data.user).toHaveProperty('email', testEmail);
+    expect(res.body.data.user).toHaveProperty('username', testUsername);
+    expect(res.body.data.user).toHaveProperty('accountId', testAccountId);
+  });
+
+  it('should return 400 for an invalid refresh token', async () => {
+    const res = await request(app).post('/api/auth/refresh').send({ refreshToken: 'this-is-a-completely-invalid-token-value' });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('should return 400 when refresh token is missing from the request body', async () => {
+    const res = await request(app).post('/api/auth/refresh').send({});
+
+    expect(res.status).toBe(400);
+  });
+
+  it('should return 400 for an already-used refresh token (theft detection)', async () => {
+    // Issue a dedicated token for this test case
+    const freshToken = await tokenMgmt.issueRefreshToken(testUserId);
+
+    // Use it once via the endpoint — this rotates it (old token marked as replaced)
+    const firstUse = await request(app).post('/api/auth/refresh').send({ refreshToken: freshToken });
+    expect(firstUse.status).toBe(200);
+
+    // Reuse the same (now-consumed) token — this should trigger theft detection
+    const secondUse = await request(app).post('/api/auth/refresh').send({ refreshToken: freshToken });
+    expect(secondUse.status).toBe(400);
+  });
+});

--- a/src/__tests__/unit/token-management.service.test.ts
+++ b/src/__tests__/unit/token-management.service.test.ts
@@ -1,0 +1,166 @@
+import 'reflect-metadata';
+import { TokenManagementService } from '@users/services/token-management.service';
+import { TokenRepository } from '@users/repositories/token.repository';
+import { UserRepository } from '@users/repositories/user.repository';
+import { TokenService } from '@shared/security/token.service';
+import { IRefreshTokenResult } from '@users/services/dto/refresh-token-result.dto';
+
+describe('TokenManagementService', () => {
+  let svc: TokenManagementService;
+  let tokenRepo: jest.Mocked<TokenRepository>;
+  let userRepo: jest.Mocked<UserRepository>;
+  let tokenService: jest.Mocked<TokenService>;
+  const loggerMock = { debug: jest.fn(), warn: jest.fn(), error: jest.fn(), info: jest.fn(), context: '' } as any;
+
+  const mockUser = {
+    id: 'user-1',
+    accountId: 'account-1',
+    email: 'test@example.com',
+    username: 'testuser',
+    displayName: 'Test User',
+    avatarUrl: null,
+    emailVerified: true,
+    passwordHash: 'hashed',
+    deletedAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    roles: [{ id: 'role-1', name: 'ACCOUNT_OWNER' }],
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    tokenRepo = {
+      findRefreshTokenByHash: jest.fn(),
+      createRefreshToken: jest.fn(),
+      replaceRefreshToken: jest.fn(),
+      revokeRefreshTokenFamily: jest.fn(),
+      revokeAllUserRefreshTokens: jest.fn(),
+      revokeRefreshToken: jest.fn(),
+    } as unknown as jest.Mocked<TokenRepository>;
+
+    userRepo = {
+      findById: jest.fn(),
+    } as unknown as jest.Mocked<UserRepository>;
+
+    tokenService = {
+      generateToken: jest.fn().mockReturnValue('jwt-token'),
+      verifyToken: jest.fn(),
+    } as unknown as jest.Mocked<TokenService>;
+
+    svc = new TokenManagementService(loggerMock, tokenRepo, tokenService, userRepo);
+  });
+
+  describe('rotateRefreshToken', () => {
+    const now = new Date();
+    const future = new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000);
+
+    const storedToken = {
+      id: 'token-1',
+      userId: 'user-1',
+      tokenHash: 'old-hash',
+      family: 'family-1',
+      replacedBy: null,
+      revokedAt: null,
+      expiresAt: future,
+      createdAt: now,
+    };
+
+    it('should return null when token is not found or expired', async () => {
+      tokenRepo.findRefreshTokenByHash.mockResolvedValue(null);
+
+      const result = await svc.rotateRefreshToken('invalid-token');
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null and revoke family when token was already replaced (theft detection)', async () => {
+      tokenRepo.findRefreshTokenByHash.mockResolvedValue({
+        ...storedToken,
+        replacedBy: 'token-2',
+      });
+      tokenRepo.revokeRefreshTokenFamily.mockResolvedValue();
+
+      const result = await svc.rotateRefreshToken('stolen-token');
+
+      expect(result).toBeNull();
+      expect(tokenRepo.revokeRefreshTokenFamily).toHaveBeenCalledWith('family-1');
+    });
+
+    it('should return user context alongside the new token on success', async () => {
+      const newTokenRecord = {
+        id: 'token-2',
+        userId: 'user-1',
+        tokenHash: 'new-hash',
+        family: 'family-1',
+        replacedBy: null,
+        revokedAt: null,
+        expiresAt: future,
+        createdAt: now,
+      };
+
+      tokenRepo.findRefreshTokenByHash.mockResolvedValue(storedToken);
+      tokenRepo.createRefreshToken.mockResolvedValue(newTokenRecord);
+      tokenRepo.replaceRefreshToken.mockResolvedValue();
+      userRepo.findById.mockResolvedValue(mockUser);
+
+      const result = await svc.rotateRefreshToken('valid-token');
+
+      expect(result).not.toBeNull();
+      const r = result as IRefreshTokenResult;
+      expect(typeof r.refreshToken).toBe('string');
+      expect(r.refreshToken.length).toBeGreaterThan(0);
+      expect(r.userId).toBe('user-1');
+      expect(r.accountId).toBe('account-1');
+      expect(r.roles).toEqual(['ACCOUNT_OWNER']);
+    });
+
+    it('should return null when user is not found for the stored token', async () => {
+      tokenRepo.findRefreshTokenByHash.mockResolvedValue(storedToken);
+      tokenRepo.createRefreshToken.mockResolvedValue({
+        ...storedToken,
+        id: 'token-2',
+        tokenHash: 'new-hash',
+      });
+      tokenRepo.replaceRefreshToken.mockResolvedValue();
+      userRepo.findById.mockResolvedValue(null);
+
+      const result = await svc.rotateRefreshToken('valid-token-no-user');
+
+      expect(result).toBeNull();
+    });
+
+    it('should extract role names from user roles', async () => {
+      const userWithMultipleRoles = {
+        ...mockUser,
+        roles: [
+          { id: 'role-1', name: 'ACCOUNT_OWNER' },
+          { id: 'role-2', name: 'SUPER_ADMIN' },
+        ],
+      };
+
+      const newTokenRecord = {
+        id: 'token-3',
+        userId: 'user-1',
+        tokenHash: 'multi-role-hash',
+        family: 'family-1',
+        replacedBy: null,
+        revokedAt: null,
+        expiresAt: future,
+        createdAt: now,
+      };
+
+      tokenRepo.findRefreshTokenByHash.mockResolvedValue(storedToken);
+      tokenRepo.createRefreshToken.mockResolvedValue(newTokenRecord);
+      tokenRepo.replaceRefreshToken.mockResolvedValue();
+      userRepo.findById.mockResolvedValue(userWithMultipleRoles);
+
+      const result = await svc.rotateRefreshToken('valid-token-multi-role');
+
+      expect(result).not.toBeNull();
+      const r = result as IRefreshTokenResult;
+      expect(r.roles).toContain('ACCOUNT_OWNER');
+      expect(r.roles).toContain('SUPER_ADMIN');
+    });
+  });
+});

--- a/src/main/users/controllers/account-management.controller.ts
+++ b/src/main/users/controllers/account-management.controller.ts
@@ -12,6 +12,7 @@ import { TokenManagementService } from '@users/services/token-management.service
 import { AccountDeactivationService } from '@users/services/account-deactivation.service';
 import { AuthService } from '@users/services/auth.service';
 import { UserService } from '@users/services/user.service';
+import { TokenService } from '@shared/security/token.service';
 import { ForgotPasswordDTO } from '@users/services/dto/forgot-password.dto';
 import { ResetPasswordDTO } from '@users/services/dto/reset-password.dto';
 import { ChangePasswordDTO } from '@users/services/dto/change-password.dto';
@@ -36,6 +37,7 @@ export class AccountManagementController {
     @inject(TYPES.AccountDeactivationService) private readonly _deactivation: AccountDeactivationService,
     @inject(TYPES.AuthService) private readonly _auth: AuthService,
     @inject(TYPES.UserService) private readonly _userService: UserService,
+    @inject(TYPES.TokenService) private readonly _tokenService: TokenService,
   ) {
     this._log.context = AccountManagementController.name;
   }
@@ -149,20 +151,33 @@ export class AccountManagementController {
   @httpPost('/refresh', ValidateRequestMiddleware.with(RefreshTokenDTO))
   public async refresh(req: Request, res: Response): Promise<void> {
     const dto = RefreshTokenDTO.from(req.body);
-    const newRefreshToken = await this._tokenMgmt.rotateRefreshToken(dto.refreshToken);
-    if (!newRefreshToken) {
+    const result = await this._tokenMgmt.rotateRefreshToken(dto.refreshToken);
+    if (!result) {
       ResponseHandler.badRequest(res, 'Invalid or expired refresh token');
       return;
     }
 
-    // Issue a new access token — we need the user info from the stored token
-    // The rotate method already validated the token; we extract userId from the
-    // stored token. For simplicity, the rotate method on its own doesn't return
-    // user info. We handle this by generating the access token from the refresh
-    // token's context.
-    //
-    // TODO: Extend rotateRefreshToken to return user context alongside the new token.
-    ResponseHandler.badRequest(res, 'Refresh token flow requires user context — see TODO');
+    try {
+      // Generate a new JWT access token using the user context from the rotated token
+      const token = this._tokenService.generateToken(result.userId, result.accountId, result.roles);
+
+      // Fetch the full user DTO for the response
+      const userDTO = await this._userService.getById(result.userId);
+      if (!userDTO) {
+        this._log.error('User not found after successful token rotation', { userId: result.userId });
+        ResponseHandler.badRequest(res, 'User not found');
+        return;
+      }
+
+      ResponseHandler.ok(res, {
+        token,
+        refreshToken: result.refreshToken,
+        user: userDTO,
+      });
+    } catch (err: unknown) {
+      this._log.error('Failed to issue new access token during refresh', { error: String(err) });
+      ResponseHandler.badRequest(res, 'Failed to issue new access token');
+    }
   }
 
   // ---------------------------------------------------------------------------

--- a/src/main/users/services/dto/refresh-token-result.dto.ts
+++ b/src/main/users/services/dto/refresh-token-result.dto.ts
@@ -1,0 +1,14 @@
+/**
+ * Result of a successful refresh token rotation, carrying user context
+ * so the caller can issue a new JWT without an additional DB round-trip.
+ */
+export interface IRefreshTokenResult {
+  /** The new opaque refresh token to return to the client. */
+  refreshToken: string;
+  /** ID of the user who owns this refresh token. */
+  userId: string;
+  /** Account (tenant) ID the user belongs to. */
+  accountId: string;
+  /** Role names assigned to the user (e.g. ACCOUNT_OWNER, SUPER_ADMIN). */
+  roles: string[];
+}

--- a/src/main/users/services/token-management.service.ts
+++ b/src/main/users/services/token-management.service.ts
@@ -4,6 +4,8 @@ import { ILogger } from '@shared/logger.interface';
 import { TYPES } from '@shared/types.container';
 import { TokenRepository } from '@users/repositories/token.repository';
 import { TokenService } from '@shared/security/token.service';
+import { UserRepository } from '@users/repositories/user.repository';
+import { IRefreshTokenResult } from '@users/services/dto/refresh-token-result.dto';
 
 /**
  * Manages refresh token lifecycle: issue, rotate, revoke, and theft detection.
@@ -24,6 +26,7 @@ export class TokenManagementService {
     @inject(TYPES.Logger) private readonly _log: ILogger,
     @inject(TYPES.TokenRepository) private readonly _tokenRepo: TokenRepository,
     @inject(TYPES.TokenService) private readonly _tokenService: TokenService,
+    @inject(UserRepository) private readonly _userRepo: UserRepository,
   ) {
     this._log.context = TokenManagementService.name;
   }
@@ -49,10 +52,13 @@ export class TokenManagementService {
    * issues a new one in the same family. If the incoming token was already
    * replaced (possible theft), the entire family is revoked.
    *
+   * On success returns the new refresh token along with the user context
+   * (userId, accountId, roles) needed to issue a new JWT access token.
+   *
    * @param rawToken - The raw refresh token from the client.
-   * @returns The new raw refresh token, or `null` if the token is invalid/revoked/theft-detected.
+   * @returns The new refresh token with user context, or `null` if the token is invalid/revoked/theft-detected.
    */
-  public async rotateRefreshToken(rawToken: string): Promise<string | null> {
+  public async rotateRefreshToken(rawToken: string): Promise<IRefreshTokenResult | null> {
     const tokenHash = this._hashToken(rawToken);
     const stored = await this._tokenRepo.findRefreshTokenByHash(tokenHash);
 
@@ -89,7 +95,19 @@ export class TokenManagementService {
     // Mark old token as replaced
     await this._tokenRepo.replaceRefreshToken(stored.id, newToken.id);
 
-    return newRawToken;
+    // Fetch user context so the caller can issue a JWT
+    const user = await this._userRepo.findById(stored.userId);
+    if (!user) {
+      this._log.error('User not found for refresh token', { userId: stored.userId });
+      return null;
+    }
+
+    return {
+      refreshToken: newRawToken,
+      userId: user.id,
+      accountId: user.accountId,
+      roles: user.roles.map(r => r.name),
+    };
   }
 
   /**


### PR DESCRIPTION
## Summary

Fix `POST /api/auth/refresh` to return a new JWT access token, refresh token, and user context — enabling the SPA to refresh its session.

### Problem
The endpoint always returned 400 because `rotateRefreshToken()` only returned the raw refresh token string.

### Solution
- **`IRefreshTokenResult` DTO**: `{ refreshToken, userId, accountId, roles }`
- **`TokenManagementService.rotateRefreshToken()`**: Now fetches user context via `UserRepository`
- **`AccountManagementController.refresh()`**: Generates a fresh JWT, fetches `UserDTO`, returns `{ token, refreshToken, user }`

### Tests
- **Unit** (5): token not found, theft detection, success + user context, user not found, multi-role
- **Integration** (4): 200 valid, 400 invalid, 400 missing, 400 theft detection

### Files
| File | Change |
|---|---|
| `src/main/users/services/dto/refresh-token-result.dto.ts` | New |
| `src/main/users/services/token-management.service.ts` | Extended |
| `src/main/users/controllers/account-management.controller.ts` | Fixed |
| `src/__tests__/unit/token-management.service.test.ts` | New |
| `src/__tests__/integration/refresh-token.test.ts` | New |
| `swagger.json` | Regenerated |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
