### PR TITLE
fix(admin-web): fix signal URL leak and StrictMode double-fetch (#42 follow-up)

### DIFF
--- a/apps/admin-web/src/features/accounts/services/accounts-service.ts
+++ b/apps/admin-web/src/features/accounts/services/accounts-service.ts
@@ -19,7 +19,8 @@ export interface AccountListResponse {
 
 export const accountsService = {
   list(params: { skip: number; limit: number; search?: string; signal?: AbortSignal }) {
-    return apiClient.get<AccountListResponse>('/admin/accounts', { params });
+    const { signal, ...queryParams } = params;
+    return apiClient.get<AccountListResponse>('/admin/accounts', { params: queryParams, signal });
   },
   getById(id: string) {
     return apiClient.get<AccountDTO>(`/admin/accounts/${id}`);

--- a/apps/admin-web/src/features/products/services/products-service.ts
+++ b/apps/admin-web/src/features/products/services/products-service.ts
@@ -50,6 +50,7 @@ export interface ProductListParams {
 
 export const productsService = {
   list(params: ProductListParams) {
-    return apiClient.get<ProductListResponse>('/admin/products', { params });
+    const { signal, ...queryParams } = params;
+    return apiClient.get<ProductListResponse>('/admin/products', { params: queryParams, signal });
   },
 };

--- a/apps/admin-web/src/shared/hooks/usePaginatedQuery.ts
+++ b/apps/admin-web/src/shared/hooks/usePaginatedQuery.ts
@@ -52,6 +52,10 @@ export interface UsePaginatedQueryParams<
  * the partial-match behavior in TanStack Query matches against the prefix +
  * `'list'` segments regardless of the extra keys inside the object.
  *
+ * `refetchOnMount` is set to `false` to prevent React StrictMode from
+ * double-fetching on initial mount in development. Query-key changes
+ * (page, filters) always trigger a new fetch regardless of this setting.
+ *
  * @example
  * const { data, isLoading, isFetching } = usePaginatedQuery({
  *   page: 1,
@@ -82,6 +86,8 @@ export function usePaginatedQuery<TFilters extends Record<string, unknown>, TIte
       });
     },
     staleTime,
+    /** Prevent StrictMode double-mount from refetching; queryKey changes still trigger fetch. */
+    refetchOnMount: false,
     placeholderData: params.placeholderData ? (prev) => prev : undefined,
   });
 }


### PR DESCRIPTION
Follow-up fixes after #42. Playwright investigation revealed:

1. **\`signal\` leaking into API URL as query param** — \`products-service.ts\` and \`accounts-service.ts\` passed the entire params object (including \`signal: AbortSignal\`) to axios as \`{ params }\`, serializing the AbortSignal as \`[object AbortSignal]\` in the URL. Fix: destructure \`signal\` out and pass it as an axios config option.
2. **Double-request on mount** — React 18 StrictMode double-mounts components → TanStack Query v5 \`refetchOnMount: true\` (default) re-fires fetch on remount. Fix: \`refetchOnMount: false\` in \`usePaginatedQuery\` — queryKey changes (page, filters) always trigger a new fetch regardless.

## Changes
- \`products-service.ts\`: destructure \`signal\` from params, pass as axios config
- \`accounts-service.ts\`: same fix
- \`usePaginatedQuery.ts\`: add \`refetchOnMount: false\` + JSDoc

## Verification
- ✅ 278/278 tests
- ✅ Typecheck clean
- ✅ Lint clean
