### PR TITLE
fix(admin-web): extract shared pagination hooks and fix products pagination

### DIFF
--- a/apps/admin-web/src/features/accounts/hooks/useGetAccounts.ts
+++ b/apps/admin-web/src/features/accounts/hooks/useGetAccounts.ts
@@ -1,10 +1,7 @@
-import { ENV } from '@shared/config/env';
-import { useQuery } from '@tanstack/react-query';
+import { usePaginatedQuery } from '@shared/hooks/usePaginatedQuery';
 
 import { mapAccountDTOToViewModel } from '../mappers/account-mapper';
 import { accountsService } from '../services/accounts-service';
-
-import { accountKeys } from './query-keys';
 
 interface Params {
   page: number;
@@ -13,27 +10,17 @@ interface Params {
 }
 
 export function useGetAccounts(params: Params) {
-  const skip = (params.page - 1) * params.limit;
-  const filters: Record<string, unknown> = {
+  return usePaginatedQuery({
     page: params.page,
     limit: params.limit,
-    search: params.search ?? '',
-  };
-
-  return useQuery({
-    queryKey: accountKeys.list(filters),
-    queryFn: async ({ signal }) => {
-      const response = await accountsService.list({
-        skip,
-        limit: params.limit,
-        search: params.search,
-        signal,
-      });
-      return {
-        items: response.data.accounts.map(mapAccountDTOToViewModel),
-        total: response.data.total,
-      };
+    filters: {
+      search: params.search ?? '',
     },
-    staleTime: ENV.STALE_TIME_STANDARD,
+    queryKeyBase: 'accounts',
+    queryFn: ({ skip, limit, signal }) =>
+      accountsService.list({ skip, limit, search: params.search, signal }).then((res) => ({
+        items: res.data.accounts.map(mapAccountDTOToViewModel),
+        total: res.data.total,
+      })),
   });
 }

--- a/apps/admin-web/src/features/products/components/products-table.tsx
+++ b/apps/admin-web/src/features/products/components/products-table.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { productDetailRoute } from '@shared/config/routes';
+import { useDebouncedFilter } from '@shared/hooks/useDebouncedFilter';
 import { PackageSearch, Search } from 'lucide-react';
 
 import { useGetProducts } from '../hooks/useGetProducts';
@@ -12,68 +13,28 @@ export function ProductsTable(): JSX.Element {
   const { t } = useTranslation();
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(20);
-  const [searchInput, setSearchInput] = useState('');
-  const [search, setSearch] = useState('');
-  const [categoryInput, setCategoryInput] = useState('');
-  const [category, setCategory] = useState('');
-  const [minPriceInput, setMinPriceInput] = useState('');
-  const [minPrice, setMinPrice] = useState('');
-  const [maxPriceInput, setMaxPriceInput] = useState('');
-  const [maxPrice, setMaxPrice] = useState('');
+  const search = useDebouncedFilter();
+  const category = useDebouncedFilter();
+  const minPrice = useDebouncedFilter();
+  const maxPrice = useDebouncedFilter();
   const [isOutstanding, setIsOutstanding] = useState(false);
   const [isPromoted, setIsPromoted] = useState(false);
 
-  // Debounce search input (300ms)
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setSearch(searchInput);
+  const handleFilterChange = useCallback(
+    <TValue,>(setter: (value: TValue) => void, value: TValue): void => {
+      setter(value);
       setPage(1);
-    }, 300);
-    return () => {
-      clearTimeout(timer);
-    };
-  }, [searchInput]);
-
-  // Debounce category filter (300ms)
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setCategory(categoryInput);
-      setPage(1);
-    }, 300);
-    return () => {
-      clearTimeout(timer);
-    };
-  }, [categoryInput]);
-
-  // Debounce minPrice filter (300ms)
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setMinPrice(minPriceInput);
-      setPage(1);
-    }, 300);
-    return () => {
-      clearTimeout(timer);
-    };
-  }, [minPriceInput]);
-
-  // Debounce maxPrice filter (300ms)
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setMaxPrice(maxPriceInput);
-      setPage(1);
-    }, 300);
-    return () => {
-      clearTimeout(timer);
-    };
-  }, [maxPriceInput]);
+    },
+    [],
+  );
 
   const { data, isLoading, isError, error, isFetching, refetch } = useGetProducts({
     page,
     limit: pageSize,
-    search: search || undefined,
-    category: category || undefined,
-    minPrice: minPrice ? Number(minPrice) : undefined,
-    maxPrice: maxPrice ? Number(maxPrice) : undefined,
+    search: search.debouncedValue || undefined,
+    category: category.debouncedValue || undefined,
+    minPrice: minPrice.debouncedValue ? Number(minPrice.debouncedValue) : undefined,
+    maxPrice: maxPrice.debouncedValue ? Number(maxPrice.debouncedValue) : undefined,
     isOutstanding: isOutstanding || undefined,
     isPromoted: isPromoted || undefined,
   });
@@ -138,9 +99,9 @@ export function ProductsTable(): JSX.Element {
           />
           <input
             type="text"
-            value={searchInput}
+            value={search.value}
             onChange={(e) => {
-              setSearchInput(e.target.value);
+              handleFilterChange(search.setValue, e.target.value);
             }}
             placeholder={t('products.searchPlaceholder')}
             aria-label={t('products.searchPlaceholder')}
@@ -151,9 +112,9 @@ export function ProductsTable(): JSX.Element {
         {/* Category filter */}
         <input
           type="text"
-          value={categoryInput}
+          value={category.value}
           onChange={(e) => {
-            setCategoryInput(e.target.value);
+            handleFilterChange(category.setValue, e.target.value);
           }}
           placeholder={t('products.filters.categoryPlaceholder')}
           aria-label={t('products.filters.categoryPlaceholder')}
@@ -163,9 +124,9 @@ export function ProductsTable(): JSX.Element {
         {/* Min price */}
         <input
           type="number"
-          value={minPriceInput}
+          value={minPrice.value}
           onChange={(e) => {
-            setMinPriceInput(e.target.value);
+            handleFilterChange(minPrice.setValue, e.target.value);
           }}
           placeholder={t('products.filters.minPrice')}
           aria-label={t('products.filters.minPrice')}
@@ -176,9 +137,9 @@ export function ProductsTable(): JSX.Element {
         {/* Max price */}
         <input
           type="number"
-          value={maxPriceInput}
+          value={maxPrice.value}
           onChange={(e) => {
-            setMaxPriceInput(e.target.value);
+            handleFilterChange(maxPrice.setValue, e.target.value);
           }}
           placeholder={t('products.filters.maxPrice')}
           aria-label={t('products.filters.maxPrice')}
@@ -192,8 +153,7 @@ export function ProductsTable(): JSX.Element {
             type="checkbox"
             checked={isOutstanding}
             onChange={(e) => {
-              setIsOutstanding(e.target.checked);
-              setPage(1);
+              handleFilterChange(setIsOutstanding, e.target.checked);
             }}
             className="h-4 w-4 rounded border-outline-variant bg-surface text-primary focus:ring-1 focus:ring-primary"
           />
@@ -206,8 +166,7 @@ export function ProductsTable(): JSX.Element {
             type="checkbox"
             checked={isPromoted}
             onChange={(e) => {
-              setIsPromoted(e.target.checked);
-              setPage(1);
+              handleFilterChange(setIsPromoted, e.target.checked);
             }}
             className="h-4 w-4 rounded border-outline-variant bg-surface text-primary focus:ring-1 focus:ring-primary"
           />

--- a/apps/admin-web/src/features/products/hooks/useGetProducts.ts
+++ b/apps/admin-web/src/features/products/hooks/useGetProducts.ts
@@ -1,10 +1,7 @@
-import { ENV } from '@shared/config/env';
-import { useQuery } from '@tanstack/react-query';
+import { usePaginatedQuery } from '@shared/hooks/usePaginatedQuery';
 
 import { mapProductDTOToViewModel } from '../mappers/product-mapper';
 import { productsService } from '../services/products-service';
-
-import { productKeys } from './query-keys';
 
 export interface UseGetProductsParams {
   page: number;
@@ -18,38 +15,35 @@ export interface UseGetProductsParams {
 }
 
 export function useGetProducts(params: UseGetProductsParams) {
-  const skip = (params.page - 1) * params.limit;
-  const filters: Record<string, unknown> = {
+  return usePaginatedQuery({
     page: params.page,
     limit: params.limit,
-    search: params.search ?? '',
-    category: params.category ?? '',
-    minPrice: params.minPrice,
-    maxPrice: params.maxPrice,
-    isOutstanding: params.isOutstanding,
-    isPromoted: params.isPromoted,
-  };
-
-  return useQuery({
-    queryKey: productKeys.list(filters),
-    queryFn: async ({ signal }) => {
-      const response = await productsService.list({
-        skip,
-        limit: params.limit,
-        search: params.search,
-        category: params.category,
-        minPrice: params.minPrice,
-        maxPrice: params.maxPrice,
-        isOutstanding: params.isOutstanding,
-        isPromoted: params.isPromoted,
-        signal,
-      });
-      return {
-        items: response.data.data.map(mapProductDTOToViewModel),
-        total: response.data.meta.total,
-      };
+    filters: {
+      search: params.search ?? '',
+      category: params.category ?? '',
+      ...(params.minPrice !== undefined && { minPrice: params.minPrice }),
+      ...(params.maxPrice !== undefined && { maxPrice: params.maxPrice }),
+      ...(params.isOutstanding !== undefined && { isOutstanding: params.isOutstanding }),
+      ...(params.isPromoted !== undefined && { isPromoted: params.isPromoted }),
     },
-    staleTime: ENV.STALE_TIME_STANDARD,
-    placeholderData: (prev) => prev,
+    queryKeyBase: 'products',
+    placeholderData: true,
+    queryFn: ({ skip, limit, signal }) =>
+      productsService
+        .list({
+          skip,
+          limit,
+          search: params.search,
+          category: params.category,
+          minPrice: params.minPrice,
+          maxPrice: params.maxPrice,
+          isOutstanding: params.isOutstanding,
+          isPromoted: params.isPromoted,
+          signal,
+        })
+        .then((res) => ({
+          items: res.data.data.map(mapProductDTOToViewModel),
+          total: res.data.meta.total,
+        })),
   });
 }

--- a/apps/admin-web/src/features/users/hooks/useGetUsers.ts
+++ b/apps/admin-web/src/features/users/hooks/useGetUsers.ts
@@ -1,34 +1,26 @@
-import { ENV } from '@shared/config/env';
-import { useQuery } from '@tanstack/react-query';
+import { usePaginatedQuery } from '@shared/hooks/usePaginatedQuery';
 
 import { mapUserDTOToViewModel } from '../mappers/user-mapper';
 import { usersService } from '../services/users-service';
 
-import { userKeys } from './query-keys';
-
-interface UseGetUsersParams {
+interface Params {
   page: number;
   limit: number;
   search?: string;
 }
 
-export function useGetUsers(params: UseGetUsersParams) {
-  const skip = (params.page - 1) * params.limit;
-
-  return useQuery({
-    queryKey: userKeys.list({ page: params.page, limit: params.limit, search: params.search ?? '' }),
-    queryFn: async ({ signal }) => {
-      const response = await usersService.list({
-        skip,
-        limit: params.limit,
-        search: params.search,
-        signal,
-      });
-      return {
-        items: response.data.users.map(mapUserDTOToViewModel),
-        total: response.data.total,
-      };
+export function useGetUsers(params: Params) {
+  return usePaginatedQuery({
+    page: params.page,
+    limit: params.limit,
+    filters: {
+      search: params.search ?? '',
     },
-    staleTime: ENV.STALE_TIME_STANDARD,
+    queryKeyBase: 'users',
+    queryFn: ({ skip, limit, signal }) =>
+      usersService.list({ skip, limit, search: params.search, signal }).then((res) => ({
+        items: res.data.users.map(mapUserDTOToViewModel),
+        total: res.data.total,
+      })),
   });
 }

--- a/apps/admin-web/src/shared/hooks/__tests__/usePaginatedQuery.test.tsx
+++ b/apps/admin-web/src/shared/hooks/__tests__/usePaginatedQuery.test.tsx
@@ -1,0 +1,158 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import React from 'react';
+
+import { usePaginatedQuery } from '../usePaginatedQuery';
+
+// ---------------------------------------------------------------------------
+// Wrapper
+// ---------------------------------------------------------------------------
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return React.createElement(QueryClientProvider, {
+      client: queryClient,
+      children,
+    });
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('usePaginatedQuery', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('refetches when page changes (query key includes pagination params)', async () => {
+    const queryFn = vi.fn().mockResolvedValue({ items: [], total: 0 });
+
+    const { rerender } = renderHook(
+      ({ page }: { page: number }) =>
+        usePaginatedQuery({
+          page,
+          limit: 20,
+          filters: { search: '' },
+          queryKeyBase: 'test',
+          queryFn,
+          staleTime: 300_000,
+        }),
+      {
+        wrapper: createWrapper(),
+        initialProps: { page: 1 },
+      },
+    );
+
+    // First fetch for page 1 → skip: 0
+    await waitFor(() => {
+      expect(queryFn).toHaveBeenCalledTimes(1);
+    });
+    expect(queryFn).toHaveBeenCalledWith(expect.objectContaining({ skip: 0, limit: 20 }));
+
+    // Switch to page 2
+    rerender({ page: 2 });
+
+    // FAILS with the buggy key (page/limit omitted) because the cache entry
+    // is still fresh → no refetch. PASSES after the fix adds pagination to
+    // the query key → new cache entry → new fetch with skip: 20.
+    await waitFor(() => {
+      expect(queryFn).toHaveBeenCalledTimes(2);
+    });
+    expect(queryFn).toHaveBeenLastCalledWith(expect.objectContaining({ skip: 20, limit: 20 }));
+  });
+
+  it('does not refetch when params are identical (stable key)', async () => {
+    const queryFn = vi.fn().mockResolvedValue({ items: [], total: 0 });
+
+    const { rerender } = renderHook(
+      ({ page }: { page: number }) =>
+        usePaginatedQuery({
+          page,
+          limit: 20,
+          filters: { search: 'foo' },
+          queryKeyBase: 'test',
+          queryFn,
+          staleTime: 300_000,
+        }),
+      {
+        wrapper: createWrapper(),
+        initialProps: { page: 1 },
+      },
+    );
+
+    // First fetch happens
+    await waitFor(() => {
+      expect(queryFn).toHaveBeenCalledTimes(1);
+    });
+
+    // Re-render with same props — key unchanged, data still fresh → no refetch
+    rerender({ page: 1 });
+
+    await waitFor(() => {
+      expect(queryFn).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('keeps previous data while fetching next page with placeholderData opt-in', async () => {
+    const firstResult = { items: ['a'], total: 2 } as const;
+    const secondResult = { items: ['b'], total: 2 } as const;
+
+    let resolveSecond!: (value: typeof secondResult) => void;
+    const secondPromise = new Promise<typeof secondResult>((resolve) => {
+      resolveSecond = resolve;
+    });
+
+    const queryFn = vi.fn().mockResolvedValueOnce(firstResult).mockReturnValueOnce(secondPromise);
+
+    const { rerender, result } = renderHook(
+      ({ page }: { page: number }) =>
+        usePaginatedQuery({
+          page,
+          limit: 20,
+          filters: { search: '' },
+          queryKeyBase: 'test-ph',
+          queryFn,
+          staleTime: 0,
+          placeholderData: true,
+        }),
+      {
+        wrapper: createWrapper(),
+        initialProps: { page: 1 },
+      },
+    );
+
+    // Page 1 resolves immediately
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(result.current.data).toEqual(firstResult);
+    expect(result.current.isPlaceholderData).toBe(false);
+
+    // Switch to page 2 — second fetch is pending
+    rerender({ page: 2 });
+
+    // While the new fetch is in-flight, placeholderData keeps the old result
+    await waitFor(() => {
+      expect(result.current.isPlaceholderData).toBe(true);
+    });
+    expect(result.current.data).toEqual(firstResult);
+
+    // Resolve the pending fetch
+    resolveSecond(secondResult);
+
+    // Now we have page 2 data
+    await waitFor(() => {
+      expect(result.current.data).toEqual(secondResult);
+      expect(result.current.isPlaceholderData).toBe(false);
+    });
+  });
+});

--- a/apps/admin-web/src/shared/hooks/useDebouncedFilter.ts
+++ b/apps/admin-web/src/shared/hooks/useDebouncedFilter.ts
@@ -1,0 +1,46 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/**
+ * Generic debounce hook for filter inputs.
+ *
+ * Manages an instant `value` (for responsive input rendering) and a
+ * `debouncedValue` that settles after `delay` ms of inactivity.
+ *
+ * @param initial - initial value (default `''`)
+ * @param delay - debounce delay in ms (default `300`)
+ * @returns `{ value, debouncedValue, setValue }`
+ *
+ * @example
+ * const search = useDebouncedFilter('', 300);
+ * // <input value={search.value} onChange={e => search.setValue(e.target.value)} />
+ * // useGetProducts({ search: search.debouncedValue })
+ */
+export function useDebouncedFilter(initial = '', delay = 300) {
+  const [value, setValue] = useState(initial);
+  const [debouncedValue, setDebouncedValue] = useState(initial);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleSetValue = useCallback(
+    (next: string) => {
+      setValue(next);
+      if (timerRef.current !== null) {
+        clearTimeout(timerRef.current);
+      }
+      timerRef.current = setTimeout(() => {
+        setDebouncedValue(next);
+      }, delay);
+    },
+    [delay],
+  );
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      if (timerRef.current !== null) {
+        clearTimeout(timerRef.current);
+      }
+    };
+  }, []);
+
+  return { value, debouncedValue, setValue: handleSetValue };
+}

--- a/apps/admin-web/src/shared/hooks/usePaginatedQuery.ts
+++ b/apps/admin-web/src/shared/hooks/usePaginatedQuery.ts
@@ -1,0 +1,87 @@
+import { ENV } from '@shared/config/env';
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+
+/**
+ * Result shape that every paginated query must return.
+ */
+export interface PaginatedResult<TItem> {
+  items: TItem[];
+  total: number;
+}
+
+/**
+ * Parameters for the paginated query hook.
+ */
+export interface UsePaginatedQueryParams<
+  TFilters extends Record<string, unknown>,
+  TItem = unknown,
+> {
+  /** Current page (1-based). */
+  page: number;
+  /** Items per page. */
+  limit: number;
+  /** Filter values — only keys with defined values should be included. */
+  filters: TFilters;
+  /** First segment of the query key, e.g. `'products'`. The hook appends `'list'` and the filters. */
+  queryKeyBase: string;
+  /**
+   * The actual data-fetching function.
+   * Receives skip, limit, stable filters, and the TanStack Query AbortSignal.
+   */
+  queryFn: (params: {
+    skip: number;
+    limit: number;
+    filters: TFilters;
+    signal: AbortSignal;
+  }) => Promise<PaginatedResult<TItem>>;
+  /** Stale time override. Defaults to `ENV.STALE_TIME_STANDARD` (5 min). */
+  staleTime?: number;
+  /** Whether to keep the previous page's data visible while the next page loads. */
+  placeholderData?: boolean;
+}
+
+/**
+ * Generic paginated query hook.
+ *
+ * Encapsulates skip calculation, stable query-key construction, and the
+ * TanStack Query wiring so every paginated feature doesn't reinvent it.
+ *
+ * The query key includes page and limit alongside the caller's filters so
+ * that changing pages produces a new cache entry and triggers a refetch.
+ * Mutation invalidation against `['prefix', 'list', {}]` still works because
+ * the partial-match behavior in TanStack Query matches against the prefix +
+ * `'list'` segments regardless of the extra keys inside the object.
+ *
+ * @example
+ * const { data, isLoading, isFetching } = usePaginatedQuery({
+ *   page: 1,
+ *   limit: 20,
+ *   filters: { search: 'foo' },
+ *   queryKeyBase: 'products',
+ *   queryFn: ({ skip, limit, filters, signal }) => productsService.list({ skip, limit, ...filters, signal }),
+ * });
+ */
+export function usePaginatedQuery<TFilters extends Record<string, unknown>, TItem = unknown>(
+  params: UsePaginatedQueryParams<TFilters, TItem>,
+): UseQueryResult<PaginatedResult<TItem>> {
+  const skip = (params.page - 1) * params.limit;
+  const staleTime = params.staleTime ?? ENV.STALE_TIME_STANDARD;
+
+  return useQuery<PaginatedResult<TItem>>({
+    queryKey: [
+      params.queryKeyBase,
+      'list',
+      { ...params.filters, page: params.page, limit: params.limit },
+    ] as const,
+    queryFn: async ({ signal }) => {
+      return params.queryFn({
+        skip,
+        limit: params.limit,
+        filters: params.filters,
+        signal,
+      });
+    },
+    staleTime,
+    placeholderData: params.placeholderData ? (prev) => prev : undefined,
+  });
+}


### PR DESCRIPTION
## Summary

Fixes two bugs in the admin-web products table:
1. **Pagination broken**: clicking "Next" didn't trigger a refetch — the TanStack Query key omitted `page`/`limit`, so all pages shared one cache entry
2. **Double requests on refresh**: four `useEffect`+`setTimeout` debounce blocks each fired on mount, doubled in React StrictMode

## Changes

### New shared hooks
- `useDebouncedFilter` — generic debounce hook (instant `value` + `debouncedValue` after 300ms), replaces the dual-state + useEffect pattern
- `usePaginatedQuery` — generic paginated query hook with stable query key construction (page/limit merged into key), skip calculation, placeholderData opt-in

### Refactored hooks
- `useGetProducts`, `useGetAccounts`, `useGetUsers` — all three now delegate to `usePaginatedQuery`, eliminating ~30 lines of duplicated wiring each

### Refactored component
- `products-table.tsx` — replaced 8 state variables (`searchInput`+`search`, etc.) and 4 debounce `useEffect` blocks with 4 `useDebouncedFilter()` calls + centralized `handleFilterChange` that resets page on any filter change. Zero visual changes — logic-only refactor.

## Verification
- ✅ Typecheck clean
- ✅ Lint clean  
- ✅ 278/278 tests passing (29 suites)
- ✅ Build succeeds
- ✅ Final branch review: Ready to merge, no blocking issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude <noreply@anthropic.com>