### PR TITLE
feat: replace role deletion with activate/deactivate toggle

### DIFF
--- a/prisma/migrations/20260716173245_add_role_deleted_at/migration.sql
+++ b/prisma/migrations/20260716173245_add_role_deleted_at/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Role" ADD COLUMN     "deletedAt" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -51,6 +51,8 @@ model Role {
   id   String @id @default(uuid())
   name String
 
+  deletedAt DateTime? // null = active; set = deactivated (soft-delete, reversible)
+
   accountId String? // null = global role
   account   Account? @relation(fields: [accountId], references: [id])
   users     User[]   @relation("UserRoles")

--- a/src/__tests__/integration/role-toggle-api.test.ts
+++ b/src/__tests__/integration/role-toggle-api.test.ts
@@ -38,6 +38,8 @@ beforeAll(async () => {
 
   const rolesResult = await pgDb.query(`SELECT "id", "name" FROM public."Role" WHERE "accountId" IS NULL`);
   superAdminRoleId = rolesResult.rows.find((r: any) => r.name === 'SUPER_ADMIN')?.id;
+  // eslint-disable-next-line jest/no-standalone-expect
+  expect(superAdminRoleId).toBeDefined();
 
   const superAdminRes = await request(app)
     .post('/api/accounts/register/local')
@@ -49,6 +51,10 @@ beforeAll(async () => {
       roleIds: superAdminRoleId ? [superAdminRoleId] : [],
     });
   superAdminToken = superAdminRes.body.data?.token;
+  // eslint-disable-next-line jest/no-standalone-expect
+  expect(superAdminRes.status).toBe(201);
+  // eslint-disable-next-line jest/no-standalone-expect
+  expect(superAdminToken).toBeDefined();
 });
 
 afterAll(async () => {

--- a/src/__tests__/integration/role-toggle-api.test.ts
+++ b/src/__tests__/integration/role-toggle-api.test.ts
@@ -1,0 +1,131 @@
+// Avoid importing ESM 'jose' via ProviderTokenVerifier during tests
+jest.mock('@shared/security/provider-token-verifier', () => ({
+  ProviderTokenVerifier: jest.fn().mockImplementation(() => ({
+    verifyProvider: jest.fn().mockResolvedValue({
+      providerId: 'prov-1',
+      email: 'roletoggle_provider@test.local',
+      email_verified: true,
+      name: 'Provider User',
+      picture: null,
+    }),
+  })),
+}));
+
+import request from 'supertest';
+import { v4 as uuidv4 } from 'uuid';
+import { App } from '../../main/app';
+import { container } from '@shared/container';
+import { TYPES } from '@shared/types.container';
+import { PgDBContext } from '@config/pg-db';
+
+let app: any;
+let appInstance: App;
+let pgDb: PgDBContext;
+let testAccountId: string;
+let superAdminToken: string;
+let superAdminRoleId: string;
+
+beforeAll(async () => {
+  appInstance = new App();
+  app = await appInstance.setup();
+  pgDb = container.get<PgDBContext>(TYPES.TenantDB);
+
+  testAccountId = uuidv4();
+  await pgDb.query(
+    `INSERT INTO public."Account" ("id", "name", "createdAt", "updatedAt") VALUES ($1, $2, NOW(), NOW()) ON CONFLICT ("id") DO NOTHING`,
+    [testAccountId, 'Role Toggle API Test Account'],
+  );
+
+  const rolesResult = await pgDb.query(`SELECT "id", "name" FROM public."Role" WHERE "accountId" IS NULL`);
+  superAdminRoleId = rolesResult.rows.find((r: any) => r.name === 'SUPER_ADMIN')?.id;
+
+  const superAdminRes = await request(app)
+    .post('/api/accounts/register/local')
+    .send({
+      email: 'roletoggle_superadmin@test.local',
+      username: 'roletoggle_superadmin_user',
+      password: 'SecurePass123',
+      accountId: testAccountId,
+      roleIds: superAdminRoleId ? [superAdminRoleId] : [],
+    });
+  superAdminToken = superAdminRes.body.data?.token;
+});
+
+afterAll(async () => {
+  try {
+    await pgDb.query(`DELETE FROM public."Role" WHERE "name" LIKE 'test-toggle-%'`);
+    await pgDb.query('DELETE FROM public."UserIdentity" WHERE "userId" IN (SELECT "id" FROM public."User" WHERE "accountId" = $1)', [
+      testAccountId,
+    ]);
+    await pgDb.query('DELETE FROM public."User" WHERE "accountId" = $1', [testAccountId]);
+    await pgDb.query('DELETE FROM public."Account" WHERE "id" = $1', [testAccountId]);
+  } catch {
+    // ignore cleanup errors
+  }
+  await appInstance.close();
+});
+
+describe('PATCH /api/admin/roles/:id/toggle', () => {
+  it('deactivates an active role, then reactivates it on second toggle', async () => {
+    const roleName = `test-toggle-${uuidv4().slice(0, 8)}`;
+    const createRes = await request(app)
+      .post('/api/admin/roles')
+      .set('Authorization', `Bearer ${superAdminToken}`)
+      .send({ name: roleName });
+    expect(createRes.status).toBe(201);
+    const roleId = createRes.body.data.id;
+
+    const deactivate = await request(app).patch(`/api/admin/roles/${roleId}/toggle`).set('Authorization', `Bearer ${superAdminToken}`);
+    expect(deactivate.status).toBe(200);
+    expect(deactivate.body.data.role.deletedAt).not.toBeNull();
+
+    const reactivate = await request(app).patch(`/api/admin/roles/${roleId}/toggle`).set('Authorization', `Bearer ${superAdminToken}`);
+    expect(reactivate.status).toBe(200);
+    expect(reactivate.body.data.role.deletedAt).toBeNull();
+  });
+
+  it('returns 409 for SUPER_ADMIN', async () => {
+    const res = await request(app).patch(`/api/admin/roles/${superAdminRoleId}/toggle`).set('Authorization', `Bearer ${superAdminToken}`);
+    expect(res.status).toBe(409);
+  });
+
+  it('returns 404 for an unknown role id', async () => {
+    const res = await request(app).patch(`/api/admin/roles/${uuidv4()}/toggle`).set('Authorization', `Bearer ${superAdminToken}`);
+    expect(res.status).toBe(404);
+  });
+
+  it('rejects the old DELETE verb (endpoint removed)', async () => {
+    const res = await request(app).delete(`/api/admin/roles/${uuidv4()}`).set('Authorization', `Bearer ${superAdminToken}`);
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('GET /api/admin/roles?status=', () => {
+  it('filters inactive roles and includes deletedAt in the payload', async () => {
+    const roleName = `test-toggle-${uuidv4().slice(0, 8)}`;
+    const createRes = await request(app)
+      .post('/api/admin/roles')
+      .set('Authorization', `Bearer ${superAdminToken}`)
+      .send({ name: roleName });
+    const roleId = createRes.body.data.id;
+    await request(app).patch(`/api/admin/roles/${roleId}/toggle`).set('Authorization', `Bearer ${superAdminToken}`);
+
+    const inactive = await request(app).get('/api/admin/roles?status=inactive').set('Authorization', `Bearer ${superAdminToken}`);
+    expect(inactive.status).toBe(200);
+    expect(inactive.body.data.roles.some((r: any) => r.id === roleId)).toBe(true);
+    expect(inactive.body.data.roles.every((r: any) => r.deletedAt !== null)).toBe(true);
+
+    const active = await request(app).get('/api/admin/roles?status=active').set('Authorization', `Bearer ${superAdminToken}`);
+    expect(active.status).toBe(200);
+    expect(active.body.data.roles.some((r: any) => r.id === roleId)).toBe(false);
+
+    const all = await request(app).get('/api/admin/roles').set('Authorization', `Bearer ${superAdminToken}`);
+    expect(all.status).toBe(200);
+    expect(all.body.data.roles.some((r: any) => r.id === roleId)).toBe(true);
+  });
+
+  it('returns 400 for an invalid status value', async () => {
+    const res = await request(app).get('/api/admin/roles?status=nope').set('Authorization', `Bearer ${superAdminToken}`);
+    expect(res.status).toBe(400);
+  });
+});

--- a/src/__tests__/unit/admin/role.controller.test.ts
+++ b/src/__tests__/unit/admin/role.controller.test.ts
@@ -2,6 +2,9 @@ import { Request, Response } from 'express';
 import { RoleController } from '@admin/controllers/role.controller';
 import { RoleService } from '@admin/services/role.service';
 import { ILogger } from '@shared/logger.interface';
+import { RoleInactiveError } from '@admin/errors/role-inactive.error';
+import { RoleNotFoundError } from '@admin/errors/role-not-found.error';
+import { SystemRoleProtectedError } from '@admin/errors/system-role-protected.error';
 
 describe('RoleController', () => {
   let controller: RoleController;
@@ -14,7 +17,7 @@ describe('RoleController', () => {
     serviceMock = {
       getAll: jest.fn(),
       create: jest.fn(),
-      delete: jest.fn(),
+      toggleActive: jest.fn(),
       assignRole: jest.fn(),
       unassignRole: jest.fn(),
     };
@@ -42,12 +45,12 @@ describe('RoleController', () => {
   describe('list', () => {
     it('should return all roles', async () => {
       req = {};
-      const roles = [{ id: 'role-1', name: 'SUPER_ADMIN', accountId: null, _count: { users: 1 } }];
+      const roles = [{ id: 'role-1', name: 'SUPER_ADMIN', accountId: null, deletedAt: null, _count: { users: 1 } }];
       serviceMock.getAll.mockResolvedValue(roles);
 
       await controller.list(req as Request, res as Response);
 
-      expect(serviceMock.getAll).toHaveBeenCalled();
+      expect(serviceMock.getAll).toHaveBeenCalledWith(undefined);
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.json).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -55,6 +58,25 @@ describe('RoleController', () => {
           data: { roles },
         }),
       );
+    });
+
+    it('should pass the status filter to the service', async () => {
+      req = { query: { status: 'inactive' } } as unknown as Partial<Request>;
+      serviceMock.getAll.mockResolvedValue([]);
+
+      await controller.list(req as Request, res as Response);
+
+      expect(serviceMock.getAll).toHaveBeenCalledWith('inactive');
+      expect(res.status).toHaveBeenCalledWith(200);
+    });
+
+    it('should return 400 for an invalid status filter', async () => {
+      req = { query: { status: 'nope' } } as unknown as Partial<Request>;
+
+      await controller.list(req as Request, res as Response);
+
+      expect(serviceMock.getAll).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(400);
     });
 
     it('should handle errors', async () => {
@@ -112,24 +134,49 @@ describe('RoleController', () => {
   });
 
   // =========================================================================
-  // delete
+  // toggleActive
   // =========================================================================
-  describe('delete', () => {
-    it('should delete a role by id', async () => {
-      req = { params: { id: 'role-1' } };
-      serviceMock.delete.mockResolvedValue(undefined);
+  describe('toggleActive', () => {
+    it('should toggle a role and return it', async () => {
+      req = { params: { id: 'role-1' } } as unknown as Partial<Request>;
+      const role = { id: 'role-1', name: 'MODERATOR', accountId: null, deletedAt: new Date() };
+      serviceMock.toggleActive.mockResolvedValue(role);
 
-      await controller.delete(req as Request, res as Response);
+      await controller.toggleActive(req as Request, res as Response);
 
-      expect(serviceMock.delete).toHaveBeenCalledWith('role-1');
+      expect(serviceMock.toggleActive).toHaveBeenCalledWith('role-1');
       expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'success',
+          data: { role },
+        }),
+      );
     });
 
-    it('should handle errors', async () => {
-      req = { params: { id: 'bad-id' } };
-      serviceMock.delete.mockRejectedValue(new Error('Not found'));
+    it('should return 404 when the role does not exist', async () => {
+      req = { params: { id: 'bad-id' } } as unknown as Partial<Request>;
+      serviceMock.toggleActive.mockRejectedValue(new RoleNotFoundError());
 
-      await controller.delete(req as Request, res as Response);
+      await controller.toggleActive(req as Request, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+    });
+
+    it('should return 409 for a protected system role', async () => {
+      req = { params: { id: 'role-sa' } } as unknown as Partial<Request>;
+      serviceMock.toggleActive.mockRejectedValue(new SystemRoleProtectedError());
+
+      await controller.toggleActive(req as Request, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(409);
+    });
+
+    it('should return 500 for unexpected errors', async () => {
+      req = { params: { id: 'role-1' } } as unknown as Partial<Request>;
+      serviceMock.toggleActive.mockRejectedValue(new Error('boom'));
+
+      await controller.toggleActive(req as Request, res as Response);
 
       expect(res.status).toHaveBeenCalledWith(500);
     });
@@ -147,6 +194,24 @@ describe('RoleController', () => {
 
       expect(serviceMock.assignRole).toHaveBeenCalledWith('user-1', 'role-1');
       expect(res.status).toHaveBeenCalledWith(200);
+    });
+
+    it('should return 404 when the role does not exist', async () => {
+      req = { params: { userId: 'user-1', roleId: 'bad-role' } } as unknown as Partial<Request>;
+      serviceMock.assignRole.mockRejectedValue(new RoleNotFoundError());
+
+      await controller.assignRole(req as Request, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+    });
+
+    it('should return 409 when the role is deactivated', async () => {
+      req = { params: { userId: 'user-1', roleId: 'role-1' } } as unknown as Partial<Request>;
+      serviceMock.assignRole.mockRejectedValue(new RoleInactiveError());
+
+      await controller.assignRole(req as Request, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(409);
     });
 
     it('should handle errors', async () => {

--- a/src/__tests__/unit/admin/role.dto.test.ts
+++ b/src/__tests__/unit/admin/role.dto.test.ts
@@ -1,4 +1,4 @@
-import { CreateRoleDTO, CreateRoleSchema } from '@admin/services/dto/role.dto';
+import { CreateRoleDTO, CreateRoleSchema, ListRolesQueryDTO, RoleResponseDTO } from '@admin/services/dto/role.dto';
 
 describe('CreateRoleDTO', () => {
   describe('validation schema', () => {
@@ -38,5 +38,39 @@ describe('CreateRoleDTO', () => {
     it('should throw on invalid body', () => {
       expect(() => CreateRoleDTO.from({ name: '' })).toThrow();
     });
+  });
+});
+
+describe('ListRolesQueryDTO', () => {
+  it('should accept empty query (no status)', () => {
+    const dto = ListRolesQueryDTO.from({});
+    expect(dto.status).toBeUndefined();
+  });
+
+  it('should accept status=active', () => {
+    const dto = ListRolesQueryDTO.from({ status: 'active' });
+    expect(dto.status).toBe('active');
+  });
+
+  it('should accept status=inactive', () => {
+    const dto = ListRolesQueryDTO.from({ status: 'inactive' });
+    expect(dto.status).toBe('inactive');
+  });
+
+  it('should reject an invalid status value', () => {
+    expect(() => ListRolesQueryDTO.from({ status: 'deleted' })).toThrow();
+  });
+});
+
+describe('RoleResponseDTO deletedAt', () => {
+  it('should expose deletedAt when present', () => {
+    const when = new Date('2026-07-16T00:00:00Z');
+    const dto = RoleResponseDTO.from({ id: 'r1', name: 'MEMBER', accountId: null, deletedAt: when });
+    expect(dto.deletedAt).toEqual(when);
+  });
+
+  it('should default deletedAt to null when absent', () => {
+    const dto = RoleResponseDTO.from({ id: 'r1', name: 'MEMBER', accountId: null });
+    expect(dto.deletedAt).toBeNull();
   });
 });

--- a/src/__tests__/unit/admin/role.service.test.ts
+++ b/src/__tests__/unit/admin/role.service.test.ts
@@ -1,4 +1,7 @@
 import { RoleService } from '@admin/services/role.service';
+import { RoleNotFoundError } from '@admin/errors/role-not-found.error';
+import { SystemRoleProtectedError } from '@admin/errors/system-role-protected.error';
+import { RoleInactiveError } from '@admin/errors/role-inactive.error';
 import { ILogger } from '@shared/logger.interface';
 
 describe('RoleService', () => {
@@ -10,8 +13,9 @@ describe('RoleService', () => {
     prismaMock = {
       role: {
         findMany: jest.fn(),
+        findUnique: jest.fn(),
         create: jest.fn(),
-        delete: jest.fn(),
+        update: jest.fn(),
       },
       user: {
         update: jest.fn(),
@@ -36,8 +40,8 @@ describe('RoleService', () => {
   describe('getAll', () => {
     it('should return all roles with user count', async () => {
       const roles = [
-        { id: 'role-1', name: 'SUPER_ADMIN', accountId: null, _count: { users: 1 } },
-        { id: 'role-2', name: 'ACCOUNT_OWNER', accountId: null, _count: { users: 5 } },
+        { id: 'role-1', name: 'SUPER_ADMIN', accountId: null, deletedAt: null, _count: { users: 1 } },
+        { id: 'role-2', name: 'ACCOUNT_OWNER', accountId: null, deletedAt: null, _count: { users: 5 } },
       ];
       prismaMock.role.findMany.mockResolvedValue(roles);
 
@@ -45,6 +49,29 @@ describe('RoleService', () => {
 
       expect(result).toEqual(roles);
       expect(prismaMock.role.findMany).toHaveBeenCalledWith({
+        where: {},
+        include: { _count: { select: { users: true } } },
+      });
+    });
+
+    it('should filter only active roles when status=active', async () => {
+      prismaMock.role.findMany.mockResolvedValue([]);
+
+      await service.getAll('active');
+
+      expect(prismaMock.role.findMany).toHaveBeenCalledWith({
+        where: { deletedAt: null },
+        include: { _count: { select: { users: true } } },
+      });
+    });
+
+    it('should filter only deactivated roles when status=inactive', async () => {
+      prismaMock.role.findMany.mockResolvedValue([]);
+
+      await service.getAll('inactive');
+
+      expect(prismaMock.role.findMany).toHaveBeenCalledWith({
+        where: { deletedAt: { not: null } },
         include: { _count: { select: { users: true } } },
       });
     });
@@ -102,22 +129,60 @@ describe('RoleService', () => {
   });
 
   // =========================================================================
-  // delete
+  // toggleActive
   // =========================================================================
-  describe('delete', () => {
-    it('should delete a role by id', async () => {
-      prismaMock.role.delete.mockResolvedValue({ id: 'role-1', name: 'TEST', accountId: null });
+  describe('toggleActive', () => {
+    it('should deactivate an active role', async () => {
+      prismaMock.role.findUnique.mockResolvedValue({ id: 'role-1', name: 'MODERATOR', accountId: null, deletedAt: null });
+      const updated = { id: 'role-1', name: 'MODERATOR', accountId: null, deletedAt: new Date() };
+      prismaMock.role.update.mockResolvedValue(updated);
 
-      await service.delete('role-1');
+      const result = await service.toggleActive('role-1');
 
-      expect(prismaMock.role.delete).toHaveBeenCalledWith({ where: { id: 'role-1' } });
+      expect(result).toEqual(updated);
+      expect(prismaMock.role.update).toHaveBeenCalledWith({
+        where: { id: 'role-1' },
+        data: { deletedAt: expect.any(Date) },
+      });
+    });
+
+    it('should reactivate a deactivated role', async () => {
+      prismaMock.role.findUnique.mockResolvedValue({
+        id: 'role-1',
+        name: 'MODERATOR',
+        accountId: null,
+        deletedAt: new Date('2026-07-01T00:00:00Z'),
+      });
+      const updated = { id: 'role-1', name: 'MODERATOR', accountId: null, deletedAt: null };
+      prismaMock.role.update.mockResolvedValue(updated);
+
+      const result = await service.toggleActive('role-1');
+
+      expect(result).toEqual(updated);
+      expect(prismaMock.role.update).toHaveBeenCalledWith({
+        where: { id: 'role-1' },
+        data: { deletedAt: null },
+      });
+    });
+
+    it('should throw RoleNotFoundError for unknown id', async () => {
+      prismaMock.role.findUnique.mockResolvedValue(null);
+
+      await expect(service.toggleActive('bad-id')).rejects.toThrow(RoleNotFoundError);
+      expect(prismaMock.role.update).not.toHaveBeenCalled();
+    });
+
+    it('should throw SystemRoleProtectedError for SUPER_ADMIN', async () => {
+      prismaMock.role.findUnique.mockResolvedValue({ id: 'role-sa', name: 'SUPER_ADMIN', accountId: null, deletedAt: null });
+
+      await expect(service.toggleActive('role-sa')).rejects.toThrow(SystemRoleProtectedError);
+      expect(prismaMock.role.update).not.toHaveBeenCalled();
     });
 
     it('should propagate prisma errors', async () => {
-      const error = new Error('Record not found');
-      prismaMock.role.delete.mockRejectedValue(error);
+      prismaMock.role.findUnique.mockRejectedValue(new Error('DB error'));
 
-      await expect(service.delete('bad-id')).rejects.toThrow('Record not found');
+      await expect(service.toggleActive('role-1')).rejects.toThrow('DB error');
     });
   });
 
@@ -125,7 +190,8 @@ describe('RoleService', () => {
   // assignRole
   // =========================================================================
   describe('assignRole', () => {
-    it('should connect role to user', async () => {
+    it('should connect an active role to a user', async () => {
+      prismaMock.role.findUnique.mockResolvedValue({ id: 'role-1', name: 'MODERATOR', accountId: null, deletedAt: null });
       prismaMock.user.update.mockResolvedValue({ id: 'user-1' });
 
       await service.assignRole('user-1', 'role-1');
@@ -136,9 +202,23 @@ describe('RoleService', () => {
       });
     });
 
+    it('should throw RoleNotFoundError when the role does not exist', async () => {
+      prismaMock.role.findUnique.mockResolvedValue(null);
+
+      await expect(service.assignRole('user-1', 'bad-role')).rejects.toThrow(RoleNotFoundError);
+      expect(prismaMock.user.update).not.toHaveBeenCalled();
+    });
+
+    it('should throw RoleInactiveError when the role is deactivated', async () => {
+      prismaMock.role.findUnique.mockResolvedValue({ id: 'role-1', name: 'MODERATOR', accountId: null, deletedAt: new Date() });
+
+      await expect(service.assignRole('user-1', 'role-1')).rejects.toThrow(RoleInactiveError);
+      expect(prismaMock.user.update).not.toHaveBeenCalled();
+    });
+
     it('should propagate prisma errors', async () => {
-      const error = new Error('User not found');
-      prismaMock.user.update.mockRejectedValue(error);
+      prismaMock.role.findUnique.mockResolvedValue({ id: 'role-1', name: 'MODERATOR', accountId: null, deletedAt: null });
+      prismaMock.user.update.mockRejectedValue(new Error('User not found'));
 
       await expect(service.assignRole('bad-user', 'role-1')).rejects.toThrow('User not found');
     });

--- a/src/__tests__/unit/auth.middleware.test.ts
+++ b/src/__tests__/unit/auth.middleware.test.ts
@@ -156,6 +156,22 @@ describe('AuthMiddleware', () => {
       expect(next).toHaveBeenCalled();
     });
 
+    it('should query user with roles filtered to active only (deletedAt: null)', async () => {
+      mockPrisma.user.findFirst.mockResolvedValue(dbUser);
+      req.headers = { authorization: `Bearer ${validToken}` };
+
+      await authMiddleware.handler(req as Request, res as Response, next);
+
+      expect(mockPrisma.user.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          include: {
+            userIdentity: true,
+            roles: { where: { deletedAt: null } },
+          },
+        }),
+      );
+    });
+
     it('should return 401 when no authorization header', async () => {
       req.headers = {};
 

--- a/src/main/admin/controllers/role.controller.ts
+++ b/src/main/admin/controllers/role.controller.ts
@@ -1,12 +1,16 @@
 import { Request, Response } from 'express';
-import { controller, httpGet, httpPost, httpDelete, request, response } from 'inversify-express-utils';
+import { controller, httpGet, httpPost, httpPatch, httpDelete, request, response } from 'inversify-express-utils';
 import { inject } from 'inversify';
+import { ZodError } from 'zod';
 import { TYPES } from '@shared/types.container';
 import { AuthMiddleware } from '@shared/middleware/auth.middleware';
 import { ResponseHandler } from '@shared/response-handler';
 import { ILogger } from '@shared/logger.interface';
+import { RoleInactiveError } from '@admin/errors/role-inactive.error';
+import { RoleNotFoundError } from '@admin/errors/role-not-found.error';
+import { SystemRoleProtectedError } from '@admin/errors/system-role-protected.error';
 import { RoleService } from '@admin/services/role.service';
-import { CreateRoleDTO } from '@admin/services/dto/role.dto';
+import { CreateRoleDTO, ListRolesQueryDTO } from '@admin/services/dto/role.dto';
 
 @controller('/api/admin')
 export class RoleController {
@@ -18,16 +22,21 @@ export class RoleController {
   }
 
   /**
-   * Lists all roles with user counts.
-   * @param req - Express request.
+   * Lists roles with user counts, optionally filtered by activation state.
+   * @param req - Express request; optional `status` query param ('active' | 'inactive').
    * @param res - Express response.
    */
   @httpGet('/roles', AuthMiddleware.forRoles('SUPER_ADMIN'))
   public async list(@request() req: Request, @response() res: Response): Promise<void> {
     try {
-      const roles = await this._service.getAll();
+      const query = ListRolesQueryDTO.from(req.query);
+      const roles = await this._service.getAll(query.status);
       ResponseHandler.ok(res, { roles });
     } catch (err) {
+      if (err instanceof ZodError) {
+        ResponseHandler.badRequest(res, 'Invalid status filter: must be "active" or "inactive"');
+        return;
+      }
       this._log.error('Failed to list roles', { error: err });
       ResponseHandler.error(res, 'Failed to list roles', 500);
     }
@@ -51,18 +60,27 @@ export class RoleController {
   }
 
   /**
-   * Deletes a role by ID.
+   * Toggles a role between active and deactivated (soft-delete).
+   * Replaces the former DELETE endpoint — roles are never physically deleted.
    * @param req - Express request with role id in params.
-   * @param res - Express response.
+   * @param res - Express response with the updated role.
    */
-  @httpDelete('/roles/:id', AuthMiddleware.forRoles('SUPER_ADMIN'))
-  public async delete(@request() req: Request, @response() res: Response): Promise<void> {
+  @httpPatch('/roles/:id/toggle', AuthMiddleware.forRoles('SUPER_ADMIN'))
+  public async toggleActive(@request() req: Request, @response() res: Response): Promise<void> {
     try {
-      await this._service.delete(req.params.id);
-      ResponseHandler.deleted(res);
+      const role = await this._service.toggleActive(req.params.id);
+      ResponseHandler.ok(res, { role });
     } catch (err) {
-      this._log.error('Failed to delete role', { error: err, roleId: req.params.id });
-      ResponseHandler.error(res, 'Failed to delete role', 500);
+      if (err instanceof RoleNotFoundError) {
+        ResponseHandler.notFound(res, err.message);
+        return;
+      }
+      if (err instanceof SystemRoleProtectedError) {
+        ResponseHandler.error(res, err.message, err.statusCode);
+        return;
+      }
+      this._log.error('Failed to toggle role', { error: err, roleId: req.params.id });
+      ResponseHandler.error(res, 'Failed to toggle role', 500);
     }
   }
 
@@ -77,6 +95,14 @@ export class RoleController {
       await this._service.assignRole(req.params.userId, req.params.roleId);
       ResponseHandler.ok(res, { message: 'Role assigned successfully' });
     } catch (err) {
+      if (err instanceof RoleNotFoundError) {
+        ResponseHandler.notFound(res, err.message);
+        return;
+      }
+      if (err instanceof RoleInactiveError) {
+        ResponseHandler.error(res, err.message, err.statusCode);
+        return;
+      }
       this._log.error('Failed to assign role', { error: err, userId: req.params.userId, roleId: req.params.roleId });
       ResponseHandler.error(res, 'Failed to assign role', 500);
     }

--- a/src/main/admin/errors/role-inactive.error.ts
+++ b/src/main/admin/errors/role-inactive.error.ts
@@ -1,0 +1,10 @@
+import { AppError } from '@shared/errors/app.error';
+
+/**
+ * Thrown when attempting to assign a deactivated role to a user.
+ */
+export class RoleInactiveError extends AppError {
+  public constructor(message = 'Role is deactivated and cannot be assigned') {
+    super(message, 409, 'ROLE_INACTIVE');
+  }
+}

--- a/src/main/admin/errors/role-not-found.error.ts
+++ b/src/main/admin/errors/role-not-found.error.ts
@@ -1,0 +1,10 @@
+import { AppError } from '@shared/errors/app.error';
+
+/**
+ * Thrown when the requested role does not exist in the database.
+ */
+export class RoleNotFoundError extends AppError {
+  public constructor(message = 'Role not found') {
+    super(message, 404, 'ROLE_NOT_FOUND');
+  }
+}

--- a/src/main/admin/errors/system-role-protected.error.ts
+++ b/src/main/admin/errors/system-role-protected.error.ts
@@ -1,0 +1,10 @@
+import { AppError } from '@shared/errors/app.error';
+
+/**
+ * Thrown when attempting to deactivate a protected system role (SUPER_ADMIN).
+ */
+export class SystemRoleProtectedError extends AppError {
+  public constructor(message = 'The SUPER_ADMIN role cannot be deactivated') {
+    super(message, 409, 'SYSTEM_ROLE_PROTECTED');
+  }
+}

--- a/src/main/admin/services/dto/role.dto.ts
+++ b/src/main/admin/services/dto/role.dto.ts
@@ -40,6 +40,7 @@ export const RoleResponseSchema = z.object({
   id: z.string(),
   name: z.string(),
   accountId: z.string().nullable(),
+  deletedAt: z.date().nullable().optional(),
   _count: z
     .object({
       users: z.number(),
@@ -53,12 +54,14 @@ export class RoleResponseDTO {
   public readonly id: string;
   public readonly name: string;
   public readonly accountId: string | null;
+  public readonly deletedAt: Date | null;
   public readonly userCount?: number;
 
   private constructor(data: RoleResponseType) {
     this.id = data.id;
     this.name = data.name;
     this.accountId = data.accountId;
+    this.deletedAt = data.deletedAt ?? null;
     if (data._count) {
       this.userCount = data._count.users;
     }
@@ -71,5 +74,34 @@ export class RoleResponseDTO {
    */
   public static from(model: RoleResponseType): RoleResponseDTO {
     return new RoleResponseDTO(model);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// ListRolesQueryDTO
+// ---------------------------------------------------------------------------
+
+export const ListRolesQuerySchema = z.object({
+  status: z.enum(['active', 'inactive']).optional(),
+});
+
+export type ListRolesQueryType = z.infer<typeof ListRolesQuerySchema>;
+
+export class ListRolesQueryDTO {
+  public readonly status?: 'active' | 'inactive';
+
+  private constructor(data: ListRolesQueryType) {
+    this.status = data.status;
+  }
+
+  /**
+   * Creates a ListRolesQueryDTO from an unvalidated query object.
+   * @param query - The raw request query.
+   * @returns A validated ListRolesQueryDTO.
+   * @throws ZodError if validation fails.
+   */
+  public static from(query: unknown): ListRolesQueryDTO {
+    const parsed = ListRolesQuerySchema.parse(query ?? {});
+    return new ListRolesQueryDTO(parsed);
   }
 }

--- a/src/main/admin/services/role.service.ts
+++ b/src/main/admin/services/role.service.ts
@@ -2,6 +2,9 @@ import { inject, injectable } from 'inversify';
 import { PrismaClient } from '@prisma/client';
 import { ILogger } from '@shared/logger.interface';
 import { TYPES } from '@shared/types.container';
+import { RoleNotFoundError } from '@admin/errors/role-not-found.error';
+import { SystemRoleProtectedError } from '@admin/errors/system-role-protected.error';
+import { RoleInactiveError } from '@admin/errors/role-inactive.error';
 
 @injectable()
 export class RoleService {
@@ -13,12 +16,17 @@ export class RoleService {
   }
 
   /**
-   * Returns all roles with their user count.
-   * @returns Array of roles with _count.users.
+   * Returns roles with their user count, optionally filtered by activation state.
+   * @param status - Optional filter: 'active' (deletedAt = null) or 'inactive' (deletedAt set).
+   * @returns Array of roles with _count.users and deletedAt.
    */
-  public async getAll(): Promise<Array<{ id: string; name: string; accountId: string | null; _count: { users: number } }>> {
-    this._log.debug('Fetching all roles');
+  public async getAll(
+    status?: 'active' | 'inactive',
+  ): Promise<Array<{ id: string; name: string; accountId: string | null; deletedAt: Date | null; _count: { users: number } }>> {
+    this._log.debug('Fetching roles', { status: status ?? 'all' });
+    const where = status === 'active' ? { deletedAt: null } : status === 'inactive' ? { deletedAt: { not: null } } : {};
     return this._prisma.role.findMany({
+      where,
       include: { _count: { select: { users: true } } },
     });
   }
@@ -37,20 +45,44 @@ export class RoleService {
   }
 
   /**
-   * Deletes a role by ID.
+   * Toggles a role between active and deactivated (soft-delete via deletedAt).
    * @param id - The role ID.
+   * @returns The updated role.
+   * @throws RoleNotFoundError if the role does not exist.
+   * @throws SystemRoleProtectedError if the role is SUPER_ADMIN.
    */
-  public async delete(id: string): Promise<void> {
-    this._log.debug('Deleting role', { id });
-    await this._prisma.role.delete({ where: { id } });
+  public async toggleActive(id: string): Promise<{ id: string; name: string; accountId: string | null; deletedAt: Date | null }> {
+    const role = await this._prisma.role.findUnique({ where: { id } });
+    if (!role) {
+      this._log.warn('Role not found for toggle', { roleId: id });
+      throw new RoleNotFoundError();
+    }
+    if (role.name === 'SUPER_ADMIN') {
+      this._log.warn('Attempted to toggle protected system role', { roleId: id });
+      throw new SystemRoleProtectedError();
+    }
+    const deletedAt = role.deletedAt ? null : new Date();
+    this._log.debug('Toggling role active state', { roleId: id, deactivating: deletedAt !== null });
+    return this._prisma.role.update({ where: { id }, data: { deletedAt } });
   }
 
   /**
-   * Assigns a role to a user.
+   * Assigns a role to a user. Deactivated roles cannot be assigned.
    * @param userId - The user ID.
    * @param roleId - The role ID to assign.
+   * @throws RoleNotFoundError if the role does not exist.
+   * @throws RoleInactiveError if the role is deactivated.
    */
   public async assignRole(userId: string, roleId: string): Promise<void> {
+    const role = await this._prisma.role.findUnique({ where: { id: roleId } });
+    if (!role) {
+      this._log.warn('Role not found for assignment', { userId, roleId });
+      throw new RoleNotFoundError();
+    }
+    if (role.deletedAt) {
+      this._log.warn('Attempted to assign a deactivated role', { userId, roleId });
+      throw new RoleInactiveError();
+    }
     this._log.debug('Assigning role to user', { userId, roleId });
     await this._prisma.user.update({
       where: { id: userId },

--- a/src/main/docs/modules/admin.paths.ts
+++ b/src/main/docs/modules/admin.paths.ts
@@ -259,8 +259,9 @@ export function registerAdminPaths(registry: OpenAPIRegistry): void {
     .summary('List all roles with user counts')
     .operationId('adminListRoles')
     .security('bearerAuth')
+    .queryParam('status', z.enum(['active', 'inactive']).optional(), 'Filter by activation state (default: all)')
     .response(200, 'List of roles', z.object({ roles: z.array(Schemas.RoleResponseDTO) }))
-    .errors(401, 403)
+    .errors(400, 401, 403)
     .register(registry);
 
   endpoint('post', '/api/admin/roles')
@@ -273,14 +274,14 @@ export function registerAdminPaths(registry: OpenAPIRegistry): void {
     .errors(400, 401, 403)
     .register(registry);
 
-  endpoint('delete', '/api/admin/roles/{id}')
+  endpoint('patch', '/api/admin/roles/{id}/toggle')
     .tag(TAG.ADMIN_ROLES)
-    .summary('Delete a role by ID')
-    .operationId('adminDeleteRole')
+    .summary('Toggle a role between active and deactivated (soft-delete)')
+    .operationId('adminToggleRole')
     .security('bearerAuth')
     .pathParam('id', 'Role ID')
-    .response204('Role deleted')
-    .errors(401, 403, 404)
+    .response(200, 'Role toggled', z.object({ role: Schemas.RoleResponseDTO }))
+    .errors(401, 403, 404, 409)
     .register(registry);
 
   // ── Admin User-Role Management ────────────────────────────────────────

--- a/src/main/shared/middleware/auth.middleware.ts
+++ b/src/main/shared/middleware/auth.middleware.ts
@@ -107,7 +107,8 @@ export class AuthMiddleware extends BaseMiddleware {
           },
           include: {
             userIdentity: true,
-            roles: true,
+            // Deactivated roles must not grant permissions — filter them out
+            roles: { where: { deletedAt: null } },
           },
         });
 

--- a/src/main/users/repositories/user.repository.ts
+++ b/src/main/users/repositories/user.repository.ts
@@ -5,6 +5,9 @@ import { RoleType } from '@users/dto';
 
 export type UserWithRoles = User & { roles: RoleType[] };
 
+/** Deactivated roles must not appear in auth/JWT flows — always filter. */
+const ACTIVE_ROLES_INCLUDE = { roles: { where: { deletedAt: null } } } as const;
+
 @injectable()
 export class UserRepository {
   public constructor(@inject(TYPES.PrismaClient) private readonly prisma: PrismaClient) {}
@@ -12,34 +15,34 @@ export class UserRepository {
   public findByEmail(email: string): Promise<UserWithRoles | null> {
     return this.prisma.user.findFirst({
       where: { email },
-      include: { roles: true },
+      include: ACTIVE_ROLES_INCLUDE,
     });
   }
 
   public findByUsername(username: string): Promise<UserWithRoles | null> {
     return this.prisma.user.findFirst({
       where: { username },
-      include: { roles: true },
+      include: ACTIVE_ROLES_INCLUDE,
     });
   }
 
   public create(data: Prisma.UserCreateInput): Promise<UserWithRoles> {
     return this.prisma.user.create({
       data,
-      include: { roles: true },
+      include: ACTIVE_ROLES_INCLUDE,
     });
   }
 
   public findById(id: string): Promise<UserWithRoles | null> {
     return this.prisma.user.findFirst({
       where: { id },
-      include: { roles: true },
+      include: ACTIVE_ROLES_INCLUDE,
     });
   }
 
   public findAll(): Promise<UserWithRoles[]> {
     return this.prisma.user.findMany({
-      include: { roles: true },
+      include: ACTIVE_ROLES_INCLUDE,
     });
   }
 
@@ -53,14 +56,14 @@ export class UserRepository {
     return this.prisma.user.update({
       where: { id },
       data,
-      include: { roles: true },
+      include: ACTIVE_ROLES_INCLUDE,
     });
   }
 
   public async findByIdWithRoles(id: string): Promise<UserWithRoles | null> {
     return this.prisma.user.findFirst({
       where: { id },
-      include: { roles: true },
+      include: ACTIVE_ROLES_INCLUDE,
     });
   }
 
@@ -72,7 +75,7 @@ export class UserRepository {
     const created = await this.prisma.$transaction(async tx => {
       const user = await tx.user.create({
         data: userCreateInput,
-        include: { roles: true },
+        include: ACTIVE_ROLES_INCLUDE,
       });
 
       await tx.userIdentity.create({

--- a/swagger.json
+++ b/swagger.json
@@ -1766,6 +1766,10 @@
             "type": "string",
             "nullable": true
           },
+          "deletedAt": {
+            "type": "string",
+            "nullable": true
+          },
           "_count": {
             "type": "object",
             "properties": {
@@ -7267,6 +7271,193 @@
       }
     },
     "/api/admin/users/{id}": {
+      "get": {
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Get a single user (admin)",
+        "operationId": "adminGetUser",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "User ID"
+            },
+            "required": true,
+            "description": "User ID",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "User detail",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserDTO"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - missing or invalid token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden - insufficient role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
       "delete": {
         "tags": [
           "Admin"
@@ -10993,6 +11184,22 @@
             "bearerAuth": []
           }
         ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "active",
+                "inactive"
+              ],
+              "description": "Filter by activation state (default: all)"
+            },
+            "required": false,
+            "description": "Filter by activation state (default: all)",
+            "name": "status",
+            "in": "query"
+          }
+        ],
         "responses": {
           "200": {
             "description": "List of roles",
@@ -11010,6 +11217,56 @@
                   },
                   "required": [
                     "roles"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
                   ]
                 }
               }
@@ -11303,13 +11560,13 @@
         }
       }
     },
-    "/api/admin/roles/{id}": {
-      "delete": {
+    "/api/admin/roles/{id}/toggle": {
+      "patch": {
         "tags": [
           "Admin - Roles"
         ],
-        "summary": "Delete a role by ID",
-        "operationId": "adminDeleteRole",
+        "summary": "Toggle a role between active and deactivated (soft-delete)",
+        "operationId": "adminToggleRole",
         "security": [
           {
             "bearerAuth": []
@@ -11329,8 +11586,23 @@
           }
         ],
         "responses": {
-          "204": {
-            "description": "Role deleted"
+          "200": {
+            "description": "Role toggled",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "role": {
+                      "$ref": "#/components/schemas/RoleResponseDTO"
+                    }
+                  },
+                  "required": [
+                    "role"
+                  ]
+                }
+              }
+            }
           },
           "401": {
             "description": "Unauthorized - missing or invalid token",
@@ -11434,6 +11706,56 @@
           },
           "404": {
             "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": [
+                        "error"
+                      ]
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "code": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "path": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "required": [
+                          "code",
+                          "message",
+                          "path"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "message"
+                  ]
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Error",
             "content": {
               "application/json": {
                 "schema": {


### PR DESCRIPTION
## Summary

Replaces the physical `DELETE /api/admin/roles/:id` endpoint with a soft-delete **toggle**: roles are never deleted anymore, only deactivated/reactivated via `PATCH /api/admin/roles/:id/toggle`.

### Changes

- **Prisma**: new nullable `Role.deletedAt` column (additive migration `add_role_deleted_at`); `null` = active.
- **`PATCH /api/admin/roles/:id/toggle`** (SUPER_ADMIN only): flips `deletedAt`. `404` unknown role, `409` when targeting the protected `SUPER_ADMIN` role. The old DELETE endpoint is gone.
- **`GET /api/admin/roles?status=active|inactive`**: optional filter (default: all, now including `deletedAt`); invalid value → `400`.
- **Enforcement**: `AuthMiddleware` and all `UserRepository` role includes filter `deletedAt: null` — a deactivated role stops granting permissions on the very next request (assignments are preserved).
- **`POST /api/admin/users/:userId/roles/:roleId`**: assigning a deactivated role → `409`; unknown role → `404`.
- New domain errors under `src/main/admin/errors/` (`RoleNotFoundError`, `SystemRoleProtectedError`, `RoleInactiveError`).
- OpenAPI paths updated + `swagger.json` regenerated.

### Tests

- Unit: `RoleService` toggle/filter/guards, `RoleController` mappings, `AuthMiddleware` filtered include, DTO validation.
- Integration (`role-toggle-api.test.ts`): toggle round-trip, SUPER_ADMIN 409, unknown 404, removed DELETE verb, status filters, invalid filter 400.
- Full suite: **83/83 suites, 868 tests green**; lint/format/docs:validate/build clean.

### Notes

- Backend only — the admin-web frontend still calls the old DELETE and will be adapted in a follow-up PR.
- Product note: a deactivated role keeps occupying its name (`@@unique([accountId, name])`) until reactivated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)