### PR TITLE
fix(auth): preserve current route on page refresh

### DIFF
--- a/apps/admin-web/src/pages/login-page.tsx
+++ b/apps/admin-web/src/pages/login-page.tsx
@@ -1,26 +1,33 @@
 import { useCallback, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { LoginForm } from '@features/auth/components/login-form';
 import type { LoginFormValues } from '@features/auth/schemas/login.schema';
 import { useIsAuthenticated, useLogin } from '@shared/auth';
 import { ROUTES } from '@shared/config/routes';
 import { Shield } from 'lucide-react';
 
+interface LocationState {
+  from?: string;
+}
+
 export function LoginPage(): JSX.Element {
   const login = useLogin();
   const isAuthenticated = useIsAuthenticated();
   const navigate = useNavigate();
+  const location = useLocation();
+
+  const from = (location.state as LocationState | null)?.from || ROUTES.DASHBOARD;
 
   useEffect(() => {
-    if (isAuthenticated) navigate(ROUTES.DASHBOARD, { replace: true });
-  }, [isAuthenticated, navigate]);
+    if (isAuthenticated) navigate(from, { replace: true });
+  }, [isAuthenticated, navigate, from]);
 
   const handleSubmit = useCallback(
     async (values: LoginFormValues): Promise<void> => {
       await login(values);
-      navigate(ROUTES.DASHBOARD, { replace: true });
+      navigate(from, { replace: true });
     },
-    [login, navigate],
+    [login, navigate, from],
   );
 
   return (

--- a/apps/admin-web/src/pages/login-page.tsx
+++ b/apps/admin-web/src/pages/login-page.tsx
@@ -16,7 +16,7 @@ export function LoginPage(): JSX.Element {
   const navigate = useNavigate();
   const location = useLocation();
 
-  const from = (location.state as LocationState | null)?.from || ROUTES.DASHBOARD;
+  const from = (location.state as LocationState | null)?.from ?? ROUTES.DASHBOARD;
 
   useEffect(() => {
     if (isAuthenticated) navigate(from, { replace: true });

--- a/apps/admin-web/src/shared/auth/protected-route.tsx
+++ b/apps/admin-web/src/shared/auth/protected-route.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import { type ReactNode, useMemo } from 'react';
 import { Navigate, useLocation } from 'react-router-dom';
 
 import { useAuthLoading, useIsAuthenticated } from './hooks';
@@ -19,14 +19,17 @@ export function ProtectedRoute({ children, fallbackPath = '/login' }: Props): JS
   const isLoading = useAuthLoading();
   const location = useLocation();
 
+  const navigateState = useMemo(
+    () => ({ from: location.pathname + location.search }),
+    [location.pathname, location.search],
+  );
+
   if (isLoading) {
     return <></>;
   }
 
   if (!isAuthenticated) {
-    return (
-      <Navigate to={fallbackPath} state={{ from: location.pathname + location.search }} replace />
-    );
+    return <Navigate to={fallbackPath} state={navigateState} replace />;
   }
 
   return <>{children}</>;

--- a/apps/admin-web/src/shared/auth/protected-route.tsx
+++ b/apps/admin-web/src/shared/auth/protected-route.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react';
-import { Navigate } from 'react-router-dom';
+import { Navigate, useLocation } from 'react-router-dom';
 
-import { useIsAuthenticated } from './hooks';
+import { useAuthLoading, useIsAuthenticated } from './hooks';
 
 interface Props {
   children: ReactNode;
@@ -10,13 +10,23 @@ interface Props {
 
 /**
  * Wraps protected routes. Redirects to login if the user is not authenticated.
+ * While auth state is loading, renders nothing to prevent a flash-redirect.
+ * Passes the attempted URL as `state.from` so LoginPage can redirect back.
  * Does NOT check permissions — use RequirePermission for that.
  */
 export function ProtectedRoute({ children, fallbackPath = '/login' }: Props): JSX.Element {
   const isAuthenticated = useIsAuthenticated();
+  const isLoading = useAuthLoading();
+  const location = useLocation();
+
+  if (isLoading) {
+    return <></>;
+  }
 
   if (!isAuthenticated) {
-    return <Navigate to={fallbackPath} replace />;
+    return (
+      <Navigate to={fallbackPath} state={{ from: location.pathname + location.search }} replace />
+    );
   }
 
   return <>{children}</>;


### PR DESCRIPTION
## What

Fixes a bug where pressing F5 on any protected route (e.g. `/users`) while logged in would redirect the user to `/dashboard` instead of keeping them on the current page.

## Root Cause

Two issues chained together:

1. **`ProtectedRoute`** checked only `isAuthenticated` without waiting for `isLoading`. On page refresh, the auth state is still loading (refresh token being validated), so `isAuthenticated=false` triggered an immediate redirect to `/login`.
2. **`LoginPage`** always redirected to `/dashboard` after auth, with no mechanism to go back to the original URL.

## Changes

- **`protected-route.tsx`**: Added `useAuthLoading()` check — renders nothing while loading, preventing the premature redirect. When a real redirect is needed (user not authenticated), passes the current URL as `state.from`.
- **`login-page.tsx`**: Reads `location.state.from` and navigates there after auth (session restore or explicit login). Falls back to `/dashboard` when no state is present (direct navigation to `/login`).

## Verification

- All 56 existing tests pass
- F5 on `/users` while logged in → stays on `/users`
- Direct navigation to `/users` without session → login → redirected to `/users`
- Direct navigation to `/login` → login → redirected to `/dashboard` (fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)