### PR TITLE
fix(users): merge accountId into unique where in tenant extension

### DIFF
--- a/.claude/rules/meta-workflow.md
+++ b/.claude/rules/meta-workflow.md
@@ -49,18 +49,54 @@ The skill lives in user-global scope (`~/.claude/skills/git-commit/`) and Claude
 Integration tests require real services running locally. **Before `npm run test`:**
 
 ```bash
-docker-compose up -d          # at minimum Postgres; full stack is fine
-pg_isready                    # or: psql "${TENANT_DB_URL}" -c 'select 1'
+docker compose up -d          # at minimum Postgres; full stack is fine
 ```
 
 MongoDB and BullMQ/Redis are mocked in tests (MongoMemoryServer + `QUEUE_BACKEND=mock`), so the only docker-compose dependency is Postgres. **After the test run:**
 
 ```bash
-docker-compose down           # optional — keeps volumes
-# docker-compose down -v      # FULL reset (irreversible)
+docker compose down           # optional — keeps volumes
+# docker compose down -v      # FULL reset (irreversible)
 ```
 
 A test run is considered clean only when the final lines show `Ran all test suites.` with **no** `Jest did not exit one second after the test run has completed.` warning. If you see that warning, see `.claude/skills/testing/SKILL.md` (open handles + `openHandlesTimeout`) and `.claude/skills/docker-dev/SKILL.md` (integration test environment).
+
+### MongoDB binary for `mongodb-memory-server`
+
+`mongodb-memory-server` downloads a `mongod` binary on first run and caches it at `~/.cache/mongodb-binaries/`. In restricted networks (proxy / 403 from fastdl.mongodb.org), the download fails.
+
+**Rule — try the normal path first, then fall back:**
+
+1. **Try running tests normally** — assume the binary is cached from a previous run, or that the network allows the download. Use `npm run test` without any extra env vars.
+
+2. **If `mongodb-memory-server` fails to download** (`MongoBinaryDownloadError` or 403), check whether the binary already exists from a prior extraction at `$HOME/.mongodb-binaries/mongod`. If it does, set the env var and re-run:
+   ```bash
+   MONGOMS_SYSTEM_BINARY="$HOME/.mongodb-binaries/mongod" npm run test
+   ```
+
+3. **If the extracted binary does NOT exist**, extract it from the Docker `mongo` container (the `mongo:4.4.5` image ships a compatible `mongod`). This is a ONE-TIME setup — once done, the binary stays on disk. Do NOT repeat extraction on every test run:
+   ```bash
+   # Copy mongod binary
+   docker compose cp mongo:/usr/bin/mongod /tmp/mongod
+   mkdir -p ~/.mongodb-binaries/lib
+
+   # Copy its non-glibc shared libraries
+   docker compose exec -T mongo bash -c \
+     "cd /usr/lib/x86_64-linux-gnu && tar -ch libasn1.so.8 libcrypto.so.1.1 libcurl.so.4 libffi.so.6 libgmp.so.10 libgnutls.so.30 libgssapi.so.3 libgssapi_krb5.so.2 libhcrypto.so.4 libheimbase.so.1 libheimntlm.so.0 libhogweed.so.4 libhx509.so.5 libidn2.so.0 libk5crypto.so.3 libkrb5.so.26 libkrb5.so.3 libkrb5support.so.0 liblber-2.4.so.2 libldap_r-2.4.so.2 libnettle.so.6 libnghttp2.so.14 libp11-kit.so.0 libpsl.so.5 libroken.so.18 librtmp.so.1 libsasl2.so.2 libsqlite3.so.0 libssl.so.1.1 libtasn1.so.6 libunistring.so.2 libwind.so.0" \
+     | tar -x -C ~/.mongodb-binaries/lib
+
+   # Create wrapper that points LD_LIBRARY_PATH at the extracted libs
+   mv /tmp/mongod ~/.mongodb-binaries/mongod.bin
+   printf '#!/bin/bash\nexport LD_LIBRARY_PATH="$HOME/.mongodb-binaries/lib:$LD_LIBRARY_PATH"\nexec "$HOME/.mongodb-binaries/mongod.bin" "$@"\n' > ~/.mongodb-binaries/mongod
+   chmod +x ~/.mongodb-binaries/mongod
+
+   # Verify
+   ~/.mongodb-binaries/mongod --version
+   ```
+
+   Then run tests with `MONGOMS_SYSTEM_BINARY` as in step 2.
+
+4. **Always** prefix Jest commands with `MONGOMS_SYSTEM_BINARY="$HOME/.mongodb-binaries/mongod"` when the host has no cached binary and no network access to MongoDB's download server. The "Using SystemBinary!" and "Requested version X ... Using SystemBinary!" messages are expected and harmless.
 
 ## Where to find project-specific guidance
 

--- a/src/__tests__/integration/tenant-extension.test.ts
+++ b/src/__tests__/integration/tenant-extension.test.ts
@@ -22,23 +22,23 @@ let userA2Id: string; // second user in A, used for the delete test
 let userBId: string;
 
 beforeAll(async () => {
-  // Clean slate: ensures no leftover data from previous runs
-  await pool.query('DELETE FROM public."UserIdentity"');
-  await pool.query('DELETE FROM public."User"');
-  await pool.query('DELETE FROM public."Account"');
+  // Targeted cleanup of leftovers from a previous crashed run, keyed by stable
+  // natural keys so we never wipe unrelated dev data.
+  await pool.query(`DELETE FROM public."User" WHERE "username" = ANY($1::text[])`, [['tenext-a', 'tenext-a2', 'tenext-b']]);
+  await pool.query(`DELETE FROM public."Account" WHERE "name" = ANY($1::text[])`, [['tenext Account A', 'tenext Account B']]);
 
   // Account A
   await pool.query(
     `INSERT INTO public."Account" ("id", "name", "createdAt", "updatedAt")
      VALUES ($1, $2, NOW(), NOW())`,
-    [accountAId, 'Account A'],
+    [accountAId, 'tenext Account A'],
   );
 
   // Account B
   await pool.query(
     `INSERT INTO public."Account" ("id", "name", "createdAt", "updatedAt")
      VALUES ($1, $2, NOW(), NOW())`,
-    [accountBId, 'Account B'],
+    [accountBId, 'tenext Account B'],
   );
 
   // User 1 in Account A
@@ -67,8 +67,8 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
-  // Clean up seeded data (child tables first, parent tables last)
-  await pool.query('DELETE FROM public."UserIdentity"');
+  // Clean up seeded data (child tables first, parent tables last).
+  // userA2 may already be deleted by the delete test — the no-op is harmless.
   await pool.query('DELETE FROM public."User" WHERE "id" = ANY($1::text[])', [[userAId, userA2Id, userBId]]);
   await pool.query('DELETE FROM public."Account" WHERE "id" = ANY($1::text[])', [[accountAId, accountBId]]);
   await pool.end();

--- a/src/__tests__/integration/tenant-extension.test.ts
+++ b/src/__tests__/integration/tenant-extension.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Integration tests for the tenant Prisma extension.
+ *
+ * Verifies that findUnique/update/delete work correctly with tenant isolation:
+ * - The extension must NOT inject `AND` into `where` for unique operations,
+ *   because Prisma's WhereUniqueInput rejects it.
+ * - Instead, accountId is merged alongside the unique field.
+ * - Tenant isolation is preserved: a caller in tenant A cannot affect tenant B's data.
+ */
+
+import { v4 as uuidv4 } from 'uuid';
+import { Pool } from 'pg';
+import prisma from '@users/custom-prisma-client';
+import { runWithRequestContext } from '@shared/tenant-context-als';
+
+const pool = new Pool({ connectionString: process.env.TENANT_DB_URL! });
+
+const accountAId = uuidv4();
+const accountBId = uuidv4();
+let userAId: string;
+let userA2Id: string; // second user in A, used for the delete test
+let userBId: string;
+
+beforeAll(async () => {
+  // Clean slate: ensures no leftover data from previous runs
+  await pool.query('DELETE FROM public."UserIdentity"');
+  await pool.query('DELETE FROM public."User"');
+  await pool.query('DELETE FROM public."Account"');
+
+  // Account A
+  await pool.query(
+    `INSERT INTO public."Account" ("id", "name", "createdAt", "updatedAt")
+     VALUES ($1, $2, NOW(), NOW())`,
+    [accountAId, 'Account A'],
+  );
+
+  // Account B
+  await pool.query(
+    `INSERT INTO public."Account" ("id", "name", "createdAt", "updatedAt")
+     VALUES ($1, $2, NOW(), NOW())`,
+    [accountBId, 'Account B'],
+  );
+
+  // User 1 in Account A
+  const userA = await pool.query(
+    `INSERT INTO public."User" ("id", "accountId", "username", "email", "createdAt", "updatedAt")
+     VALUES ($1, $2, $3, $4, NOW(), NOW()) RETURNING "id"`,
+    [uuidv4(), accountAId, 'tenext-a', 'tenext-a@test.com'],
+  );
+  userAId = userA.rows[0].id;
+
+  // User 2 in Account A (for delete test)
+  const userA2 = await pool.query(
+    `INSERT INTO public."User" ("id", "accountId", "username", "email", "createdAt", "updatedAt")
+     VALUES ($1, $2, $3, $4, NOW(), NOW()) RETURNING "id"`,
+    [uuidv4(), accountAId, 'tenext-a2', 'tenext-a2@test.com'],
+  );
+  userA2Id = userA2.rows[0].id;
+
+  // User in Account B
+  const userB = await pool.query(
+    `INSERT INTO public."User" ("id", "accountId", "username", "email", "createdAt", "updatedAt")
+     VALUES ($1, $2, $3, $4, NOW(), NOW()) RETURNING "id"`,
+    [uuidv4(), accountBId, 'tenext-b', 'tenext-b@test.com'],
+  );
+  userBId = userB.rows[0].id;
+});
+
+afterAll(async () => {
+  // Clean up seeded data (child tables first, parent tables last)
+  await pool.query('DELETE FROM public."UserIdentity"');
+  await pool.query('DELETE FROM public."User" WHERE "id" = ANY($1::text[])', [[userAId, userA2Id, userBId]]);
+  await pool.query('DELETE FROM public."Account" WHERE "id" = ANY($1::text[])', [[accountAId, accountBId]]);
+  await pool.end();
+});
+
+describe('Tenant extension — unique where handling', () => {
+  // ---------------------------------------------------------------------------
+  // Case 1: update own user within tenant — must NOT throw
+  // PrismaClientValidationError
+  // ---------------------------------------------------------------------------
+  it('updates own user without PrismaClientValidationError', async () => {
+    await runWithRequestContext({ tenantId: accountAId, userId: userAId }, async () => {
+      const result = await prisma.user.update({
+        where: { id: userAId },
+        data: { displayName: 'Updated Name' },
+      });
+      expect(result.displayName).toBe('Updated Name');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Case 2: delete own (second) user within tenant
+  // ---------------------------------------------------------------------------
+  it('deletes own user in tenant', async () => {
+    await runWithRequestContext({ tenantId: accountAId, userId: userAId }, async () => {
+      await prisma.user.delete({ where: { id: userA2Id } });
+    });
+
+    // Verify it's actually gone
+    const check = await pool.query('SELECT "id" FROM public."User" WHERE "id" = $1', [userA2Id]);
+    expect(check.rows).toHaveLength(0);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Case 3: isolation — tenant A cannot update/delete tenant B's user
+  // Expects Prisma P2025 (record not found after tenant filter is applied)
+  // ---------------------------------------------------------------------------
+  it('rejects update of another tenant user with P2025', async () => {
+    await runWithRequestContext({ tenantId: accountAId, userId: userAId }, async () => {
+      await expect(
+        prisma.user.update({
+          where: { id: userBId },
+          data: { displayName: 'Hack' },
+        }),
+      ).rejects.toMatchObject({ code: 'P2025' });
+    });
+  });
+
+  it('rejects delete of another tenant user with P2025', async () => {
+    await runWithRequestContext({ tenantId: accountAId, userId: userAId }, async () => {
+      await expect(prisma.user.delete({ where: { id: userBId } })).rejects.toMatchObject({
+        code: 'P2025',
+      });
+    });
+
+    // Verify userB is still in the database
+    const stillThere = await pool.query('SELECT "id" FROM public."User" WHERE "id" = $1', [userBId]);
+    expect(stillThere.rows).toHaveLength(1);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Case 4: SUPER_ADMIN bypass — without tenantId, filter is skipped
+  // ---------------------------------------------------------------------------
+  it('bypasses tenant filter when tenantId is undefined (SUPER_ADMIN)', async () => {
+    await runWithRequestContext({ tenantId: undefined, userId: 'admin' }, async () => {
+      const result = await prisma.user.update({
+        where: { id: userBId },
+        data: { displayName: 'Admin Updated' },
+      });
+      expect(result.displayName).toBe('Admin Updated');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Case 5: findUnique — returns own user and null for other tenant
+  // ---------------------------------------------------------------------------
+  it('findUnique returns own user and null for other tenant user', async () => {
+    await runWithRequestContext({ tenantId: accountAId, userId: userAId }, async () => {
+      const own = await prisma.user.findUnique({ where: { id: userAId } });
+      expect(own).not.toBeNull();
+      expect(own!.id).toBe(userAId);
+
+      const other = await prisma.user.findUnique({ where: { id: userBId } });
+      expect(other).toBeNull();
+    });
+  });
+});

--- a/src/main/users/custom-prisma-client.ts
+++ b/src/main/users/custom-prisma-client.ts
@@ -31,6 +31,10 @@ const tenantExtension = Prisma.defineExtension(prisma =>
             return { AND: [{ accountId: tenantId }, where] };
           };
 
+          // WhereUniqueInput does not accept a top-level AND — merge accountId
+          // alongside the unique field instead (extended where unique, Prisma >= 5).
+          const addAccountToUniqueWhere = (where: any): any => ({ ...where, accountId: tenantId });
+
           const addAccountToData = (data: any): any => {
             if (!data) return { accountId: tenantId };
             if (data.accountId && data.accountId !== tenantId) {
@@ -42,10 +46,7 @@ const tenantExtension = Prisma.defineExtension(prisma =>
           // Operation handling (conservative)
           switch (operation) {
             case 'findUnique': {
-              // Convert where clause to ensure accountId
-              // Note: in some cases you'll need to use findFirst instead of findUnique
-              // if semantics/typing fails; test your specific case.
-              const newArgs = { ...args, where: addAccountToWhere(args?.where) };
+              const newArgs = { ...args, where: addAccountToUniqueWhere(args?.where) };
               return query(newArgs);
             }
 
@@ -60,7 +61,7 @@ const tenantExtension = Prisma.defineExtension(prisma =>
             case 'update':
             case 'delete': {
               if (!args?.where) throw new Error(`${operation} requires a where clause`);
-              const newArgs = { ...args, where: addAccountToWhere(args.where) };
+              const newArgs = { ...args, where: addAccountToUniqueWhere(args.where) };
               return query(newArgs);
             }
 


### PR DESCRIPTION
**Bug:** La extensión de tenant inyectaba `AND: [{accountId}, where]` en `findUnique`/`update`/`delete`. Prisma `WhereUniqueInput` rechaza un `where` con solo `AND` → `PrismaClientValidationError` en cualquier llamada con tenant activo (flujos `ACCOUNT_OWNER`). El SUPER_ADMIN no lo veía porque sin tenantId la extensión hace bypass.

**Fix:** Añade helper `addAccountToUniqueWhere` que hace spread `{ ...where, accountId: tenantId }` en lugar de `AND` (Prisma 6 extended where unique). Aislamiento más fuerte: el tenantId siempre gana, atómico en la misma operación, sin ventana TOCTOU. Cubre los 6 modelos con `accountId`.

**Test:** `tenant-extension.test.ts` — 6 casos con Prisma real contra Postgres de docker: update/delete/findUnique propios, aislamiento cross-tenant (P2025 + registro intacto), bypass SUPER_ADMIN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)