### PR TITLE
feat(admin-web): phase 7 complementary features (queues, notifications, palette, drawer, 404)

### DIFF
--- a/apps/admin-web/CLAUDE.md
+++ b/apps/admin-web/CLAUDE.md
@@ -140,6 +140,9 @@ Reusable primitives live in `src/shared/ui/`. Do NOT duplicate these inside feat
 | `dropdown-menu.tsx`            | Row action menus and context menus                                     |
 | `tabs.tsx`                     | Tab navigation panels                                                  |
 | `skeletons/chart-skeleton.tsx` | Shape-matched skeleton for chart loading states                        |
+| `drawer.tsx`                   | Global right drawer — slide-in detail panel (used by accounts, users, queues) |
+| `command-palette/`             | ⌘K palette (`CommandPaletteProvider` + `CommandPalette`), items from `shared/config/nav-items.ts` |
+| `notifications/` (in `shared/`) | Notification Center core: `NotificationProvider`, `useNotifications`, `publishNotification` bus |
 
 All standard shadcn/ui primitives (Button, Input, Select, Checkbox, Popover, etc.) are also available from `src/shared/ui/`. Use `cn()` from `@shared/utils` for conditional class composition.
 

--- a/apps/admin-web/src/App.tsx
+++ b/apps/admin-web/src/App.tsx
@@ -12,6 +12,7 @@ import { ScrapersPage } from '@pages/scrapers-page';
 import { SettingsPage } from '@pages/settings-page';
 import { UsersPage } from '@pages/users-page';
 import { configureAuthHandlers } from '@shared/api/client';
+import { createAppQueryClient } from '@shared/api/query-client';
 import { AuthProvider } from '@shared/auth/auth-provider';
 import { AuthService } from '@shared/auth/auth-service';
 import { InMemoryStorage } from '@shared/auth/in-memory-storage';
@@ -21,7 +22,7 @@ import { ROUTES } from '@shared/config/routes';
 import { NotificationProvider } from '@shared/notifications';
 import { Permission, RequirePermission } from '@shared/permissions';
 import { AppLayout } from '@shared/ui/layout/app-layout';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClientProvider } from '@tanstack/react-query';
 import { Toaster } from 'sonner';
 
 const DASHBOARD_PERMISSIONS: Permission[] = [Permission.VIEW_DASHBOARD];
@@ -44,14 +45,7 @@ const TOAST_OPTIONS = {
   },
 };
 
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      staleTime: 30_000,
-      retry: 1,
-    },
-  },
-});
+const queryClient = createAppQueryClient();
 
 const storage = new InMemoryStorage();
 const authService = new AuthService(storage);

--- a/apps/admin-web/src/App.tsx
+++ b/apps/admin-web/src/App.tsx
@@ -18,6 +18,7 @@ import { AuthService } from '@shared/auth/auth-service';
 import { InMemoryStorage } from '@shared/auth/in-memory-storage';
 import { ProtectedRoute } from '@shared/auth/protected-route';
 import { SessionManager } from '@shared/auth/session-manager';
+import { CommandPaletteProvider } from '@shared/command-palette';
 import { ROUTES } from '@shared/config/routes';
 import { NotificationProvider } from '@shared/notifications';
 import { Permission, RequirePermission } from '@shared/permissions';
@@ -69,128 +70,130 @@ export function App(): JSX.Element {
     <QueryClientProvider client={queryClient}>
       <AuthProvider authService={authService} sessionManager={sessionManager} storage={storage}>
         <NotificationProvider>
-          <Routes>
-            {/* Public */}
-            <Route path={ROUTES.LOGIN} element={<LoginPage />} />
+          <CommandPaletteProvider>
+            <Routes>
+              {/* Public */}
+              <Route path={ROUTES.LOGIN} element={<LoginPage />} />
 
-            {/* Protected */}
-            <Route
-              path="/"
-              element={
-                <ProtectedRoute>
-                  <AppLayout />
-                </ProtectedRoute>
-              }
-            >
-              <Route index element={<Navigate to={ROUTES.DASHBOARD} replace />} />
+              {/* Protected */}
               <Route
-                path={ROUTES.DASHBOARD}
+                path="/"
                 element={
-                  <RequirePermission permissions={DASHBOARD_PERMISSIONS}>
-                    <DashboardPage />
-                  </RequirePermission>
+                  <ProtectedRoute>
+                    <AppLayout />
+                  </ProtectedRoute>
                 }
-              />
-              <Route
-                path={ROUTES.ACCOUNTS}
-                element={
-                  <RequirePermission permissions={ACCOUNTS_PERMISSIONS}>
-                    <AccountsPage />
-                  </RequirePermission>
-                }
-              />
-              <Route
-                path={ROUTES.USERS}
-                element={
-                  <RequirePermission permissions={USERS_PERMISSIONS}>
-                    <UsersPage />
-                  </RequirePermission>
-                }
-              />
-              <Route
-                path={ROUTES.ROLES}
-                element={
-                  <RequirePermission permissions={ROLES_PERMISSIONS}>
-                    <RolesPage />
-                  </RequirePermission>
-                }
-              />
-              <Route
-                path={ROUTES.PRODUCTS}
-                element={
-                  <RequirePermission permissions={PRODUCTS_PERMISSIONS}>
-                    <ProductsPage />
-                  </RequirePermission>
-                }
-              />
-              <Route
-                path={ROUTES.PRODUCTS_STATS}
-                element={
-                  <RequirePermission permissions={PRODUCTS_PERMISSIONS}>
-                    <ProductsStatsPage />
-                  </RequirePermission>
-                }
-              />
-              <Route
-                path={ROUTES.PRODUCT_DETAIL}
-                element={
-                  <RequirePermission permissions={PRODUCTS_PERMISSIONS}>
-                    <ProductDetailPage />
-                  </RequirePermission>
-                }
-              />
-              <Route
-                path={ROUTES.SCRAPERS}
-                element={
-                  <RequirePermission permissions={SCRAPERS_PERMISSIONS}>
-                    <ScrapersPage />
-                  </RequirePermission>
-                }
-              />
-              <Route
-                path={ROUTES.RULES}
-                element={
-                  <RequirePermission permissions={RULES_PERMISSIONS}>
-                    <RulesPage />
-                  </RequirePermission>
-                }
-              />
-              <Route
-                path={ROUTES.QUEUES}
-                element={
-                  <RequirePermission permissions={QUEUES_PERMISSIONS}>
-                    <QueuesPage />
-                  </RequirePermission>
-                }
-              />
-              <Route
-                path={ROUTES.SETTINGS}
-                element={
-                  <RequirePermission permissions={SETTINGS_PERMISSIONS}>
-                    <SettingsPage />
-                  </RequirePermission>
-                }
-              />
-            </Route>
+              >
+                <Route index element={<Navigate to={ROUTES.DASHBOARD} replace />} />
+                <Route
+                  path={ROUTES.DASHBOARD}
+                  element={
+                    <RequirePermission permissions={DASHBOARD_PERMISSIONS}>
+                      <DashboardPage />
+                    </RequirePermission>
+                  }
+                />
+                <Route
+                  path={ROUTES.ACCOUNTS}
+                  element={
+                    <RequirePermission permissions={ACCOUNTS_PERMISSIONS}>
+                      <AccountsPage />
+                    </RequirePermission>
+                  }
+                />
+                <Route
+                  path={ROUTES.USERS}
+                  element={
+                    <RequirePermission permissions={USERS_PERMISSIONS}>
+                      <UsersPage />
+                    </RequirePermission>
+                  }
+                />
+                <Route
+                  path={ROUTES.ROLES}
+                  element={
+                    <RequirePermission permissions={ROLES_PERMISSIONS}>
+                      <RolesPage />
+                    </RequirePermission>
+                  }
+                />
+                <Route
+                  path={ROUTES.PRODUCTS}
+                  element={
+                    <RequirePermission permissions={PRODUCTS_PERMISSIONS}>
+                      <ProductsPage />
+                    </RequirePermission>
+                  }
+                />
+                <Route
+                  path={ROUTES.PRODUCTS_STATS}
+                  element={
+                    <RequirePermission permissions={PRODUCTS_PERMISSIONS}>
+                      <ProductsStatsPage />
+                    </RequirePermission>
+                  }
+                />
+                <Route
+                  path={ROUTES.PRODUCT_DETAIL}
+                  element={
+                    <RequirePermission permissions={PRODUCTS_PERMISSIONS}>
+                      <ProductDetailPage />
+                    </RequirePermission>
+                  }
+                />
+                <Route
+                  path={ROUTES.SCRAPERS}
+                  element={
+                    <RequirePermission permissions={SCRAPERS_PERMISSIONS}>
+                      <ScrapersPage />
+                    </RequirePermission>
+                  }
+                />
+                <Route
+                  path={ROUTES.RULES}
+                  element={
+                    <RequirePermission permissions={RULES_PERMISSIONS}>
+                      <RulesPage />
+                    </RequirePermission>
+                  }
+                />
+                <Route
+                  path={ROUTES.QUEUES}
+                  element={
+                    <RequirePermission permissions={QUEUES_PERMISSIONS}>
+                      <QueuesPage />
+                    </RequirePermission>
+                  }
+                />
+                <Route
+                  path={ROUTES.SETTINGS}
+                  element={
+                    <RequirePermission permissions={SETTINGS_PERMISSIONS}>
+                      <SettingsPage />
+                    </RequirePermission>
+                  }
+                />
+              </Route>
 
-            {/* Catch-all */}
-            <Route
-              path="*"
-              element={
-                <div className="flex min-h-screen items-center justify-center bg-surface">
-                  <div className="text-center">
-                    <h1 className="text-headline-lg font-semibold text-on-surface">
-                      404 — Not Found
-                    </h1>
-                    <p className="mt-sm text-body-md text-on-surface-variant">
-                      This page does not exist.
-                    </p>
+              {/* Catch-all */}
+              <Route
+                path="*"
+                element={
+                  <div className="flex min-h-screen items-center justify-center bg-surface">
+                    <div className="text-center">
+                      <h1 className="text-headline-lg font-semibold text-on-surface">
+                        404 — Not Found
+                      </h1>
+                      <p className="mt-sm text-body-md text-on-surface-variant">
+                        This page does not exist.
+                      </p>
+                    </div>
                   </div>
-                </div>
-              }
-            />
-          </Routes>
-          <Toaster position="bottom-right" toastOptions={TOAST_OPTIONS} />
+                }
+              />
+            </Routes>
+            <Toaster position="bottom-right" toastOptions={TOAST_OPTIONS} />
+          </CommandPaletteProvider>
         </NotificationProvider>
       </AuthProvider>
     </QueryClientProvider>

--- a/apps/admin-web/src/App.tsx
+++ b/apps/admin-web/src/App.tsx
@@ -2,6 +2,7 @@ import { Navigate, Route, Routes } from 'react-router-dom';
 import { AccountsPage } from '@pages/accounts-page';
 import { DashboardPage } from '@pages/dashboard-page';
 import { LoginPage } from '@pages/login-page';
+import { NotFoundPage } from '@pages/not-found-page';
 import { ProductDetailPage } from '@pages/product-detail-page';
 import { ProductsPage } from '@pages/products-page';
 import { ProductsStatsPage } from '@pages/products-stats-page';
@@ -176,21 +177,7 @@ export function App(): JSX.Element {
               </Route>
 
               {/* Catch-all */}
-              <Route
-                path="*"
-                element={
-                  <div className="flex min-h-screen items-center justify-center bg-surface">
-                    <div className="text-center">
-                      <h1 className="text-headline-lg font-semibold text-on-surface">
-                        404 — Not Found
-                      </h1>
-                      <p className="mt-sm text-body-md text-on-surface-variant">
-                        This page does not exist.
-                      </p>
-                    </div>
-                  </div>
-                }
-              />
+              <Route path="*" element={<NotFoundPage />} />
             </Routes>
             <Toaster position="bottom-right" toastOptions={TOAST_OPTIONS} />
           </CommandPaletteProvider>

--- a/apps/admin-web/src/App.tsx
+++ b/apps/admin-web/src/App.tsx
@@ -18,6 +18,7 @@ import { InMemoryStorage } from '@shared/auth/in-memory-storage';
 import { ProtectedRoute } from '@shared/auth/protected-route';
 import { SessionManager } from '@shared/auth/session-manager';
 import { ROUTES } from '@shared/config/routes';
+import { NotificationProvider } from '@shared/notifications';
 import { Permission, RequirePermission } from '@shared/permissions';
 import { AppLayout } from '@shared/ui/layout/app-layout';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -73,128 +74,130 @@ export function App(): JSX.Element {
   return (
     <QueryClientProvider client={queryClient}>
       <AuthProvider authService={authService} sessionManager={sessionManager} storage={storage}>
-        <Routes>
-          {/* Public */}
-          <Route path={ROUTES.LOGIN} element={<LoginPage />} />
+        <NotificationProvider>
+          <Routes>
+            {/* Public */}
+            <Route path={ROUTES.LOGIN} element={<LoginPage />} />
 
-          {/* Protected */}
-          <Route
-            path="/"
-            element={
-              <ProtectedRoute>
-                <AppLayout />
-              </ProtectedRoute>
-            }
-          >
-            <Route index element={<Navigate to={ROUTES.DASHBOARD} replace />} />
+            {/* Protected */}
             <Route
-              path={ROUTES.DASHBOARD}
+              path="/"
               element={
-                <RequirePermission permissions={DASHBOARD_PERMISSIONS}>
-                  <DashboardPage />
-                </RequirePermission>
+                <ProtectedRoute>
+                  <AppLayout />
+                </ProtectedRoute>
               }
-            />
-            <Route
-              path={ROUTES.ACCOUNTS}
-              element={
-                <RequirePermission permissions={ACCOUNTS_PERMISSIONS}>
-                  <AccountsPage />
-                </RequirePermission>
-              }
-            />
-            <Route
-              path={ROUTES.USERS}
-              element={
-                <RequirePermission permissions={USERS_PERMISSIONS}>
-                  <UsersPage />
-                </RequirePermission>
-              }
-            />
-            <Route
-              path={ROUTES.ROLES}
-              element={
-                <RequirePermission permissions={ROLES_PERMISSIONS}>
-                  <RolesPage />
-                </RequirePermission>
-              }
-            />
-            <Route
-              path={ROUTES.PRODUCTS}
-              element={
-                <RequirePermission permissions={PRODUCTS_PERMISSIONS}>
-                  <ProductsPage />
-                </RequirePermission>
-              }
-            />
-            <Route
-              path={ROUTES.PRODUCTS_STATS}
-              element={
-                <RequirePermission permissions={PRODUCTS_PERMISSIONS}>
-                  <ProductsStatsPage />
-                </RequirePermission>
-              }
-            />
-            <Route
-              path={ROUTES.PRODUCT_DETAIL}
-              element={
-                <RequirePermission permissions={PRODUCTS_PERMISSIONS}>
-                  <ProductDetailPage />
-                </RequirePermission>
-              }
-            />
-            <Route
-              path={ROUTES.SCRAPERS}
-              element={
-                <RequirePermission permissions={SCRAPERS_PERMISSIONS}>
-                  <ScrapersPage />
-                </RequirePermission>
-              }
-            />
-            <Route
-              path={ROUTES.RULES}
-              element={
-                <RequirePermission permissions={RULES_PERMISSIONS}>
-                  <RulesPage />
-                </RequirePermission>
-              }
-            />
-            <Route
-              path={ROUTES.QUEUES}
-              element={
-                <RequirePermission permissions={QUEUES_PERMISSIONS}>
-                  <QueuesPage />
-                </RequirePermission>
-              }
-            />
-            <Route
-              path={ROUTES.SETTINGS}
-              element={
-                <RequirePermission permissions={SETTINGS_PERMISSIONS}>
-                  <SettingsPage />
-                </RequirePermission>
-              }
-            />
-          </Route>
+            >
+              <Route index element={<Navigate to={ROUTES.DASHBOARD} replace />} />
+              <Route
+                path={ROUTES.DASHBOARD}
+                element={
+                  <RequirePermission permissions={DASHBOARD_PERMISSIONS}>
+                    <DashboardPage />
+                  </RequirePermission>
+                }
+              />
+              <Route
+                path={ROUTES.ACCOUNTS}
+                element={
+                  <RequirePermission permissions={ACCOUNTS_PERMISSIONS}>
+                    <AccountsPage />
+                  </RequirePermission>
+                }
+              />
+              <Route
+                path={ROUTES.USERS}
+                element={
+                  <RequirePermission permissions={USERS_PERMISSIONS}>
+                    <UsersPage />
+                  </RequirePermission>
+                }
+              />
+              <Route
+                path={ROUTES.ROLES}
+                element={
+                  <RequirePermission permissions={ROLES_PERMISSIONS}>
+                    <RolesPage />
+                  </RequirePermission>
+                }
+              />
+              <Route
+                path={ROUTES.PRODUCTS}
+                element={
+                  <RequirePermission permissions={PRODUCTS_PERMISSIONS}>
+                    <ProductsPage />
+                  </RequirePermission>
+                }
+              />
+              <Route
+                path={ROUTES.PRODUCTS_STATS}
+                element={
+                  <RequirePermission permissions={PRODUCTS_PERMISSIONS}>
+                    <ProductsStatsPage />
+                  </RequirePermission>
+                }
+              />
+              <Route
+                path={ROUTES.PRODUCT_DETAIL}
+                element={
+                  <RequirePermission permissions={PRODUCTS_PERMISSIONS}>
+                    <ProductDetailPage />
+                  </RequirePermission>
+                }
+              />
+              <Route
+                path={ROUTES.SCRAPERS}
+                element={
+                  <RequirePermission permissions={SCRAPERS_PERMISSIONS}>
+                    <ScrapersPage />
+                  </RequirePermission>
+                }
+              />
+              <Route
+                path={ROUTES.RULES}
+                element={
+                  <RequirePermission permissions={RULES_PERMISSIONS}>
+                    <RulesPage />
+                  </RequirePermission>
+                }
+              />
+              <Route
+                path={ROUTES.QUEUES}
+                element={
+                  <RequirePermission permissions={QUEUES_PERMISSIONS}>
+                    <QueuesPage />
+                  </RequirePermission>
+                }
+              />
+              <Route
+                path={ROUTES.SETTINGS}
+                element={
+                  <RequirePermission permissions={SETTINGS_PERMISSIONS}>
+                    <SettingsPage />
+                  </RequirePermission>
+                }
+              />
+            </Route>
 
-          {/* Catch-all */}
-          <Route
-            path="*"
-            element={
-              <div className="flex min-h-screen items-center justify-center bg-surface">
-                <div className="text-center">
-                  <h1 className="text-headline-lg font-semibold text-on-surface">
-                    404 — Not Found
-                  </h1>
-                  <p className="mt-sm text-body-md text-on-surface-variant">
-                    This page does not exist.
-                  </p>
+            {/* Catch-all */}
+            <Route
+              path="*"
+              element={
+                <div className="flex min-h-screen items-center justify-center bg-surface">
+                  <div className="text-center">
+                    <h1 className="text-headline-lg font-semibold text-on-surface">
+                      404 — Not Found
+                    </h1>
+                    <p className="mt-sm text-body-md text-on-surface-variant">
+                      This page does not exist.
+                    </p>
+                  </div>
                 </div>
-              </div>
-            }
-          />
-        </Routes>
-        <Toaster position="bottom-right" toastOptions={TOAST_OPTIONS} />
+              }
+            />
+          </Routes>
+          <Toaster position="bottom-right" toastOptions={TOAST_OPTIONS} />
+        </NotificationProvider>
       </AuthProvider>
     </QueryClientProvider>
   );

--- a/apps/admin-web/src/__tests__/App.test.tsx
+++ b/apps/admin-web/src/__tests__/App.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { ROUTES } from '@shared/config/routes';
+import en from '@shared/i18n/locales/en.json';
 import { App } from '../App';
 
 // Initialize i18n before tests
@@ -25,5 +26,16 @@ describe('App', () => {
     );
     // Should redirect to login since no auth session
     expect(screen.getByText('BazaarSentinel')).toBeInTheDocument();
+  });
+
+  it('renders the design-system NotFound page on unknown routes', async () => {
+    render(
+      <MemoryRouter initialEntries={['/definitely-not-a-route']}>
+        <App />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText(en.common.notFound)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: en.common.goToDashboard })).toBeInTheDocument();
   });
 });

--- a/apps/admin-web/src/features/accounts/components/account-detail-drawer.tsx
+++ b/apps/admin-web/src/features/accounts/components/account-detail-drawer.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { X } from 'lucide-react';
+import { Drawer } from '@shared/ui/drawer';
 
 import { useGetAccount } from '../hooks/useGetAccount';
 
@@ -11,77 +11,67 @@ interface Props {
 export function AccountDetailDrawer({ accountId, onClose }: Props): JSX.Element {
   const { t } = useTranslation();
   const { data, isLoading, isError } = useGetAccount(accountId);
-  const isOpen = accountId !== null;
 
   return (
-    <>
-      {/* Backdrop */}
-      {isOpen && <div className="fixed inset-0 z-40 bg-black/30" role="presentation" onClick={onClose} onKeyDown={onClose} />}
-
-      {/* Drawer */}
-      <div
-        className={`fixed right-0 top-0 z-50 h-full w-96 transform border-l border-outline-variant bg-surface-container-high p-lg shadow-lg transition-transform duration-200 ${
-          isOpen ? 'translate-x-0' : 'translate-x-full'
-        }`}
-      >
-        <div className="mb-lg flex items-center justify-between">
-          <h2 className="text-lg font-semibold text-on-surface">{t('accounts.drawer.title')}</h2>
-          <button
-            onClick={onClose}
-            className="rounded-sm p-xs text-on-surface-variant hover:bg-surface-container-highest"
-            aria-label={t('accounts.drawer.close')}
-          >
-            <X size={18} />
-          </button>
+    <Drawer open={accountId !== null} title={t('accounts.drawer.title')} onClose={onClose}>
+      {isLoading && (
+        <div className="space-y-sm">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <div key={i} className="h-6 animate-pulse rounded-sm bg-surface-container-highest" />
+          ))}
         </div>
+      )}
 
-        {isLoading && (
-          <div className="space-y-sm">
-            {Array.from({ length: 5 }).map((_, i) => (
-              <div key={i} className="h-6 animate-pulse rounded-sm bg-surface-container-highest" />
-            ))}
+      {isError && (
+        <div className="rounded-md border border-danger bg-danger-muted p-md text-sm text-danger">
+          {t('accounts.drawer.error')}
+        </div>
+      )}
+
+      {data && (
+        <dl className="space-y-md">
+          <div>
+            <dt className="text-label-xs font-mono text-on-surface-variant">
+              {t('accounts.drawer.name')}
+            </dt>
+            <dd className="mt-xs text-body-md text-on-surface">{data.name}</dd>
           </div>
-        )}
-
-        {isError && (
-          <div className="rounded-md border border-danger bg-danger-muted p-md text-sm text-danger">
-            {t('accounts.drawer.error')}
+          <div>
+            <dt className="text-label-xs font-mono text-on-surface-variant">
+              {t('accounts.drawer.accountId')}
+            </dt>
+            <dd className="mt-xs font-mono text-body-sm text-on-surface-variant">{data.id}</dd>
           </div>
-        )}
-
-        {data && (
-          <dl className="space-y-md">
+          <div className="grid grid-cols-2 gap-md">
             <div>
-              <dt className="text-label-xs font-mono text-on-surface-variant">{t('accounts.drawer.name')}</dt>
-              <dd className="mt-xs text-body-md text-on-surface">{data.name}</dd>
+              <dt className="text-label-xs font-mono text-on-surface-variant">
+                {t('accounts.drawer.users')}
+              </dt>
+              <dd className="mt-xs text-body-md text-on-surface">{data.userCount}</dd>
             </div>
             <div>
-              <dt className="text-label-xs font-mono text-on-surface-variant">{t('accounts.drawer.accountId')}</dt>
-              <dd className="mt-xs font-mono text-body-sm text-on-surface-variant">{data.id}</dd>
+              <dt className="text-label-xs font-mono text-on-surface-variant">
+                {t('accounts.drawer.subscriptions')}
+              </dt>
+              <dd className="mt-xs text-body-md text-on-surface">{data.subscriptionCount}</dd>
             </div>
-            <div className="grid grid-cols-2 gap-md">
-              <div>
-                <dt className="text-label-xs font-mono text-on-surface-variant">{t('accounts.drawer.users')}</dt>
-                <dd className="mt-xs text-body-md text-on-surface">{data.userCount}</dd>
-              </div>
-              <div>
-                <dt className="text-label-xs font-mono text-on-surface-variant">{t('accounts.drawer.subscriptions')}</dt>
-                <dd className="mt-xs text-body-md text-on-surface">{data.subscriptionCount}</dd>
-              </div>
-              <div>
-                <dt className="text-label-xs font-mono text-on-surface-variant">{t('accounts.drawer.alarms')}</dt>
-                <dd className="mt-xs text-body-md text-on-surface">{data.alarmCount}</dd>
-              </div>
-              <div>
-                <dt className="text-label-xs font-mono text-on-surface-variant">{t('accounts.drawer.created')}</dt>
-                <dd className="mt-xs text-body-md text-on-surface">
-                  {data.createdAt.toLocaleDateString()}
-                </dd>
-              </div>
+            <div>
+              <dt className="text-label-xs font-mono text-on-surface-variant">
+                {t('accounts.drawer.alarms')}
+              </dt>
+              <dd className="mt-xs text-body-md text-on-surface">{data.alarmCount}</dd>
             </div>
-          </dl>
-        )}
-      </div>
-    </>
+            <div>
+              <dt className="text-label-xs font-mono text-on-surface-variant">
+                {t('accounts.drawer.created')}
+              </dt>
+              <dd className="mt-xs text-body-md text-on-surface">
+                {data.createdAt.toLocaleDateString()}
+              </dd>
+            </div>
+          </div>
+        </dl>
+      )}
+    </Drawer>
   );
 }

--- a/apps/admin-web/src/features/notifications/__tests__/notification-bell.test.tsx
+++ b/apps/admin-web/src/features/notifications/__tests__/notification-bell.test.tsx
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { NotificationProvider, publishNotification } from '@shared/notifications';
+
+import { NotificationBell } from '../components/notification-bell';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, defaultVal?: string | Record<string, unknown>): string => {
+      if (typeof defaultVal === 'string') return defaultVal;
+      return key;
+    },
+  }),
+}));
+
+function renderBell(): void {
+  render(
+    <MemoryRouter>
+      <NotificationProvider>
+        <NotificationBell />
+      </NotificationProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe('NotificationBell', () => {
+  it('shows no badge initially and an empty panel on open', () => {
+    renderBell();
+    const trigger = screen.getByRole('button', { name: 'Open notifications' });
+    expect(trigger.textContent).toBe('');
+
+    fireEvent.click(trigger);
+    expect(screen.getByText('No notifications')).toBeInTheDocument();
+  });
+
+  it('shows the unread badge and lists published notifications', () => {
+    renderBell();
+
+    act(() => {
+      publishNotification({ title: 'Redis is down', severity: 'error' });
+      publishNotification({ title: 'Jobs failed', severity: 'warning' });
+    });
+
+    expect(screen.getByText('2')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open notifications' }));
+    expect(screen.getByText('Redis is down')).toBeInTheDocument();
+    expect(screen.getByText('Jobs failed')).toBeInTheDocument();
+  });
+
+  it('caps the visible badge at 9+', () => {
+    renderBell();
+    act(() => {
+      for (let i = 0; i < 12; i++) {
+        publishNotification({ title: 'n' + String(i) });
+      }
+    });
+    expect(screen.getByText('9+')).toBeInTheDocument();
+  });
+
+  it('mark all as read clears the badge but keeps the list', () => {
+    renderBell();
+    act(() => {
+      publishNotification({ title: 'One' });
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open notifications' }));
+    fireEvent.click(screen.getByText('Mark all as read'));
+
+    expect(screen.queryByText('1')).not.toBeInTheDocument();
+    expect(screen.getByText('One')).toBeInTheDocument();
+  });
+});

--- a/apps/admin-web/src/features/notifications/__tests__/system-alerts-watcher.test.tsx
+++ b/apps/admin-web/src/features/notifications/__tests__/system-alerts-watcher.test.tsx
@@ -1,0 +1,123 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { NotificationProvider, useNotifications } from '@shared/notifications';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+
+import { SystemAlertsWatcher } from '../components/system-alerts-watcher';
+
+const API_BASE = 'http://localhost:3000/api';
+
+const server = setupServer();
+
+beforeAll(() => {
+  server.listen({ onUnhandledRequest: 'error' });
+});
+
+afterEach(() => {
+  server.resetHandlers();
+});
+
+afterAll(() => {
+  server.close();
+});
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, defaultVal?: string | Record<string, unknown>): string => {
+      if (typeof defaultVal === 'string') return defaultVal;
+      return key;
+    },
+  }),
+}));
+
+function Probe(): JSX.Element {
+  const { notifications } = useNotifications();
+  return <div data-testid="probe">{notifications.map((n) => n.title).join('|')}</div>;
+}
+
+function setup(): QueryClient {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <NotificationProvider>
+          <SystemAlertsWatcher />
+          <Probe />
+        </NotificationProvider>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+  return queryClient;
+}
+
+describe('SystemAlertsWatcher', () => {
+  it('notifies when a health service transitions connected → error', async () => {
+    let healthCalls = 0;
+    server.use(
+      http.get(`${API_BASE}/admin/dashboard/health`, () => {
+        healthCalls += 1;
+        return HttpResponse.json({
+          services: [{ service: 'redis', status: healthCalls === 1 ? 'connected' : 'error' }],
+          timestamp: new Date().toISOString(),
+        });
+      }),
+      http.get(`${API_BASE}/admin/queues/stats`, () => HttpResponse.json({ queues: [] })),
+    );
+
+    const queryClient = setup();
+
+    // First fetch settles — no notification on initial snapshot
+    await waitFor(() => {
+      expect(healthCalls).toBe(1);
+    });
+    expect(screen.getByTestId('probe').textContent).toBe('');
+
+    // Second fetch flips redis to error
+    await act(async () => {
+      await queryClient.refetchQueries();
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('probe').textContent).toContain('notifications.serviceDown');
+    });
+  });
+
+  it('notifies when a queue accumulates new failed jobs', async () => {
+    let statsCalls = 0;
+    server.use(
+      http.get(`${API_BASE}/admin/dashboard/health`, () =>
+        HttpResponse.json({
+          services: [{ service: 'redis', status: 'connected' }],
+          timestamp: new Date().toISOString(),
+        }),
+      ),
+      http.get(`${API_BASE}/admin/queues/stats`, () => {
+        statsCalls += 1;
+        return HttpResponse.json({
+          queues: [
+            {
+              queueName: 'PRODUCTS_SCRAPING',
+              counts: { failed: statsCalls === 1 ? 0 : 2 },
+            },
+          ],
+        });
+      }),
+    );
+
+    const queryClient = setup();
+
+    await waitFor(() => {
+      expect(statsCalls).toBe(1);
+    });
+    expect(screen.getByTestId('probe').textContent).toBe('');
+
+    await act(async () => {
+      await queryClient.refetchQueries();
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('probe').textContent).toContain('notifications.jobsFailed');
+    });
+  });
+});

--- a/apps/admin-web/src/features/notifications/components/notification-bell.tsx
+++ b/apps/admin-web/src/features/notifications/components/notification-bell.tsx
@@ -1,0 +1,158 @@
+import { useCallback, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+import type { AppNotification, NotificationSeverity } from '@shared/notifications';
+import { useNotifications } from '@shared/notifications';
+import { formatDistanceToNow } from 'date-fns';
+import type { LucideIcon } from 'lucide-react';
+import { AlertTriangle, Bell, CheckCheck, CheckCircle2, Info, XCircle } from 'lucide-react';
+
+const SEVERITY_ICONS: Record<NotificationSeverity, LucideIcon> = {
+  info: Info,
+  success: CheckCircle2,
+  warning: AlertTriangle,
+  error: XCircle,
+};
+
+const SEVERITY_CLASSES: Record<NotificationSeverity, string> = {
+  info: 'text-info',
+  success: 'text-success',
+  warning: 'text-warning',
+  error: 'text-danger',
+};
+
+/** TopBar bell with unread badge and a dropdown Notification Center panel. */
+export function NotificationBell(): JSX.Element {
+  const { t } = useTranslation();
+  const { notifications, unreadCount, markRead, markAllRead } = useNotifications();
+  const navigate = useNavigate();
+  const [open, setOpen] = useState(false);
+
+  const handleToggle = useCallback(() => {
+    setOpen((prev) => !prev);
+  }, []);
+
+  const handleClose = useCallback(() => {
+    setOpen(false);
+  }, []);
+
+  const handleMarkAllRead = useCallback(() => {
+    markAllRead();
+  }, [markAllRead]);
+
+  const handleActivate = useCallback(
+    (notification: AppNotification) => {
+      markRead(notification.id);
+      if (notification.link) {
+        navigate(notification.link);
+        setOpen(false);
+      }
+    },
+    [markRead, navigate],
+  );
+
+  return (
+    <div className="relative">
+      <button
+        onClick={handleToggle}
+        aria-label={t('notifications.open', 'Open notifications')}
+        aria-expanded={open}
+        className="relative rounded-md p-xs text-on-surface-variant transition-colors hover:bg-surface-container-high"
+      >
+        <Bell size={18} aria-hidden="true" />
+        {unreadCount > 0 && (
+          <span className="absolute -right-0.5 -top-0.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-primary px-[3px] text-label-xs font-mono text-on-primary">
+            {unreadCount > 9 ? '9+' : unreadCount}
+          </span>
+        )}
+      </button>
+
+      {open && (
+        <>
+          <div className="fixed inset-0 z-40" role="presentation" onClick={handleClose} />
+          <div
+            role="dialog"
+            aria-label={t('notifications.title', 'Notifications')}
+            className="absolute right-0 top-full z-50 mt-xs w-96 rounded-md border border-outline-variant bg-surface-container-high shadow-lg"
+          >
+            <div className="flex items-center justify-between border-b border-outline-variant p-sm">
+              <h2 className="text-body-sm font-semibold text-on-surface">
+                {t('notifications.title', 'Notifications')}
+              </h2>
+              {unreadCount > 0 && (
+                <button
+                  onClick={handleMarkAllRead}
+                  className="flex items-center gap-xs rounded-sm px-xs py-0.5 text-label-xs text-primary hover:bg-surface-container-highest"
+                >
+                  <CheckCheck size={14} aria-hidden="true" />
+                  {t('notifications.markAllRead', 'Mark all as read')}
+                </button>
+              )}
+            </div>
+            <ul className="max-h-[60vh] overflow-y-auto">
+              {notifications.length === 0 && (
+                <li className="p-md text-center text-body-sm text-on-surface-variant">
+                  {t('notifications.empty', 'No notifications')}
+                </li>
+              )}
+              {notifications.map((notification) => (
+                <NotificationListItem
+                  key={notification.id}
+                  notification={notification}
+                  onActivate={handleActivate}
+                />
+              ))}
+            </ul>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+interface NotificationListItemProps {
+  notification: AppNotification;
+  onActivate: (notification: AppNotification) => void;
+}
+
+function NotificationListItem({
+  notification,
+  onActivate,
+}: NotificationListItemProps): JSX.Element {
+  const handleClick = useCallback(() => {
+    onActivate(notification);
+  }, [onActivate, notification]);
+
+  const Icon = SEVERITY_ICONS[notification.severity];
+
+  return (
+    <li className="border-t border-outline-variant first:border-t-0">
+      <button
+        onClick={handleClick}
+        className={`flex w-full items-start gap-sm p-sm text-left transition-colors hover:bg-surface-container-highest ${
+          notification.read ? 'opacity-60' : ''
+        }`}
+      >
+        <Icon
+          size={16}
+          className={`mt-0.5 shrink-0 ${SEVERITY_CLASSES[notification.severity]}`}
+          aria-hidden="true"
+        />
+        <span className="flex-1">
+          <span className="block text-body-sm text-on-surface">{notification.title}</span>
+          {notification.description && (
+            <span className="mt-xs block text-body-sm text-on-surface-variant">
+              {notification.description}
+            </span>
+          )}
+          <span className="mt-xs block text-label-xs font-mono text-on-surface-variant">
+            {formatDistanceToNow(notification.createdAt, { addSuffix: true })}
+          </span>
+        </span>
+        {!notification.read && (
+          <span className="mt-1 h-2 w-2 shrink-0 rounded-full bg-primary" aria-hidden="true" />
+        )}
+      </button>
+    </li>
+  );
+}

--- a/apps/admin-web/src/features/notifications/components/system-alerts-watcher.tsx
+++ b/apps/admin-web/src/features/notifications/components/system-alerts-watcher.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useHealthStatus } from '@features/dashboard';
+import { useGetQueues } from '@features/queues';
+import { ROUTES } from '@shared/config/routes';
+import { useNotifications } from '@shared/notifications';
+
+/**
+ * Invisible watcher mounted in the authenticated layout. Reuses the health
+ * and queue-stats queries (30s refetch) and raises notifications on
+ * transitions: service connected→error / error→connected, and failed-job
+ * count increases. The first snapshot never notifies.
+ */
+export function SystemAlertsWatcher(): null {
+  const { t } = useTranslation();
+  const { notify } = useNotifications();
+  const { data: health } = useHealthStatus();
+  const { data: queues } = useGetQueues();
+
+  const prevHealthRef = useRef<Record<string, string> | null>(null);
+  const prevFailedRef = useRef<Record<string, number> | null>(null);
+
+  useEffect(() => {
+    if (!health) return;
+    const current: Record<string, string> = {};
+    for (const s of health.services) {
+      current[s.service] = s.status;
+    }
+    const prev = prevHealthRef.current;
+    if (prev) {
+      for (const [service, status] of Object.entries(current)) {
+        if (!(service in prev)) continue;
+        const before = prev[service];
+        if (before === status) continue;
+        if (status === 'error') {
+          notify({ title: t('notifications.serviceDown', { service }), severity: 'error' });
+        } else if (status === 'connected') {
+          notify({ title: t('notifications.serviceRecovered', { service }), severity: 'success' });
+        }
+      }
+    }
+    prevHealthRef.current = current;
+  }, [health, notify, t]);
+
+  useEffect(() => {
+    if (!queues) return;
+    const current: Record<string, number> = {};
+    for (const queue of queues) {
+      current[queue.name] = queue.failedCount;
+    }
+    const prev = prevFailedRef.current;
+    if (prev) {
+      for (const [name, failed] of Object.entries(current)) {
+        const before = prev[name] ?? 0;
+        if (failed > before) {
+          notify({
+            title: t('notifications.jobsFailed', { count: failed - before, queue: name }),
+            severity: 'warning',
+            link: ROUTES.QUEUES,
+          });
+        }
+      }
+    }
+    prevFailedRef.current = current;
+  }, [queues, notify, t]);
+
+  return null;
+}

--- a/apps/admin-web/src/features/notifications/index.ts
+++ b/apps/admin-web/src/features/notifications/index.ts
@@ -1,0 +1,1 @@
+export { NotificationBell } from './components/notification-bell';

--- a/apps/admin-web/src/features/notifications/index.ts
+++ b/apps/admin-web/src/features/notifications/index.ts
@@ -1,1 +1,2 @@
 export { NotificationBell } from './components/notification-bell';
+export { SystemAlertsWatcher } from './components/system-alerts-watcher';

--- a/apps/admin-web/src/features/queues/__tests__/queue-jobs-table.test.tsx
+++ b/apps/admin-web/src/features/queues/__tests__/queue-jobs-table.test.tsx
@@ -1,0 +1,132 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+
+import { QueueJobsTable } from '../components/queue-jobs-table';
+
+const API_BASE = 'http://localhost:3000/api';
+
+const server = setupServer();
+
+beforeAll(() => {
+  server.listen({ onUnhandledRequest: 'error' });
+});
+
+afterEach(() => {
+  server.resetHandlers();
+});
+
+afterAll(() => {
+  server.close();
+});
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, defaultVal?: string | Record<string, unknown>): string => {
+      if (typeof defaultVal === 'string') return defaultVal;
+      return key;
+    },
+  }),
+}));
+
+function createTestQueryClient(): QueryClient {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+
+function renderTable(queueName: string | null, onSelectJob = vi.fn()) {
+  render(
+    <QueryClientProvider client={createTestQueryClient()}>
+      <QueueJobsTable queueName={queueName} onSelectJob={onSelectJob} />
+    </QueryClientProvider>,
+  );
+  return onSelectJob;
+}
+
+const mockJobs = {
+  jobs: [
+    {
+      id: '101',
+      name: 'scrape-category',
+      status: 'failed',
+      attemptsMade: 3,
+      timestamp: 1752700100000,
+      processedOn: 1752700101000,
+      finishedOn: 1752700105000,
+      failedReason: 'Navigation timeout of 30000 ms exceeded',
+    },
+  ],
+};
+
+describe('QueueJobsTable', () => {
+  it('shows a hint when no queue is selected (and does not fetch)', () => {
+    renderTable(null);
+    expect(screen.getByText('Select a queue to inspect its recent jobs.')).toBeInTheDocument();
+  });
+
+  it('shows skeleton rows while loading', () => {
+    server.use(
+      http.get(
+        `${API_BASE}/admin/queues/PRODUCTS_SCRAPING/jobs`,
+        () => new Promise(() => undefined),
+      ),
+    );
+    renderTable('PRODUCTS_SCRAPING');
+    expect(document.querySelectorAll('.animate-pulse').length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('shows error state with Retry on 500', async () => {
+    server.use(
+      http.get(
+        `${API_BASE}/admin/queues/PRODUCTS_SCRAPING/jobs`,
+        () => new HttpResponse(null, { status: 500 }),
+      ),
+    );
+    renderTable('PRODUCTS_SCRAPING');
+    await screen.findByText('Retry');
+    expect(screen.getByText('Failed to load jobs')).toBeInTheDocument();
+  });
+
+  it('shows empty state when there are no jobs', async () => {
+    server.use(
+      http.get(`${API_BASE}/admin/queues/PRODUCTS_SCRAPING/jobs`, () =>
+        HttpResponse.json({ jobs: [] }),
+      ),
+    );
+    renderTable('PRODUCTS_SCRAPING');
+    await screen.findByText('No jobs');
+  });
+
+  it('renders rows and notifies the selected job id', async () => {
+    server.use(
+      http.get(`${API_BASE}/admin/queues/PRODUCTS_SCRAPING/jobs`, () =>
+        HttpResponse.json(mockJobs),
+      ),
+    );
+    const onSelectJob = renderTable('PRODUCTS_SCRAPING');
+
+    await screen.findByText('scrape-category');
+    expect(screen.getAllByText('failed').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('Navigation timeout of 30000 ms exceeded')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('101'));
+    expect(onSelectJob).toHaveBeenCalledWith('101');
+  });
+
+  it('refetches with the chosen status filter', async () => {
+    const captured: string[] = [];
+    server.use(
+      http.get(`${API_BASE}/admin/queues/PRODUCTS_SCRAPING/jobs`, ({ request }) => {
+        captured.push(request.url);
+        return HttpResponse.json(mockJobs);
+      }),
+    );
+    renderTable('PRODUCTS_SCRAPING');
+    await screen.findByText('scrape-category');
+
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'failed' } });
+    await screen.findByText('scrape-category');
+    expect(captured.some((url) => url.includes('status=failed'))).toBe(true);
+  });
+});

--- a/apps/admin-web/src/features/queues/__tests__/queue-mapper.test.ts
+++ b/apps/admin-web/src/features/queues/__tests__/queue-mapper.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  mapJobDTOToDetail,
+  mapJobDTOToListItem,
+  mapQueueStatsDTOToViewModel,
+} from '../mappers/queue-mapper';
+
+describe('mapQueueStatsDTOToViewModel', () => {
+  it('maps counts ordered by severity with semantic variants', () => {
+    const vm = mapQueueStatsDTOToViewModel({
+      queueName: 'PRODUCTS_SCRAPING',
+      counts: { completed: 10, failed: 2, active: 1, waiting: 3 },
+    });
+
+    expect(vm.name).toBe('PRODUCTS_SCRAPING');
+    expect(vm.counts.map((c) => c.label)).toEqual(['active', 'waiting', 'failed', 'completed']);
+    expect(vm.counts.find((c) => c.label === 'failed')?.variant).toBe('danger');
+    expect(vm.counts.find((c) => c.label === 'completed')?.variant).toBe('success');
+    expect(vm.total).toBe(16);
+    expect(vm.failedCount).toBe(2);
+    expect(vm.hasFailures).toBe(true);
+  });
+
+  it('handles empty counts and unknown statuses', () => {
+    const empty = mapQueueStatsDTOToViewModel({ queueName: 'Q', counts: {} });
+    expect(empty.counts).toEqual([]);
+    expect(empty.total).toBe(0);
+    expect(empty.hasFailures).toBe(false);
+
+    const unknown = mapQueueStatsDTOToViewModel({
+      queueName: 'Q',
+      counts: { 'waiting-children': 4 },
+    });
+    expect(unknown.counts[0]).toEqual({ label: 'waiting-children', count: 4, variant: 'muted' });
+  });
+});
+
+describe('mapJobDTOToListItem', () => {
+  it('maps timestamps to Dates and computes duration', () => {
+    const item = mapJobDTOToListItem({
+      id: '101',
+      name: 'scrape-category',
+      status: 'completed',
+      attemptsMade: 1,
+      timestamp: 1752700000000,
+      processedOn: 1752700001000,
+      finishedOn: 1752700009000,
+    });
+
+    expect(item.status).toBe('completed');
+    expect(item.statusVariant).toBe('success');
+    expect(item.createdAt?.getTime()).toBe(1752700000000);
+    expect(item.finishedAt?.getTime()).toBe(1752700009000);
+    expect(item.durationMs).toBe(8000);
+    expect(item.failedReason).toBeNull();
+  });
+
+  it('defaults missing fields and unknown status', () => {
+    const item = mapJobDTOToListItem({ id: '1', name: 'x' });
+    expect(item.status).toBe('unknown');
+    expect(item.statusVariant).toBe('muted');
+    expect(item.attemptsMade).toBe(0);
+    expect(item.createdAt).toBeNull();
+    expect(item.finishedAt).toBeNull();
+    expect(item.durationMs).toBeNull();
+  });
+});
+
+describe('mapJobDTOToDetail', () => {
+  it('pretty-prints payload and return value', () => {
+    const detail = mapJobDTOToDetail({
+      id: '1',
+      name: 'x',
+      data: { url: 'https://revolico.com' },
+      returnValue: { stored: 5 },
+      progress: 40,
+      processedOn: 1752700001000,
+    });
+
+    expect(detail.payloadJson).toBe(JSON.stringify({ url: 'https://revolico.com' }, null, 2));
+    expect(detail.returnValueJson).toBe(JSON.stringify({ stored: 5 }, null, 2));
+    expect(detail.progressPercent).toBe(40);
+    expect(detail.processedAt?.getTime()).toBe(1752700001000);
+  });
+
+  it('returns null payload when the job has no data and null progress when structured', () => {
+    const detail = mapJobDTOToDetail({ id: '1', name: 'x', progress: { step: 'a' } });
+    expect(detail.payloadJson).toBeNull();
+    expect(detail.returnValueJson).toBeNull();
+    expect(detail.progressPercent).toBeNull();
+  });
+});

--- a/apps/admin-web/src/features/queues/__tests__/queue-stats-cards.test.tsx
+++ b/apps/admin-web/src/features/queues/__tests__/queue-stats-cards.test.tsx
@@ -1,0 +1,98 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+
+import { QueueStatsCards } from '../components/queue-stats-cards';
+
+const API_BASE = 'http://localhost:3000/api';
+
+const server = setupServer();
+
+beforeAll(() => {
+  server.listen({ onUnhandledRequest: 'error' });
+});
+
+afterEach(() => {
+  server.resetHandlers();
+});
+
+afterAll(() => {
+  server.close();
+});
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, defaultVal?: string | Record<string, unknown>): string => {
+      if (typeof defaultVal === 'string') return defaultVal;
+      return key;
+    },
+  }),
+}));
+
+function createTestQueryClient(): QueryClient {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+
+function renderCards(selected: string | null = null, onSelect = vi.fn()) {
+  render(
+    <QueryClientProvider client={createTestQueryClient()}>
+      <QueueStatsCards selected={selected} onSelect={onSelect} />
+    </QueryClientProvider>,
+  );
+  return onSelect;
+}
+
+const mockQueues = {
+  queues: [
+    { queueName: 'PRODUCTS_SCRAPING', counts: { waiting: 3, active: 1, failed: 2 } },
+    { queueName: 'EMAIL_SEND_JOB', counts: { completed: 89 } },
+  ],
+};
+
+describe('QueueStatsCards', () => {
+  it('shows skeleton cards while loading', () => {
+    server.use(http.get(`${API_BASE}/admin/queues/stats`, () => new Promise(() => undefined)));
+    renderCards();
+    expect(document.querySelectorAll('.animate-pulse').length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('shows error state with Retry on 500', async () => {
+    server.use(
+      http.get(`${API_BASE}/admin/queues/stats`, () => new HttpResponse(null, { status: 500 })),
+    );
+    renderCards();
+    await screen.findByText('Retry');
+    expect(screen.getByText('Failed to load queue stats')).toBeInTheDocument();
+  });
+
+  it('shows empty state when there are no queues', async () => {
+    server.use(http.get(`${API_BASE}/admin/queues/stats`, () => HttpResponse.json({ queues: [] })));
+    renderCards();
+    await screen.findByText('No queues registered');
+  });
+
+  it('renders one card per queue with counts and calls onSelect on click', async () => {
+    server.use(http.get(`${API_BASE}/admin/queues/stats`, () => HttpResponse.json(mockQueues)));
+    const onSelect = renderCards();
+
+    await screen.findByText('PRODUCTS_SCRAPING');
+    expect(screen.getByText('EMAIL_SEND_JOB')).toBeInTheDocument();
+    expect(screen.getByText('failed')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('PRODUCTS_SCRAPING'));
+    expect(onSelect).toHaveBeenCalledWith('PRODUCTS_SCRAPING');
+  });
+
+  it('marks the selected card with aria-pressed', async () => {
+    server.use(http.get(`${API_BASE}/admin/queues/stats`, () => HttpResponse.json(mockQueues)));
+    renderCards('PRODUCTS_SCRAPING');
+
+    await screen.findByText('PRODUCTS_SCRAPING');
+    const pressed = screen
+      .getAllByRole('button')
+      .filter((b) => b.getAttribute('aria-pressed') === 'true');
+    expect(pressed).toHaveLength(1);
+  });
+});

--- a/apps/admin-web/src/features/queues/__tests__/queues-dashboard.test.tsx
+++ b/apps/admin-web/src/features/queues/__tests__/queues-dashboard.test.tsx
@@ -1,0 +1,82 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+
+import { QueuesDashboard } from '../components/queues-dashboard';
+
+const API_BASE = 'http://localhost:3000/api';
+
+const server = setupServer();
+
+beforeAll(() => {
+  server.listen({ onUnhandledRequest: 'error' });
+});
+
+afterEach(() => {
+  server.resetHandlers();
+});
+
+afterAll(() => {
+  server.close();
+});
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, defaultVal?: string | Record<string, unknown>): string => {
+      if (typeof defaultVal === 'string') return defaultVal;
+      return key;
+    },
+  }),
+}));
+
+const mockJob = {
+  id: '101',
+  name: 'scrape-category',
+  status: 'failed',
+  attemptsMade: 3,
+  timestamp: 1752700100000,
+  processedOn: 1752700101000,
+  finishedOn: 1752700105000,
+  failedReason: 'Navigation timeout of 30000 ms exceeded',
+  data: { url: 'https://revolico.com/categoria/autos' },
+};
+
+describe('QueuesDashboard', () => {
+  it('drills down: queue card → jobs table → job detail drawer', async () => {
+    server.use(
+      http.get(`${API_BASE}/admin/queues/stats`, () =>
+        HttpResponse.json({
+          queues: [{ queueName: 'PRODUCTS_SCRAPING', counts: { waiting: 2, failed: 1 } }],
+        }),
+      ),
+      http.get(`${API_BASE}/admin/queues/PRODUCTS_SCRAPING/jobs`, () =>
+        HttpResponse.json({ jobs: [mockJob] }),
+      ),
+      http.get(`${API_BASE}/admin/queues/PRODUCTS_SCRAPING/jobs/101`, () =>
+        HttpResponse.json(mockJob),
+      ),
+    );
+
+    render(
+      <QueryClientProvider
+        client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
+      >
+        <QueuesDashboard />
+      </QueryClientProvider>,
+    );
+
+    // 1. Cards load
+    await screen.findByText('PRODUCTS_SCRAPING');
+
+    // 2. Select the queue → jobs table loads
+    fireEvent.click(screen.getByText('PRODUCTS_SCRAPING'));
+    await screen.findByText('scrape-category');
+
+    // 3. Open the job → drawer shows detail + payload JSON
+    fireEvent.click(screen.getByText('101'));
+    await screen.findByText('Job detail');
+    expect(await screen.findByText(/revolico\.com/)).toBeInTheDocument();
+  });
+});

--- a/apps/admin-web/src/features/queues/__tests__/queues-hooks.test.tsx
+++ b/apps/admin-web/src/features/queues/__tests__/queues-hooks.test.tsx
@@ -1,0 +1,139 @@
+import type { ReactNode } from 'react';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+
+import { useGetJobDetail } from '../hooks/useGetJobDetail';
+import { useGetQueueJobs } from '../hooks/useGetQueueJobs';
+import { useGetQueues } from '../hooks/useGetQueues';
+
+const API_BASE = 'http://localhost:3000/api';
+
+const server = setupServer();
+
+beforeAll(() => {
+  server.listen({ onUnhandledRequest: 'error' });
+});
+
+afterEach(() => {
+  server.resetHandlers();
+});
+
+afterAll(() => {
+  server.close();
+});
+
+function createWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return function Wrapper({ children }: { children: ReactNode }): JSX.Element {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+describe('useGetQueues', () => {
+  it('fetches all queue stats and maps them to view models', async () => {
+    server.use(
+      http.get(`${API_BASE}/admin/queues/stats`, () =>
+        HttpResponse.json({
+          queues: [{ queueName: 'PRODUCTS_SCRAPING', counts: { waiting: 2, failed: 1 } }],
+        }),
+      ),
+    );
+
+    const { result } = renderHook(() => useGetQueues(), { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(result.current.data?.[0].name).toBe('PRODUCTS_SCRAPING');
+    expect(result.current.data?.[0].failedCount).toBe(1);
+    expect(result.current.data?.[0].hasFailures).toBe(true);
+  });
+});
+
+describe('useGetQueueJobs', () => {
+  it('does not fetch while queueName is null', () => {
+    const { result } = renderHook(() => useGetQueueJobs(null, 'all'), {
+      wrapper: createWrapper(),
+    });
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+
+  it('passes limit and status as query params and maps rows', async () => {
+    const captured: string[] = [];
+    server.use(
+      http.get(`${API_BASE}/admin/queues/PRODUCTS_SCRAPING/jobs`, ({ request }) => {
+        captured.push(request.url);
+        return HttpResponse.json({
+          jobs: [{ id: '101', name: 'scrape-category', status: 'failed', attemptsMade: 3 }],
+        });
+      }),
+    );
+
+    const { result } = renderHook(() => useGetQueueJobs('PRODUCTS_SCRAPING', 'failed'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(captured[0]).toContain('limit=20');
+    expect(captured[0]).toContain('status=failed');
+    expect(result.current.data?.[0].statusVariant).toBe('danger');
+  });
+
+  it('omits the status param when the filter is "all"', async () => {
+    const captured: string[] = [];
+    server.use(
+      http.get(`${API_BASE}/admin/queues/EMAIL_SEND_JOB/jobs`, ({ request }) => {
+        captured.push(request.url);
+        return HttpResponse.json({ jobs: [] });
+      }),
+    );
+
+    const { result } = renderHook(() => useGetQueueJobs('EMAIL_SEND_JOB', 'all'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(captured[0]).not.toContain('status=');
+  });
+});
+
+describe('useGetJobDetail', () => {
+  it('does not fetch until both queueName and jobId are set', () => {
+    const { result } = renderHook(() => useGetJobDetail('PRODUCTS_SCRAPING', null), {
+      wrapper: createWrapper(),
+    });
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+
+  it('fetches and maps the job detail', async () => {
+    server.use(
+      http.get(`${API_BASE}/admin/queues/PRODUCTS_SCRAPING/jobs/101`, () =>
+        HttpResponse.json({
+          id: '101',
+          name: 'scrape-category',
+          status: 'failed',
+          attemptsMade: 3,
+          failedReason: 'Navigation timeout',
+          data: { url: 'https://revolico.com' },
+        }),
+      ),
+    );
+
+    const { result } = renderHook(() => useGetJobDetail('PRODUCTS_SCRAPING', '101'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(result.current.data?.failedReason).toBe('Navigation timeout');
+    expect(result.current.data?.payloadJson).toContain('revolico.com');
+  });
+});

--- a/apps/admin-web/src/features/queues/components/job-detail-drawer.tsx
+++ b/apps/admin-web/src/features/queues/components/job-detail-drawer.tsx
@@ -1,0 +1,136 @@
+import { useTranslation } from 'react-i18next';
+import { Drawer } from '@shared/ui/drawer';
+
+import { useGetJobDetail } from '../hooks/useGetJobDetail';
+
+import { QueueBadge } from './queue-badge';
+
+interface Props {
+  queueName: string | null;
+  jobId: string | null;
+  onClose: () => void;
+}
+
+export function JobDetailDrawer({ queueName, jobId, onClose }: Props): JSX.Element {
+  const { t } = useTranslation();
+  const { data, isLoading, isError } = useGetJobDetail(queueName, jobId);
+
+  return (
+    <Drawer
+      open={jobId !== null}
+      title={t('queues.drawer.title', 'Job detail')}
+      onClose={onClose}
+      widthClass="w-[480px]"
+    >
+      {isLoading && (
+        <div className="space-y-sm">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div key={i} className="h-6 animate-pulse rounded-sm bg-surface-container-highest" />
+          ))}
+        </div>
+      )}
+
+      {isError && (
+        <div className="rounded-md border border-danger bg-danger-muted p-md text-sm text-danger">
+          {t('queues.drawer.error', 'Failed to load job detail')}
+        </div>
+      )}
+
+      {data && (
+        <>
+          <dl className="space-y-md">
+            <div>
+              <dt className="text-label-xs font-mono text-on-surface-variant">
+                {t('queues.jobs.name', 'Name')}
+              </dt>
+              <dd className="mt-xs font-mono text-body-md text-on-surface">{data.name}</dd>
+            </div>
+            <div className="grid grid-cols-2 gap-md">
+              <div>
+                <dt className="text-label-xs font-mono text-on-surface-variant">
+                  {t('queues.jobs.status', 'Status')}
+                </dt>
+                <dd className="mt-xs">
+                  <QueueBadge label={data.status} variant={data.statusVariant} />
+                </dd>
+              </div>
+              <div>
+                <dt className="text-label-xs font-mono text-on-surface-variant">
+                  {t('queues.jobs.attempts', 'Attempts')}
+                </dt>
+                <dd className="mt-xs text-body-md text-on-surface">{data.attemptsMade}</dd>
+              </div>
+              <div>
+                <dt className="text-label-xs font-mono text-on-surface-variant">
+                  {t('queues.drawer.createdAt', 'Created at')}
+                </dt>
+                <dd className="mt-xs text-body-sm text-on-surface">
+                  {data.createdAt ? data.createdAt.toLocaleString() : '—'}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-label-xs font-mono text-on-surface-variant">
+                  {t('queues.drawer.processedAt', 'Processed at')}
+                </dt>
+                <dd className="mt-xs text-body-sm text-on-surface">
+                  {data.processedAt ? data.processedAt.toLocaleString() : '—'}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-label-xs font-mono text-on-surface-variant">
+                  {t('queues.drawer.finishedAt', 'Finished at')}
+                </dt>
+                <dd className="mt-xs text-body-sm text-on-surface">
+                  {data.finishedAt ? data.finishedAt.toLocaleString() : '—'}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-label-xs font-mono text-on-surface-variant">
+                  {t('queues.jobs.duration', 'Duration')}
+                </dt>
+                <dd className="mt-xs font-mono text-body-sm text-on-surface">
+                  {data.durationMs !== null ? `${(data.durationMs / 1000).toFixed(1)}s` : '—'}
+                </dd>
+              </div>
+            </div>
+            {data.progressPercent !== null && (
+              <div>
+                <dt className="text-label-xs font-mono text-on-surface-variant">
+                  {t('queues.drawer.progress', 'Progress')}
+                </dt>
+                <dd className="mt-xs text-body-md text-on-surface">{data.progressPercent}%</dd>
+              </div>
+            )}
+          </dl>
+
+          {data.failedReason !== null && (
+            <div className="mt-md rounded-md border border-danger bg-danger-muted p-md">
+              <h3 className="text-label-xs font-mono text-danger">
+                {t('queues.jobs.failedReason', 'Failure reason')}
+              </h3>
+              <p className="mt-xs text-body-sm text-danger">{data.failedReason}</p>
+            </div>
+          )}
+
+          <div className="mt-md">
+            <h3 className="text-label-xs font-mono text-on-surface-variant">
+              {t('queues.drawer.payload', 'Payload')}
+            </h3>
+            <pre className="mt-xs max-h-64 overflow-auto rounded-md bg-surface-container-lowest p-sm font-mono text-body-sm text-on-surface">
+              {data.payloadJson ?? t('queues.drawer.none', '—')}
+            </pre>
+          </div>
+
+          <div className="mt-md">
+            <h3 className="text-label-xs font-mono text-on-surface-variant">
+              {t('queues.drawer.returnValue', 'Return value')}
+            </h3>
+            <pre className="mt-xs max-h-64 overflow-auto rounded-md bg-surface-container-lowest p-sm font-mono text-body-sm text-on-surface">
+              {data.returnValueJson ?? t('queues.drawer.none', '—')}
+            </pre>
+          </div>
+        </>
+      )}
+    </Drawer>
+  );
+}

--- a/apps/admin-web/src/features/queues/components/queue-badge.tsx
+++ b/apps/admin-web/src/features/queues/components/queue-badge.tsx
@@ -1,0 +1,28 @@
+import type { BadgeVariant } from '../view-models/queue-view-model';
+
+interface QueueBadgeProps {
+  label: string;
+  count?: number;
+  variant: BadgeVariant;
+}
+
+const VARIANT_CLASSES: Record<BadgeVariant, string> = {
+  primary: 'bg-primary/10 text-primary',
+  info: 'bg-info-muted text-info',
+  success: 'bg-success-muted text-success',
+  danger: 'bg-danger-muted text-danger',
+  warning: 'bg-warning-muted text-warning',
+  muted: 'bg-surface-container-highest text-on-surface-variant',
+};
+
+/** Small status chip used by queue cards and the jobs table. */
+export function QueueBadge({ label, count, variant }: QueueBadgeProps): JSX.Element {
+  return (
+    <span
+      className={`inline-flex items-center gap-xs rounded-sm px-xs py-0.5 text-label-xs font-mono ${VARIANT_CLASSES[variant]}`}
+    >
+      {label}
+      {count !== undefined && <span className="font-semibold">{count}</span>}
+    </span>
+  );
+}

--- a/apps/admin-web/src/features/queues/components/queue-jobs-table.tsx
+++ b/apps/admin-web/src/features/queues/components/queue-jobs-table.tsx
@@ -1,0 +1,170 @@
+import { type ChangeEvent, useCallback, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { FileStack } from 'lucide-react';
+
+import { useGetQueueJobs } from '../hooks/useGetQueueJobs';
+import type { JobListItemViewModel } from '../view-models/queue-view-model';
+
+import { QueueBadge } from './queue-badge';
+
+const STATUS_FILTERS = ['all', 'waiting', 'active', 'completed', 'failed', 'delayed'] as const;
+type StatusFilter = (typeof STATUS_FILTERS)[number];
+
+interface Props {
+  queueName: string | null;
+  onSelectJob: (id: string) => void;
+}
+
+function formatDurationMs(ms: number | null): string {
+  if (ms === null) return '—';
+  if (ms < 1000) return `${String(ms)}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+export function QueueJobsTable({ queueName, onSelectJob }: Props): JSX.Element {
+  const { t } = useTranslation();
+  const [status, setStatus] = useState<StatusFilter>('all');
+  const { data, isLoading, isError, refetch, isFetching } = useGetQueueJobs(queueName, status);
+
+  const handleStatusChange = useCallback((e: ChangeEvent<HTMLSelectElement>) => {
+    setStatus(e.target.value as StatusFilter);
+  }, []);
+
+  const handleRetry = useCallback(() => {
+    void refetch();
+  }, [refetch]);
+
+  if (queueName === null) {
+    return (
+      <p className="rounded-md border border-outline-variant bg-surface-container p-md text-body-sm text-on-surface-variant">
+        {t('queues.jobs.hint', 'Select a queue to inspect its recent jobs.')}
+      </p>
+    );
+  }
+
+  return (
+    <div className="rounded-md border border-outline-variant bg-surface-container">
+      <div className="flex items-center justify-between border-b border-outline-variant p-sm">
+        <span className="font-mono text-body-sm text-on-surface">{queueName}</span>
+        <label className="flex items-center gap-xs text-label-xs font-mono text-on-surface-variant">
+          {t('queues.jobs.filterLabel', 'Status')}
+          <select
+            value={status}
+            onChange={handleStatusChange}
+            className="rounded-sm border border-outline-variant bg-surface px-sm py-xs text-body-sm text-on-surface"
+          >
+            {STATUS_FILTERS.map((s) => (
+              <option key={s} value={s}>
+                {s === 'all' ? t('queues.jobs.all', 'All statuses') : s}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      {isFetching && !isLoading && <div className="h-0.5 animate-pulse bg-primary/20" />}
+
+      {isLoading && (
+        <div className="space-y-sm p-sm">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <div key={i} className="h-8 animate-pulse rounded-sm bg-surface-container-highest" />
+          ))}
+        </div>
+      )}
+
+      {isError && (
+        <div className="p-md">
+          <p className="text-body-sm text-danger">
+            {t('queues.jobs.error', 'Failed to load jobs')}
+          </p>
+          <button
+            onClick={handleRetry}
+            className="mt-sm rounded-sm bg-primary px-sm py-xs text-body-sm font-medium text-on-primary"
+          >
+            {t('common.retry', 'Retry')}
+          </button>
+        </div>
+      )}
+
+      {data && data.length === 0 && (
+        <div className="flex flex-col items-center p-lg text-center">
+          <FileStack size={48} className="text-on-surface-variant" aria-hidden="true" />
+          <h2 className="mt-sm text-lg text-on-surface">
+            {t('queues.jobs.empty.title', 'No jobs')}
+          </h2>
+          <p className="mt-xs text-body-sm text-on-surface-variant">
+            {t('queues.jobs.empty.description', 'No recent jobs match the current filter.')}
+          </p>
+        </div>
+      )}
+
+      {data && data.length > 0 && (
+        <table className="w-full border-collapse text-body-sm">
+          <caption className="sr-only">
+            {t('queues.jobs.caption', 'Recent jobs for the selected queue')}
+          </caption>
+          <thead>
+            <tr className="text-left text-label-xs font-mono text-on-surface-variant">
+              <th className="px-sm py-xs font-medium">{t('queues.jobs.id', 'Job ID')}</th>
+              <th className="px-sm py-xs font-medium">{t('queues.jobs.name', 'Name')}</th>
+              <th className="px-sm py-xs font-medium">{t('queues.jobs.status', 'Status')}</th>
+              <th className="px-sm py-xs font-medium">{t('queues.jobs.attempts', 'Attempts')}</th>
+              <th className="px-sm py-xs font-medium">{t('queues.jobs.created', 'Created')}</th>
+              <th className="px-sm py-xs font-medium">{t('queues.jobs.duration', 'Duration')}</th>
+              <th className="px-sm py-xs font-medium">
+                {t('queues.jobs.failedReason', 'Failure reason')}
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.map((job) => (
+              <JobRow key={job.id} job={job} onSelectJob={onSelectJob} />
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}
+
+interface JobRowProps {
+  job: JobListItemViewModel;
+  onSelectJob: (id: string) => void;
+}
+
+function JobRow({ job, onSelectJob }: JobRowProps): JSX.Element {
+  const handleClick = useCallback(() => {
+    onSelectJob(job.id);
+  }, [onSelectJob, job.id]);
+
+  return (
+    <tr className="h-9 border-t border-outline-variant hover:bg-surface-container-high">
+      <td className="px-sm">
+        <button
+          type="button"
+          onClick={handleClick}
+          className="font-mono text-primary hover:underline"
+        >
+          {job.id}
+        </button>
+      </td>
+      <td className="px-sm text-on-surface">{job.name}</td>
+      <td className="px-sm">
+        <QueueBadge label={job.status} variant={job.statusVariant} />
+      </td>
+      <td className="px-sm text-on-surface-variant">{job.attemptsMade}</td>
+      <td className="px-sm text-on-surface-variant">
+        {job.createdAt ? job.createdAt.toLocaleString() : '—'}
+      </td>
+      <td className="px-sm font-mono text-on-surface-variant">
+        {formatDurationMs(job.durationMs)}
+      </td>
+      <td
+        className="max-w-[240px] truncate px-sm text-danger"
+        title={job.failedReason ?? undefined}
+      >
+        {job.failedReason ?? ''}
+      </td>
+    </tr>
+  );
+}

--- a/apps/admin-web/src/features/queues/components/queue-stats-cards.tsx
+++ b/apps/admin-web/src/features/queues/components/queue-stats-cards.tsx
@@ -1,0 +1,119 @@
+import { useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Inbox } from 'lucide-react';
+
+import { useGetQueues } from '../hooks/useGetQueues';
+import type { QueueStatsViewModel } from '../view-models/queue-view-model';
+
+import { QueueBadge } from './queue-badge';
+
+interface Props {
+  selected: string | null;
+  onSelect: (name: string) => void;
+}
+
+export function QueueStatsCards({ selected, onSelect }: Props): JSX.Element {
+  const { t } = useTranslation();
+  const { data, isLoading, isError, refetch, isFetching } = useGetQueues();
+
+  const handleRetry = useCallback(() => {
+    void refetch();
+  }, [refetch]);
+
+  if (isLoading) {
+    return (
+      <div className="grid grid-cols-1 gap-md sm:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="h-24 animate-pulse rounded-md bg-surface-container-highest" />
+        ))}
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="rounded-md border border-danger bg-danger-muted p-md">
+        <p className="text-body-sm text-danger">
+          {t('queues.cards.error', 'Failed to load queue stats')}
+        </p>
+        <button
+          onClick={handleRetry}
+          className="mt-sm rounded-sm bg-primary px-sm py-xs text-body-sm font-medium text-on-primary"
+        >
+          {t('common.retry', 'Retry')}
+        </button>
+      </div>
+    );
+  }
+
+  if (!data || data.length === 0) {
+    return (
+      <div className="flex flex-col items-center rounded-md border border-outline-variant bg-surface-container p-lg text-center">
+        <Inbox size={48} className="text-on-surface-variant" aria-hidden="true" />
+        <h2 className="mt-sm text-lg text-on-surface">
+          {t('queues.cards.empty.title', 'No queues registered')}
+        </h2>
+        <p className="mt-xs text-body-sm text-on-surface-variant">
+          {t(
+            'queues.cards.empty.description',
+            'Queues appear here once the backend registers them.',
+          )}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {isFetching && <div className="h-0.5 animate-pulse bg-primary/20" />}
+      <div className="grid grid-cols-1 gap-md sm:grid-cols-2 lg:grid-cols-3">
+        {data.map((queue) => (
+          <QueueCard
+            key={queue.name}
+            queue={queue}
+            selected={selected === queue.name}
+            onSelect={onSelect}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+interface QueueCardProps {
+  queue: QueueStatsViewModel;
+  selected: boolean;
+  onSelect: (name: string) => void;
+}
+
+function QueueCard({ queue, selected, onSelect }: QueueCardProps): JSX.Element {
+  const { t } = useTranslation();
+  const handleClick = useCallback(() => {
+    onSelect(queue.name);
+  }, [onSelect, queue.name]);
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      aria-pressed={selected}
+      className={`rounded-md border p-md text-left transition-colors ${
+        selected
+          ? 'border-primary bg-surface-container-high'
+          : 'border-outline-variant bg-surface-container hover:bg-surface-container-high'
+      }`}
+    >
+      <div className="flex items-center justify-between">
+        <span className="font-mono text-body-sm text-on-surface">{queue.name}</span>
+        <span className="text-label-xs font-mono text-on-surface-variant">
+          {queue.total} {t('queues.cards.total', 'total')}
+        </span>
+      </div>
+      <div className="mt-sm flex flex-wrap gap-xs">
+        {queue.counts.map((c) => (
+          <QueueBadge key={c.label} label={c.label} count={c.count} variant={c.variant} />
+        ))}
+      </div>
+    </button>
+  );
+}

--- a/apps/admin-web/src/features/queues/components/queues-dashboard.tsx
+++ b/apps/admin-web/src/features/queues/components/queues-dashboard.tsx
@@ -1,0 +1,32 @@
+import { useCallback, useState } from 'react';
+
+import { JobDetailDrawer } from './job-detail-drawer';
+import { QueueJobsTable } from './queue-jobs-table';
+import { QueueStatsCards } from './queue-stats-cards';
+
+/** Queues operations dashboard: stats cards → jobs table → job detail drawer. */
+export function QueuesDashboard(): JSX.Element {
+  const [selectedQueue, setSelectedQueue] = useState<string | null>(null);
+  const [selectedJobId, setSelectedJobId] = useState<string | null>(null);
+
+  const handleSelectQueue = useCallback((name: string) => {
+    setSelectedQueue(name);
+    setSelectedJobId(null);
+  }, []);
+
+  const handleCloseDrawer = useCallback(() => {
+    setSelectedJobId(null);
+  }, []);
+
+  return (
+    <div className="space-y-lg">
+      <QueueStatsCards selected={selectedQueue} onSelect={handleSelectQueue} />
+      <QueueJobsTable queueName={selectedQueue} onSelectJob={setSelectedJobId} />
+      <JobDetailDrawer
+        queueName={selectedQueue}
+        jobId={selectedJobId}
+        onClose={handleCloseDrawer}
+      />
+    </div>
+  );
+}

--- a/apps/admin-web/src/features/queues/hooks/query-keys.ts
+++ b/apps/admin-web/src/features/queues/hooks/query-keys.ts
@@ -1,0 +1,7 @@
+export const queueKeys = {
+  all: ['queues'] as const,
+  stats: () => ['queues', 'stats'] as const,
+  jobs: (name: string, filters: Record<string, unknown>) =>
+    ['queues', name, 'jobs', filters] as const,
+  job: (name: string, id: string) => ['queues', name, 'job', id] as const,
+};

--- a/apps/admin-web/src/features/queues/hooks/useGetJobDetail.ts
+++ b/apps/admin-web/src/features/queues/hooks/useGetJobDetail.ts
@@ -1,0 +1,24 @@
+import { ENV } from '@shared/config/env';
+import { useQuery } from '@tanstack/react-query';
+
+import { mapJobDTOToDetail } from '../mappers/queue-mapper';
+import { queuesService } from '../services/queues-service';
+
+import { queueKeys } from './query-keys';
+
+/**
+ * Fetches the full detail of a single job for the drawer.
+ * Disabled until both the queue and the job are selected.
+ */
+export function useGetJobDetail(queueName: string | null, jobId: string | null) {
+  return useQuery({
+    queryKey: queueKeys.job(queueName ?? '', jobId ?? ''),
+    enabled: queueName !== null && jobId !== null,
+    queryFn: async ({ signal }) => {
+      if (queueName === null || jobId === null) throw new Error('queueName and jobId required');
+      const response = await queuesService.getJob(queueName, jobId, { signal });
+      return mapJobDTOToDetail(response.data);
+    },
+    staleTime: ENV.STALE_TIME_REALTIME,
+  });
+}

--- a/apps/admin-web/src/features/queues/hooks/useGetQueueJobs.ts
+++ b/apps/admin-web/src/features/queues/hooks/useGetQueueJobs.ts
@@ -1,0 +1,32 @@
+import { ENV } from '@shared/config/env';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
+
+import { mapJobDTOToListItem } from '../mappers/queue-mapper';
+import { queuesService } from '../services/queues-service';
+import type { JobStatus } from '../view-models/queue-view-model';
+
+import { queueKeys } from './query-keys';
+
+const JOBS_LIMIT = 20;
+
+/**
+ * Fetches recent jobs for a queue, optionally filtered by status.
+ * Disabled until a queue is selected; keeps previous rows while refetching.
+ */
+export function useGetQueueJobs(queueName: string | null, status: JobStatus | 'all') {
+  return useQuery({
+    queryKey: queueKeys.jobs(queueName ?? '', { status }),
+    enabled: queueName !== null,
+    queryFn: async ({ signal }) => {
+      if (queueName === null) throw new Error('queueName is required');
+      const response = await queuesService.listJobs(queueName, {
+        limit: JOBS_LIMIT,
+        status: status === 'all' ? undefined : status,
+        signal,
+      });
+      return response.data.jobs.map(mapJobDTOToListItem);
+    },
+    staleTime: ENV.STALE_TIME_REALTIME,
+    placeholderData: keepPreviousData,
+  });
+}

--- a/apps/admin-web/src/features/queues/hooks/useGetQueues.ts
+++ b/apps/admin-web/src/features/queues/hooks/useGetQueues.ts
@@ -1,0 +1,23 @@
+import { ENV } from '@shared/config/env';
+import { useQuery } from '@tanstack/react-query';
+
+import { mapQueueStatsDTOToViewModel } from '../mappers/queue-mapper';
+import { queuesService } from '../services/queues-service';
+
+import { queueKeys } from './query-keys';
+
+/**
+ * Fetches job counts for every registered queue.
+ * Stale time: REALTIME (30s) with background refetch on the same interval.
+ */
+export function useGetQueues() {
+  return useQuery({
+    queryKey: queueKeys.stats(),
+    queryFn: async ({ signal }) => {
+      const response = await queuesService.listStats({ signal });
+      return response.data.queues.map(mapQueueStatsDTOToViewModel);
+    },
+    staleTime: ENV.STALE_TIME_REALTIME,
+    refetchInterval: ENV.STALE_TIME_REALTIME,
+  });
+}

--- a/apps/admin-web/src/features/queues/index.ts
+++ b/apps/admin-web/src/features/queues/index.ts
@@ -1,0 +1,3 @@
+export { QueuesDashboard } from './components/queues-dashboard';
+export { useGetQueues } from './hooks/useGetQueues';
+export type { QueueStatsViewModel } from './view-models/queue-view-model';

--- a/apps/admin-web/src/features/queues/mappers/queue-mapper.ts
+++ b/apps/admin-web/src/features/queues/mappers/queue-mapper.ts
@@ -1,0 +1,110 @@
+import type { QueueJobDTO, QueueStatsDTO } from '../services/queues-service';
+import type {
+  BadgeVariant,
+  JobDetailViewModel,
+  JobListItemViewModel,
+  JobStatus,
+  QueueCountViewModel,
+  QueueStatsViewModel,
+} from '../view-models/queue-view-model';
+
+/** Display order for known statuses — operational severity first. */
+const STATUS_ORDER: readonly JobStatus[] = [
+  'active',
+  'waiting',
+  'delayed',
+  'failed',
+  'completed',
+  'paused',
+];
+
+const STATUS_VARIANT: Record<JobStatus, BadgeVariant> = {
+  active: 'primary',
+  waiting: 'info',
+  delayed: 'warning',
+  failed: 'danger',
+  completed: 'success',
+  paused: 'muted',
+  unknown: 'muted',
+};
+
+function toJobStatus(raw: string): JobStatus {
+  return (STATUS_ORDER as readonly string[]).includes(raw) ? (raw as JobStatus) : 'unknown';
+}
+
+function orderIndex(status: string): number {
+  const index = (STATUS_ORDER as readonly string[]).indexOf(status);
+  return index === -1 ? STATUS_ORDER.length : index;
+}
+
+function safeJsonStringify(value: unknown): string | null {
+  if (value === undefined || value === null) return null;
+  const seen = new WeakSet();
+  try {
+    return JSON.stringify(
+      value,
+      (_key: string, val: unknown) => {
+        if (typeof val === 'object' && val !== null) {
+          if (seen.has(val)) return '[Circular]';
+          seen.add(val);
+        }
+        return val;
+      },
+      2,
+    );
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Transforms a backend QueueStatsDTO into a UI-oriented QueueStatsViewModel.
+ * Pure function — no side effects, no API calls.
+ */
+export function mapQueueStatsDTOToViewModel(dto: QueueStatsDTO): QueueStatsViewModel {
+  const counts: QueueCountViewModel[] = Object.entries(dto.counts)
+    .sort(([a], [b]) => orderIndex(a) - orderIndex(b) || a.localeCompare(b))
+    .map(([label, count]) => ({ label, count, variant: STATUS_VARIANT[toJobStatus(label)] }));
+
+  const total = Object.values(dto.counts).reduce((sum, n) => sum + n, 0);
+  const failedCount = dto.counts.failed || 0;
+
+  return { name: dto.queueName, counts, total, failedCount, hasFailures: failedCount > 0 };
+}
+
+/**
+ * Transforms a backend QueueJobDTO into a table row ViewModel.
+ * Pure function — no side effects, no API calls.
+ */
+export function mapJobDTOToListItem(dto: QueueJobDTO): JobListItemViewModel {
+  const status = toJobStatus(dto.status ?? 'unknown');
+  const finishedAt = typeof dto.finishedOn === 'number' ? new Date(dto.finishedOn) : null;
+  const processedAtMs = typeof dto.processedOn === 'number' ? dto.processedOn : null;
+
+  return {
+    id: dto.id,
+    name: dto.name,
+    status,
+    statusVariant: STATUS_VARIANT[status],
+    attemptsMade: dto.attemptsMade ?? 0,
+    createdAt: typeof dto.timestamp === 'number' ? new Date(dto.timestamp) : null,
+    finishedAt,
+    durationMs:
+      finishedAt !== null && processedAtMs !== null ? finishedAt.getTime() - processedAtMs : null,
+    failedReason: dto.failedReason ?? null,
+  };
+}
+
+/**
+ * Transforms a backend QueueJobDTO into the full drawer ViewModel.
+ * Pure function — no side effects, no API calls.
+ */
+export function mapJobDTOToDetail(dto: QueueJobDTO): JobDetailViewModel {
+  return {
+    ...mapJobDTOToListItem(dto),
+    payloadJson: safeJsonStringify(dto.data),
+    returnValueJson: safeJsonStringify(dto.returnValue),
+    progressPercent: typeof dto.progress === 'number' ? dto.progress : null,
+    processedAt: typeof dto.processedOn === 'number' ? new Date(dto.processedOn) : null,
+  };
+}

--- a/apps/admin-web/src/features/queues/services/queues-service.ts
+++ b/apps/admin-web/src/features/queues/services/queues-service.ts
@@ -1,0 +1,55 @@
+import { apiClient } from '@shared/api/client';
+
+/** Raw per-queue stats from GET /admin/queues/stats. */
+export interface QueueStatsDTO {
+  queueName: string;
+  counts: Record<string, number>;
+}
+
+/** Response envelope for GET /admin/queues/stats. */
+export interface QueueListResponseDTO {
+  queues: QueueStatsDTO[];
+}
+
+/** Raw job shape (BullMQ Job.toJSON()) surfaced by the backend. */
+export interface QueueJobDTO {
+  id: string;
+  name: string;
+  data?: unknown;
+  progress?: number | Record<string, unknown>;
+  attemptsMade?: number;
+  failedReason?: string;
+  timestamp?: number;
+  processedOn?: number | null;
+  finishedOn?: number | null;
+  returnValue?: unknown;
+  status?: string;
+}
+
+/** Response envelope for GET /admin/queues/:name/jobs. */
+export interface JobListResponseDTO {
+  jobs: QueueJobDTO[];
+}
+
+export const queuesService = {
+  /** Job counts for every registered queue. */
+  listStats(opts?: { signal?: AbortSignal }) {
+    return apiClient.get<QueueListResponseDTO>('/admin/queues/stats', { signal: opts?.signal });
+  },
+
+  /** Recent jobs for a queue, optionally filtered by status. */
+  listJobs(name: string, opts?: { limit?: number; status?: string; signal?: AbortSignal }) {
+    return apiClient.get<JobListResponseDTO>(`/admin/queues/${encodeURIComponent(name)}/jobs`, {
+      params: { limit: opts?.limit, status: opts?.status },
+      signal: opts?.signal,
+    });
+  },
+
+  /** Full detail for a single job. */
+  getJob(name: string, id: string, opts?: { signal?: AbortSignal }) {
+    return apiClient.get<QueueJobDTO>(
+      `/admin/queues/${encodeURIComponent(name)}/jobs/${encodeURIComponent(id)}`,
+      { signal: opts?.signal },
+    );
+  },
+};

--- a/apps/admin-web/src/features/queues/view-models/queue-view-model.ts
+++ b/apps/admin-web/src/features/queues/view-models/queue-view-model.ts
@@ -1,0 +1,51 @@
+/** Known BullMQ job states surfaced by the backend. */
+export type JobStatus =
+  | 'waiting'
+  | 'active'
+  | 'completed'
+  | 'failed'
+  | 'delayed'
+  | 'paused'
+  | 'unknown';
+
+/** Semantic color variant for count/status chips. */
+export type BadgeVariant = 'primary' | 'info' | 'success' | 'danger' | 'warning' | 'muted';
+
+export interface QueueCountViewModel {
+  /** Raw status label as reported by the backend (e.g. "waiting"). */
+  label: string;
+  count: number;
+  variant: BadgeVariant;
+}
+
+export interface QueueStatsViewModel {
+  name: string;
+  /** Counts ordered by operational severity (active first, paused last). */
+  counts: QueueCountViewModel[];
+  total: number;
+  failedCount: number;
+  hasFailures: boolean;
+}
+
+export interface JobListItemViewModel {
+  id: string;
+  name: string;
+  status: JobStatus;
+  statusVariant: BadgeVariant;
+  attemptsMade: number;
+  createdAt: Date | null;
+  finishedAt: Date | null;
+  /** Milliseconds between processedOn and finishedOn; null when not finished. */
+  durationMs: number | null;
+  failedReason: string | null;
+}
+
+export interface JobDetailViewModel extends JobListItemViewModel {
+  /** Pretty-printed JSON payload; null when the job carries no data. */
+  payloadJson: string | null;
+  /** Pretty-printed JSON return value; null when absent. */
+  returnValueJson: string | null;
+  /** Numeric progress 0-100; null when absent or structured. */
+  progressPercent: number | null;
+  processedAt: Date | null;
+}

--- a/apps/admin-web/src/features/users/__tests__/users-table.test.tsx
+++ b/apps/admin-web/src/features/users/__tests__/users-table.test.tsx
@@ -36,7 +36,14 @@ const { mockList, mockGetById, mockDelete, mockRolesList } = vi.hoisted(() => ({
 
 // Mock the service layer
 vi.mock('@shared/auth', () => ({
-  useCurrentUser: () => ({ userId: 'user-1', accountId: 'acc-1', roles: ['SUPER_ADMIN'], username: 'admin', email: 'admin@test.dev', expiresAt: Date.now() + 86400000 }),
+  useCurrentUser: () => ({
+    userId: 'user-1',
+    accountId: 'acc-1',
+    roles: ['SUPER_ADMIN'],
+    username: 'admin',
+    email: 'admin@test.dev',
+    expiresAt: Date.now() + 86400000,
+  }),
   useIsAuthenticated: () => true,
   useLogin: () => vi.fn(),
   useLogout: () => vi.fn(),
@@ -255,7 +262,7 @@ describe('UsersTable', () => {
     expect(screen.getByText('users.detailTitle')).toBeInTheDocument();
 
     // Close it
-    fireEvent.click(screen.getByLabelText('users.drawerClose'));
+    fireEvent.click(screen.getByLabelText('common.close'));
 
     // After closing, the backdrop (only rendered when isOpen=true) should be removed
     await waitFor(() => {

--- a/apps/admin-web/src/features/users/components/user-detail-drawer.tsx
+++ b/apps/admin-web/src/features/users/components/user-detail-drawer.tsx
@@ -1,7 +1,8 @@
-import { useCallback,useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useCurrentUser } from '@shared/auth';
-import { Trash2,X } from 'lucide-react';
+import { Drawer } from '@shared/ui/drawer';
+import { Trash2, X } from 'lucide-react';
 
 import { AlertDialog } from '@/shared/ui/alert-dialog';
 
@@ -28,8 +29,6 @@ export function UserDetailDrawer({ userId, onClose }: Props): JSX.Element {
 
   const [selectedRoleId, setSelectedRoleId] = useState('');
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
-
-  const isOpen = userId !== null;
 
   const handleAssignRole = useCallback(() => {
     if (!selectedRoleId || !userId) return;
@@ -68,48 +67,16 @@ export function UserDetailDrawer({ userId, onClose }: Props): JSX.Element {
   }
 
   // Roles that are not assigned to this user (filter out duplicates)
-  const availableRoles =
-    roles?.filter((r) => !data?.roles.includes(r.name)) ?? [];
+  const availableRoles = roles?.filter((r) => !data?.roles.includes(r.name)) ?? [];
 
   return (
     <>
-      {/* Backdrop */}
-      {isOpen && (
-        <div
-          className="fixed inset-0 z-40 bg-black/30"
-          onClick={onClose}
-          onKeyDown={(e) => { if (e.key === 'Escape' || e.key === 'Enter') onClose(); }}
-          aria-hidden="true"
-        />
-      )}
-
-      {/* Drawer */}
-      <div
-        className={`fixed right-0 top-0 z-50 h-full w-96 transform border-l border-outline-variant bg-surface-container-high p-lg shadow-lg transition-transform duration-200 ${
-          isOpen ? 'translate-x-0' : 'translate-x-full'
-        }`}
-      >
-        <div className="mb-lg flex items-center justify-between">
-          <h2 className="text-lg font-semibold text-on-surface">
-            {t('users.detailTitle')}
-          </h2>
-          <button
-            onClick={onClose}
-            className="rounded-sm p-xs text-on-surface-variant hover:bg-surface-container-highest"
-            aria-label={t('users.drawerClose')}
-          >
-            <X size={18} />
-          </button>
-        </div>
-
+      <Drawer open={userId !== null} title={t('users.detailTitle')} onClose={onClose}>
         {/* Loading skeleton */}
         {isLoading && (
           <div className="space-y-sm">
             {Array.from({ length: 6 }).map((_, i) => (
-              <div
-                key={i}
-                className="h-6 animate-pulse rounded-sm bg-surface-container-highest"
-              />
+              <div key={i} className="h-6 animate-pulse rounded-sm bg-surface-container-highest" />
             ))}
           </div>
         )}
@@ -188,7 +155,9 @@ export function UserDetailDrawer({ userId, onClose }: Props): JSX.Element {
                           {roleName}
                           {roleId && (
                             <button
-                              onClick={() => { handleRemoveRole(roleId); }}
+                              onClick={() => {
+                                handleRemoveRole(roleId);
+                              }}
                               className="rounded-sm p-[1px] text-primary/60 hover:bg-primary/20 hover:text-primary"
                               aria-label={t('users.removeRole', { role: roleName })}
                             >
@@ -211,7 +180,9 @@ export function UserDetailDrawer({ userId, onClose }: Props): JSX.Element {
               <div className="flex gap-xs">
                 <select
                   value={selectedRoleId}
-                  onChange={(e) => { setSelectedRoleId(e.target.value); }}
+                  onChange={(e) => {
+                    setSelectedRoleId(e.target.value);
+                  }}
                   className="flex-1 rounded-sm border border-outline-variant bg-surface px-sm py-xs text-body-sm text-on-surface"
                   aria-label={t('users.selectRole')}
                 >
@@ -235,7 +206,9 @@ export function UserDetailDrawer({ userId, onClose }: Props): JSX.Element {
             {/* Actions */}
             <div className="mt-lg border-t border-outline-variant pt-lg">
               <button
-                onClick={() => { setShowDeleteDialog(true); }}
+                onClick={() => {
+                  setShowDeleteDialog(true);
+                }}
                 disabled={isSelf}
                 title={isSelf ? t('users.cannotDeleteSelf') : undefined}
                 className="inline-flex items-center gap-xs rounded-sm px-sm py-xs text-body-sm text-danger transition-colors hover:bg-danger-muted disabled:cursor-not-allowed disabled:opacity-40"
@@ -247,7 +220,7 @@ export function UserDetailDrawer({ userId, onClose }: Props): JSX.Element {
             </div>
           </>
         )}
-      </div>
+      </Drawer>
 
       {/* Delete confirmation */}
       <AlertDialog

--- a/apps/admin-web/src/mocks/handlers.ts
+++ b/apps/admin-web/src/mocks/handlers.ts
@@ -11,18 +11,23 @@ export const handlers = [
   // Auth — POST /api/auth/login
   http.post(`${API_BASE}/auth/login`, async ({ request }) => {
     const body = (await request.json()) as { username: string; password: string };
-    if (body.username === 'admin' && (body.password === 'password' || body.password === 'ChangeMe123')) {
-      return HttpResponse.json(envelope({
-        token: 'mock-jwt-token',
-        refreshToken: 'mock-refresh-token',
-        user: {
-          id: 'mock-user-1',
-          email: 'admin@bazaarsentinel.dev',
-          username: 'admin',
-          accountId: 'mock-account-1',
-          roles: [{ id: '550e8400-e29b-41d4-a716-446655440001', name: 'SUPER_ADMIN' }],
-        },
-      }));
+    if (
+      body.username === 'admin' &&
+      (body.password === 'password' || body.password === 'ChangeMe123')
+    ) {
+      return HttpResponse.json(
+        envelope({
+          token: 'mock-jwt-token',
+          refreshToken: 'mock-refresh-token',
+          user: {
+            id: 'mock-user-1',
+            email: 'admin@bazaarsentinel.dev',
+            username: 'admin',
+            accountId: 'mock-account-1',
+            roles: [{ id: '550e8400-e29b-41d4-a716-446655440001', name: 'SUPER_ADMIN' }],
+          },
+        }),
+      );
     }
     return HttpResponse.json({ status: 'error', message: 'Invalid credentials' }, { status: 401 });
   }),
@@ -31,85 +36,193 @@ export const handlers = [
   http.post(`${API_BASE}/auth/refresh`, async ({ request }) => {
     const body = (await request.json()) as { refreshToken: string };
     if (body.refreshToken) {
-      return HttpResponse.json(envelope({
-        token: 'mock-refreshed-jwt-token',
-        refreshToken: 'mock-refreshed-refresh-token',
-        user: {
-          id: 'mock-user-1',
-          email: 'admin@bazaarsentinel.dev',
-          username: 'admin',
-          accountId: 'mock-account-1',
-          roles: [{ id: '550e8400-e29b-41d4-a716-446655440001', name: 'SUPER_ADMIN' }],
-        },
-      }));
+      return HttpResponse.json(
+        envelope({
+          token: 'mock-refreshed-jwt-token',
+          refreshToken: 'mock-refreshed-refresh-token',
+          user: {
+            id: 'mock-user-1',
+            email: 'admin@bazaarsentinel.dev',
+            username: 'admin',
+            accountId: 'mock-account-1',
+            roles: [{ id: '550e8400-e29b-41d4-a716-446655440001', name: 'SUPER_ADMIN' }],
+          },
+        }),
+      );
     }
-    return HttpResponse.json({ status: 'error', message: 'Invalid refresh token' }, { status: 400 });
+    return HttpResponse.json(
+      { status: 'error', message: 'Invalid refresh token' },
+      { status: 400 },
+    );
   }),
 
   // Admin — GET /api/admin/dashboard
   http.get(`${API_BASE}/admin/dashboard`, () => {
-    return HttpResponse.json(envelope({
-      productCount: 12840,
-      categoriesBreakdown: [
-        { category: 'electronics', count: 4200 },
-        { category: 'vehicles', count: 3100 },
-        { category: 'realestate', count: 2800 },
-        { category: 'services', count: 2740 },
-      ],
-      totalAccounts: 42,
-      totalUsers: 156,
-      activeSubscriptions: 38,
-      recentProducts: [],
-    }));
+    return HttpResponse.json(
+      envelope({
+        productCount: 12840,
+        categoriesBreakdown: [
+          { category: 'electronics', count: 4200 },
+          { category: 'vehicles', count: 3100 },
+          { category: 'realestate', count: 2800 },
+          { category: 'services', count: 2740 },
+        ],
+        totalAccounts: 42,
+        totalUsers: 156,
+        activeSubscriptions: 38,
+        recentProducts: [],
+      }),
+    );
   }),
 
   // Admin — GET /api/admin/dashboard/health
   http.get(`${API_BASE}/admin/dashboard/health`, () => {
-    return HttpResponse.json(envelope({
-      services: [
-        { service: 'mongodb', status: 'connected' },
-        { service: 'postgres', status: 'connected' },
-        { service: 'redis', status: 'connected' },
-      ],
-      timestamp: new Date().toISOString(),
-    }));
+    return HttpResponse.json(
+      envelope({
+        services: [
+          { service: 'mongodb', status: 'connected' },
+          { service: 'postgres', status: 'connected' },
+          { service: 'redis', status: 'connected' },
+        ],
+        timestamp: new Date().toISOString(),
+      }),
+    );
   }),
 
   // Admin — GET /api/admin/dashboard/enrichment
   http.get(`${API_BASE}/admin/dashboard/enrichment`, () => {
-    return HttpResponse.json(envelope({
-      startedAt: new Date().toISOString(),
-      totalEnrichments: 5432,
-      enrichmentHashSkips: 1200,
-      enrichmentHashSkipRate: 0.22,
-      ruleHighConfidence: 3400,
-      ruleHighConfidenceRate: 0.78,
-      cacheHits: 3800,
-      cacheMisses: 567,
-      cacheHitRate: 0.87,
-      llmCalls: 342,
-      llmFailures: 12,
-      llmFailureRate: 0.035,
-      llmPromptCacheHitTokens: 450000,
-      llmPromptCacheMissTokens: 120000,
-      llmCompletionTokens: 890000,
-      llmCacheHitRate: 0.35,
-      estimatedSavingsUSD: 342.50,
-      costPerMillionTokens: 15.0,
-    }));
+    return HttpResponse.json(
+      envelope({
+        startedAt: new Date().toISOString(),
+        totalEnrichments: 5432,
+        enrichmentHashSkips: 1200,
+        enrichmentHashSkipRate: 0.22,
+        ruleHighConfidence: 3400,
+        ruleHighConfidenceRate: 0.78,
+        cacheHits: 3800,
+        cacheMisses: 567,
+        cacheHitRate: 0.87,
+        llmCalls: 342,
+        llmFailures: 12,
+        llmFailureRate: 0.035,
+        llmPromptCacheHitTokens: 450000,
+        llmPromptCacheMissTokens: 120000,
+        llmCompletionTokens: 890000,
+        llmCacheHitRate: 0.35,
+        estimatedSavingsUSD: 342.5,
+        costPerMillionTokens: 15.0,
+      }),
+    );
   }),
 
   // Admin — GET /api/admin/accounts
   http.get(`${API_BASE}/admin/accounts`, () => {
-    return HttpResponse.json(envelope({
-      accounts: [
-        { id: '1', name: 'Acme Corp', userCount: 12, subscriptionCount: 2, alarmCount: 5, createdAt: '2024-01-15T10:30:00Z', updatedAt: '2024-06-01T10:30:00Z' },
-        { id: '2', name: 'Globex Inc', userCount: 3, subscriptionCount: 1, alarmCount: 0, createdAt: '2024-03-20T10:30:00Z', updatedAt: '2024-05-10T10:30:00Z' },
-        { id: '3', name: 'Initech', userCount: 0, subscriptionCount: 0, alarmCount: 0, createdAt: '2023-11-01T10:30:00Z', updatedAt: '2024-07-01T10:30:00Z' },
-      ],
-      total: 3,
-      skip: 0,
-      limit: 20,
-    }));
+    return HttpResponse.json(
+      envelope({
+        accounts: [
+          {
+            id: '1',
+            name: 'Acme Corp',
+            userCount: 12,
+            subscriptionCount: 2,
+            alarmCount: 5,
+            createdAt: '2024-01-15T10:30:00Z',
+            updatedAt: '2024-06-01T10:30:00Z',
+          },
+          {
+            id: '2',
+            name: 'Globex Inc',
+            userCount: 3,
+            subscriptionCount: 1,
+            alarmCount: 0,
+            createdAt: '2024-03-20T10:30:00Z',
+            updatedAt: '2024-05-10T10:30:00Z',
+          },
+          {
+            id: '3',
+            name: 'Initech',
+            userCount: 0,
+            subscriptionCount: 0,
+            alarmCount: 0,
+            createdAt: '2023-11-01T10:30:00Z',
+            updatedAt: '2024-07-01T10:30:00Z',
+          },
+        ],
+        total: 3,
+        skip: 0,
+        limit: 20,
+      }),
+    );
+  }),
+
+  // Admin — GET /api/admin/queues/stats
+  http.get(`${API_BASE}/admin/queues/stats`, () => {
+    return HttpResponse.json(
+      envelope({
+        queues: [
+          {
+            queueName: 'PRODUCTS_SCRAPING',
+            counts: { waiting: 3, active: 1, completed: 1240, failed: 2, delayed: 0 },
+          },
+          {
+            queueName: 'PRODUCT_STORAGE',
+            counts: { waiting: 0, active: 0, completed: 5321, failed: 0, delayed: 0 },
+          },
+          {
+            queueName: 'EMAIL_SEND_JOB',
+            counts: { waiting: 1, active: 0, completed: 89, failed: 1, delayed: 2 },
+          },
+        ],
+      }),
+    );
+  }),
+
+  // Admin — GET /api/admin/queues/:name/jobs
+  http.get(`${API_BASE}/admin/queues/:name/jobs`, () => {
+    return HttpResponse.json(
+      envelope({
+        jobs: [
+          {
+            id: '101',
+            name: 'scrape-category',
+            status: 'completed',
+            attemptsMade: 1,
+            timestamp: 1752700000000,
+            processedOn: 1752700001000,
+            finishedOn: 1752700009000,
+            data: { url: 'https://revolico.com/categoria/celulares' },
+          },
+          {
+            id: '102',
+            name: 'scrape-category',
+            status: 'failed',
+            attemptsMade: 3,
+            timestamp: 1752700100000,
+            processedOn: 1752700101000,
+            finishedOn: 1752700105000,
+            failedReason: 'Navigation timeout of 30000 ms exceeded',
+            data: { url: 'https://revolico.com/categoria/autos' },
+          },
+        ],
+      }),
+    );
+  }),
+
+  // Admin — GET /api/admin/queues/:name/jobs/:id
+  http.get(`${API_BASE}/admin/queues/:name/jobs/:id`, ({ params }) => {
+    return HttpResponse.json(
+      envelope({
+        id: String(params.id),
+        name: 'scrape-category',
+        status: 'failed',
+        attemptsMade: 3,
+        timestamp: 1752700100000,
+        processedOn: 1752700101000,
+        finishedOn: 1752700105000,
+        failedReason: 'Navigation timeout of 30000 ms exceeded',
+        data: { url: 'https://revolico.com/categoria/autos', pages: 5 },
+        returnValue: null,
+      }),
+    );
   }),
 ];

--- a/apps/admin-web/src/pages/not-found-page.tsx
+++ b/apps/admin-web/src/pages/not-found-page.tsx
@@ -1,0 +1,27 @@
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
+import { ROUTES } from '@shared/config/routes';
+import { SearchX } from 'lucide-react';
+
+/** Design-system 404 view (admin-web-ui.md section 4.3): icon, title, description, CTA. */
+export function NotFoundPage(): JSX.Element {
+  const { t } = useTranslation();
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-surface">
+      <div className="text-center">
+        <SearchX size={48} className="mx-auto text-on-surface-variant" aria-hidden="true" />
+        <h1 className="mt-4 text-headline-lg font-semibold text-on-surface">
+          {t('common.notFound')}
+        </h1>
+        <p className="mt-sm text-body-md text-on-surface-variant">{t('common.notFoundDesc')}</p>
+        <Link
+          to={ROUTES.DASHBOARD}
+          className="mt-md inline-flex items-center rounded-sm bg-primary px-md py-sm text-body-sm font-medium text-on-primary transition-colors hover:opacity-90"
+        >
+          {t('common.goToDashboard', 'Go to dashboard')}
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin-web/src/pages/queues-page.tsx
+++ b/apps/admin-web/src/pages/queues-page.tsx
@@ -1,8 +1,18 @@
+import { useTranslation } from 'react-i18next';
+import { QueuesDashboard } from '@features/queues';
+
 export function QueuesPage(): JSX.Element {
+  const { t } = useTranslation();
+
   return (
-    <div>
-      <h1 className="text-headline-lg text-on-surface">Queues</h1>
-      <p className="mt-md text-body-md text-on-surface-variant">Queue monitoring will appear here.</p>
+    <div className="space-y-md">
+      <div>
+        <h1 className="text-headline-lg text-on-surface">{t('nav.queues', 'Queues')}</h1>
+        <p className="mt-xs text-body-md text-on-surface-variant">
+          {t('queues.description', 'Monitor BullMQ queues: job counts, recent jobs and failures.')}
+        </p>
+      </div>
+      <QueuesDashboard />
     </div>
   );
 }

--- a/apps/admin-web/src/shared/api/__tests__/query-client.test.tsx
+++ b/apps/admin-web/src/shared/api/__tests__/query-client.test.tsx
@@ -1,0 +1,42 @@
+import type { ReactNode } from 'react';
+import { describe, expect, it } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { NotificationInput } from '@shared/notifications';
+import { subscribeToNotifications } from '@shared/notifications';
+import { QueryClientProvider, useMutation } from '@tanstack/react-query';
+
+import { createAppQueryClient } from '../query-client';
+
+describe('createAppQueryClient', () => {
+  it('publishes an error notification when any mutation fails', async () => {
+    const received: NotificationInput[] = [];
+    const unsubscribe = subscribeToNotifications((n) => {
+      received.push(n);
+    });
+
+    const queryClient = createAppQueryClient();
+    function wrapper({ children }: { children: ReactNode }): JSX.Element {
+      return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+    }
+
+    const { result } = renderHook(
+      () =>
+        useMutation({
+          mutationFn: () => {
+            throw new Error('boom');
+          },
+        }),
+      { wrapper },
+    );
+
+    result.current.mutate();
+
+    await waitFor(() => {
+      expect(received).toHaveLength(1);
+    });
+    expect(received[0].severity).toBe('error');
+    expect(received[0].description).toBe('boom');
+
+    unsubscribe();
+  });
+});

--- a/apps/admin-web/src/shared/api/query-client.ts
+++ b/apps/admin-web/src/shared/api/query-client.ts
@@ -1,0 +1,31 @@
+import i18n from '@shared/i18n/i18n';
+import { publishNotification } from '@shared/notifications';
+import { MutationCache, QueryClient } from '@tanstack/react-query';
+
+/**
+ * Builds the app-wide QueryClient.
+ *
+ * Every mutation error is also pushed to the Notification Center via the
+ * notification bus, so failures stay visible after their toast disappears.
+ * Per-hook onError handlers (retry toasts) keep working — both fire.
+ * @returns Configured QueryClient instance.
+ */
+export function createAppQueryClient(): QueryClient {
+  return new QueryClient({
+    mutationCache: new MutationCache({
+      onError: (error) => {
+        publishNotification({
+          title: i18n.t('notifications.mutationFailedTitle'),
+          description: error instanceof Error ? error.message : String(error),
+          severity: 'error',
+        });
+      },
+    }),
+    defaultOptions: {
+      queries: {
+        staleTime: 30_000,
+        retry: 1,
+      },
+    },
+  });
+}

--- a/apps/admin-web/src/shared/command-palette/__tests__/command-palette.test.tsx
+++ b/apps/admin-web/src/shared/command-palette/__tests__/command-palette.test.tsx
@@ -1,0 +1,134 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, useLocation } from 'react-router-dom';
+
+import { CommandPalette } from '../command-palette';
+import { CommandPaletteProvider } from '../command-palette-context';
+
+// cmdk requires both scrollIntoView and ResizeObserver — jsdom does not implement either
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn();
+  globalThis.ResizeObserver = vi.fn().mockImplementation(() => ({
+    observe: vi.fn(),
+    unobserve: vi.fn(),
+    disconnect: vi.fn(),
+  })) as typeof ResizeObserver;
+});
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, defaultVal?: string | Record<string, unknown>): string => {
+      if (typeof defaultVal === 'string') return defaultVal;
+      return key;
+    },
+  }),
+}));
+
+const mockState = vi.hoisted(() => ({ allowAll: true }));
+
+// Provide a standalone Permission stub so nav-items.ts resolves without the real module.
+vi.mock('@shared/permissions', () => ({
+  Permission: {
+    VIEW_DASHBOARD: 'dashboard:view',
+    VIEW_ACCOUNTS: 'accounts:view',
+    VIEW_USERS: 'users:view',
+    VIEW_ROLES: 'roles:view',
+    VIEW_PRODUCTS: 'products:view',
+    VIEW_SCRAPERS: 'scrapers:view',
+    VIEW_RULES: 'rules:view',
+    VIEW_QUEUES: 'queues:view',
+    VIEW_SETTINGS: 'settings:view',
+  },
+  useHasPermission:
+    () =>
+    (p: unknown): boolean =>
+      mockState.allowAll ? true : p === 'dashboard:view',
+}));
+
+vi.mock('@shared/auth', () => ({
+  useLogout: () => vi.fn(),
+}));
+
+function LocationProbe(): JSX.Element {
+  const location = useLocation();
+  return <div data-testid="location">{location.pathname}</div>;
+}
+
+function renderPalette(): void {
+  render(
+    <MemoryRouter>
+      <CommandPaletteProvider>
+        <CommandPalette />
+        <LocationProbe />
+      </CommandPaletteProvider>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  mockState.allowAll = true;
+});
+
+describe('CommandPalette', () => {
+  it('opens with Ctrl+K and shows navigation items', async () => {
+    const user = userEvent.setup();
+    renderPalette();
+
+    expect(screen.queryByPlaceholderText('Type a command or search…')).not.toBeInTheDocument();
+
+    await user.keyboard('{Control>}k{/Control}');
+
+    expect(await screen.findByPlaceholderText('Type a command or search…')).toBeInTheDocument();
+    expect(screen.getByText('nav.dashboard')).toBeInTheDocument();
+    expect(screen.getByText('nav.queues')).toBeInTheDocument();
+    expect(screen.getByText('Sign out')).toBeInTheDocument();
+  });
+
+  it('filters items while typing', async () => {
+    const user = userEvent.setup();
+    renderPalette();
+
+    await user.keyboard('{Control>}k{/Control}');
+    await user.type(screen.getByPlaceholderText('Type a command or search…'), 'rules');
+
+    await waitFor(() => {
+      expect(screen.queryByText('nav.accounts')).not.toBeInTheDocument();
+    });
+    expect(screen.getByText('nav.rules')).toBeInTheDocument();
+  });
+
+  it('navigates and closes when an item is selected', async () => {
+    const user = userEvent.setup();
+    renderPalette();
+
+    await user.keyboard('{Control>}k{/Control}');
+    await user.click(await screen.findByText('nav.queues'));
+
+    expect(screen.getByTestId('location').textContent).toBe('/queues');
+    expect(screen.queryByPlaceholderText('Type a command or search…')).not.toBeInTheDocument();
+  });
+
+  it('closes with Escape', async () => {
+    const user = userEvent.setup();
+    renderPalette();
+
+    await user.keyboard('{Control>}k{/Control}');
+    await screen.findByPlaceholderText('Type a command or search…');
+    await user.keyboard('{Escape}');
+
+    expect(screen.queryByPlaceholderText('Type a command or search…')).not.toBeInTheDocument();
+  });
+
+  it('hides navigation items the user has no permission for', async () => {
+    mockState.allowAll = false;
+    const user = userEvent.setup();
+    renderPalette();
+
+    await user.keyboard('{Control>}k{/Control}');
+
+    expect(await screen.findByText('nav.dashboard')).toBeInTheDocument();
+    expect(screen.queryByText('nav.users')).not.toBeInTheDocument();
+    expect(screen.queryByText('nav.queues')).not.toBeInTheDocument();
+  });
+});

--- a/apps/admin-web/src/shared/command-palette/command-palette-context.tsx
+++ b/apps/admin-web/src/shared/command-palette/command-palette-context.tsx
@@ -1,0 +1,53 @@
+import {
+  createContext,
+  type Dispatch,
+  type ReactNode,
+  type SetStateAction,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+
+interface CommandPaletteContextValue {
+  open: boolean;
+  setOpen: Dispatch<SetStateAction<boolean>>;
+}
+
+const CommandPaletteContext = createContext<CommandPaletteContextValue | null>(null);
+
+/** Owns the palette open state and the global ⌘K / Ctrl+K hotkey. */
+export function CommandPaletteProvider({ children }: { children: ReactNode }): JSX.Element {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    function onKeyDown(e: globalThis.KeyboardEvent): void {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+        e.preventDefault();
+        setOpen((prev) => !prev);
+      }
+    }
+    window.addEventListener('keydown', onKeyDown);
+    return () => {
+      window.removeEventListener('keydown', onKeyDown);
+    };
+  }, []);
+
+  const value = useMemo(() => ({ open, setOpen }), [open]);
+
+  return <CommandPaletteContext.Provider value={value}>{children}</CommandPaletteContext.Provider>;
+}
+
+/**
+ * Access the command palette open state.
+ * @returns Context value with the open flag and its setter.
+ * @throws Error when rendered outside a CommandPaletteProvider.
+ */
+// eslint-disable-next-line react-refresh/only-export-components
+export function useCommandPalette(): CommandPaletteContextValue {
+  const ctx = useContext(CommandPaletteContext);
+  if (!ctx) {
+    throw new Error('useCommandPalette must be used within CommandPaletteProvider');
+  }
+  return ctx;
+}

--- a/apps/admin-web/src/shared/command-palette/command-palette.tsx
+++ b/apps/admin-web/src/shared/command-palette/command-palette.tsx
@@ -1,0 +1,121 @@
+import { type KeyboardEvent, useCallback, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+import { useLogout } from '@shared/auth';
+import { NAV_ITEMS, type NavItem } from '@shared/config/nav-items';
+import { ROUTES } from '@shared/config/routes';
+import { useHasPermission } from '@shared/permissions';
+import { Command } from 'cmdk';
+import { LogOut } from 'lucide-react';
+
+import { useCommandPalette } from './command-palette-context';
+
+const ITEM_CLASSES =
+  'flex cursor-pointer items-center gap-sm rounded-sm px-sm py-xs text-body-sm text-on-surface data-[selected=true]:bg-surface-container-highest';
+
+/** ⌘K command palette: permission-filtered navigation plus quick actions. */
+export function CommandPalette(): JSX.Element | null {
+  const { t } = useTranslation();
+  const { open, setOpen } = useCommandPalette();
+  const navigate = useNavigate();
+  const logout = useLogout();
+  const hasPermission = useHasPermission();
+
+  const handleClose = useCallback(() => {
+    setOpen(false);
+  }, [setOpen]);
+
+  const handleNavigate = useCallback(
+    (path: string) => {
+      navigate(path);
+      setOpen(false);
+    },
+    [navigate, setOpen],
+  );
+
+  const handleSignOut = useCallback(() => {
+    logout();
+    window.location.href = ROUTES.LOGIN;
+  }, [logout]);
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLDivElement>) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        setOpen(false);
+      }
+    },
+    [setOpen],
+  );
+
+  const visibleItems = useMemo(
+    () => NAV_ITEMS.filter((item) => item.permissions.some(hasPermission)),
+    [hasPermission],
+  );
+
+  if (!open) return null;
+
+  return (
+    <>
+      <div className="fixed inset-0 z-50 bg-black/30" role="presentation" onClick={handleClose} />
+      <div
+        className="fixed left-1/2 top-[20%] z-50 w-full max-w-lg -translate-x-1/2"
+        onKeyDown={handleKeyDown}
+        role="presentation"
+      >
+        <Command
+          label={t('palette.label', 'Command palette')}
+          className="overflow-hidden rounded-md border border-outline-variant bg-surface-container-high shadow-lg"
+        >
+          {/* eslint-disable-next-line jsx-a11y/no-autofocus */}
+          <Command.Input
+            autoFocus
+            placeholder={t('palette.placeholder', 'Type a command or search…')}
+            className="w-full border-b border-outline-variant bg-transparent px-md py-sm text-body-md text-on-surface outline-none placeholder:text-on-surface-variant"
+          />
+          <Command.List className="max-h-72 overflow-y-auto p-xs [&_[cmdk-group-heading]]:px-sm [&_[cmdk-group-heading]]:py-xs [&_[cmdk-group-heading]]:font-mono [&_[cmdk-group-heading]]:text-label-xs [&_[cmdk-group-heading]]:text-on-surface-variant">
+            <Command.Empty className="p-md text-center text-body-sm text-on-surface-variant">
+              {t('palette.empty', 'No results found.')}
+            </Command.Empty>
+            <Command.Group heading={t('palette.navigation', 'Navigation')}>
+              {visibleItems.map((item) => (
+                <PaletteNavItem key={item.path} item={item} onNavigate={handleNavigate} />
+              ))}
+            </Command.Group>
+            <Command.Group heading={t('palette.actions', 'Actions')}>
+              <Command.Item
+                value={t('palette.signOut', 'Sign out')}
+                onSelect={handleSignOut}
+                className={ITEM_CLASSES}
+              >
+                <LogOut size={16} aria-hidden="true" />
+                {t('palette.signOut', 'Sign out')}
+              </Command.Item>
+            </Command.Group>
+          </Command.List>
+        </Command>
+      </div>
+    </>
+  );
+}
+
+interface PaletteNavItemProps {
+  item: NavItem;
+  onNavigate: (path: string) => void;
+}
+
+function PaletteNavItem({ item, onNavigate }: PaletteNavItemProps): JSX.Element {
+  const { t } = useTranslation();
+  const handleSelect = useCallback(() => {
+    onNavigate(item.path);
+  }, [onNavigate, item.path]);
+
+  const Icon = item.icon;
+
+  return (
+    <Command.Item value={t(item.labelKey)} onSelect={handleSelect} className={ITEM_CLASSES}>
+      <Icon size={16} aria-hidden="true" />
+      {t(item.labelKey)}
+    </Command.Item>
+  );
+}

--- a/apps/admin-web/src/shared/command-palette/command-palette.tsx
+++ b/apps/admin-web/src/shared/command-palette/command-palette.tsx
@@ -1,4 +1,4 @@
-import { type KeyboardEvent, useCallback, useMemo } from 'react';
+import { type KeyboardEvent, useCallback, useEffect, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { useLogout } from '@shared/auth';
@@ -20,6 +20,24 @@ export function CommandPalette(): JSX.Element | null {
   const navigate = useNavigate();
   const logout = useLogout();
   const hasPermission = useHasPermission();
+
+  const paletteRef = useRef<HTMLDivElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  // Store the currently focused element before opening
+  useEffect(() => {
+    if (open) {
+      previousFocusRef.current = document.activeElement as HTMLElement;
+    }
+  }, [open]);
+
+  // Restore focus on close
+  useEffect(() => {
+    if (!open && previousFocusRef.current) {
+      previousFocusRef.current.focus();
+      previousFocusRef.current = null;
+    }
+  }, [open]);
 
   const handleClose = useCallback(() => {
     setOpen(false);
@@ -43,6 +61,33 @@ export function CommandPalette(): JSX.Element | null {
       if (e.key === 'Escape') {
         e.stopPropagation();
         setOpen(false);
+        return;
+      }
+
+      // Focus trap: Tab / Shift+Tab
+      if (e.key === 'Tab' && paletteRef.current) {
+        const focusableSelector =
+          'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
+        const focusableElements =
+          paletteRef.current.querySelectorAll<HTMLElement>(focusableSelector);
+        if (focusableElements.length === 0) {
+          e.preventDefault();
+          return;
+        }
+        const first = focusableElements[0];
+        const last = focusableElements[focusableElements.length - 1];
+
+        if (e.shiftKey) {
+          if (document.activeElement === first) {
+            e.preventDefault();
+            last.focus();
+          }
+        } else {
+          if (document.activeElement === last) {
+            e.preventDefault();
+            first.focus();
+          }
+        }
       }
     },
     [setOpen],
@@ -59,6 +104,7 @@ export function CommandPalette(): JSX.Element | null {
     <>
       <div className="fixed inset-0 z-50 bg-black/30" role="presentation" onClick={handleClose} />
       <div
+        ref={paletteRef}
         className="fixed left-1/2 top-[20%] z-50 w-full max-w-lg -translate-x-1/2"
         onKeyDown={handleKeyDown}
         role="presentation"

--- a/apps/admin-web/src/shared/command-palette/command-palette.tsx
+++ b/apps/admin-web/src/shared/command-palette/command-palette.tsx
@@ -68,6 +68,7 @@ export function CommandPalette(): JSX.Element | null {
           className="overflow-hidden rounded-md border border-outline-variant bg-surface-container-high shadow-lg"
         >
           <Command.Input
+            // eslint-disable-next-line jsx-a11y/no-autofocus
             autoFocus
             placeholder={t('palette.placeholder', 'Type a command or search…')}
             className="w-full border-b border-outline-variant bg-transparent px-md py-sm text-body-md text-on-surface outline-none placeholder:text-on-surface-variant"

--- a/apps/admin-web/src/shared/command-palette/command-palette.tsx
+++ b/apps/admin-web/src/shared/command-palette/command-palette.tsx
@@ -67,7 +67,6 @@ export function CommandPalette(): JSX.Element | null {
           label={t('palette.label', 'Command palette')}
           className="overflow-hidden rounded-md border border-outline-variant bg-surface-container-high shadow-lg"
         >
-          {/* eslint-disable-next-line jsx-a11y/no-autofocus */}
           <Command.Input
             autoFocus
             placeholder={t('palette.placeholder', 'Type a command or search…')}

--- a/apps/admin-web/src/shared/command-palette/index.ts
+++ b/apps/admin-web/src/shared/command-palette/index.ts
@@ -1,0 +1,2 @@
+export { CommandPalette } from './command-palette';
+export { CommandPaletteProvider, useCommandPalette } from './command-palette-context';

--- a/apps/admin-web/src/shared/config/nav-items.ts
+++ b/apps/admin-web/src/shared/config/nav-items.ts
@@ -1,0 +1,54 @@
+import { ROUTES } from '@shared/config/routes';
+import { Permission } from '@shared/permissions';
+import type { LucideIcon } from 'lucide-react';
+import { BarChart3, Bell, Cog, Database, Layers, Search, Shield, Users } from 'lucide-react';
+
+export interface NavItem {
+  labelKey: string;
+  path: string;
+  icon: LucideIcon;
+  permissions: Permission[];
+}
+
+/** Single source of truth for app navigation — consumed by SideNav and the command palette. */
+export const NAV_ITEMS: readonly NavItem[] = [
+  {
+    labelKey: 'nav.dashboard',
+    path: ROUTES.DASHBOARD,
+    icon: BarChart3,
+    permissions: [Permission.VIEW_DASHBOARD],
+  },
+  {
+    labelKey: 'nav.accounts',
+    path: ROUTES.ACCOUNTS,
+    icon: Database,
+    permissions: [Permission.VIEW_ACCOUNTS],
+  },
+  { labelKey: 'nav.users', path: ROUTES.USERS, icon: Users, permissions: [Permission.VIEW_USERS] },
+  { labelKey: 'nav.roles', path: ROUTES.ROLES, icon: Shield, permissions: [Permission.VIEW_ROLES] },
+  {
+    labelKey: 'nav.products',
+    path: ROUTES.PRODUCTS,
+    icon: Search,
+    permissions: [Permission.VIEW_PRODUCTS],
+  },
+  {
+    labelKey: 'nav.scrapers',
+    path: ROUTES.SCRAPERS,
+    icon: Bell,
+    permissions: [Permission.VIEW_SCRAPERS],
+  },
+  { labelKey: 'nav.rules', path: ROUTES.RULES, icon: Layers, permissions: [Permission.VIEW_RULES] },
+  {
+    labelKey: 'nav.queues',
+    path: ROUTES.QUEUES,
+    icon: BarChart3,
+    permissions: [Permission.VIEW_QUEUES],
+  },
+  {
+    labelKey: 'nav.settings',
+    path: ROUTES.SETTINGS,
+    icon: Cog,
+    permissions: [Permission.VIEW_SETTINGS],
+  },
+];

--- a/apps/admin-web/src/shared/i18n/locales/en.json
+++ b/apps/admin-web/src/shared/i18n/locales/en.json
@@ -24,6 +24,12 @@
     "queues": "Queues",
     "settings": "Settings"
   },
+  "notifications": {
+    "title": "Notifications",
+    "open": "Open notifications",
+    "markAllRead": "Mark all as read",
+    "empty": "No notifications"
+  },
   "common": {
     "notFound": "404 — Not Found",
     "notFoundDesc": "This page does not exist.",

--- a/apps/admin-web/src/shared/i18n/locales/en.json
+++ b/apps/admin-web/src/shared/i18n/locales/en.json
@@ -35,6 +35,34 @@
     "next": "Next",
     "close": "Close"
   },
+  "queues": {
+    "cards": {
+      "total": "total",
+      "error": "Failed to load queue stats",
+      "empty": {
+        "title": "No queues registered",
+        "description": "Queues appear here once the backend registers them."
+      }
+    },
+    "jobs": {
+      "hint": "Select a queue to inspect its recent jobs.",
+      "caption": "Recent jobs for the selected queue",
+      "filterLabel": "Status",
+      "all": "All statuses",
+      "id": "Job ID",
+      "name": "Name",
+      "status": "Status",
+      "attempts": "Attempts",
+      "created": "Created",
+      "duration": "Duration",
+      "failedReason": "Failure reason",
+      "error": "Failed to load jobs",
+      "empty": {
+        "title": "No jobs",
+        "description": "No recent jobs match the current filter."
+      }
+    }
+  },
   "scrapers": {
     "stores": {
       "empty": {

--- a/apps/admin-web/src/shared/i18n/locales/en.json
+++ b/apps/admin-web/src/shared/i18n/locales/en.json
@@ -34,6 +34,15 @@
     "serviceRecovered": "Service {{service}} recovered",
     "jobsFailed": "{{count}} job(s) failed in {{queue}}"
   },
+  "palette": {
+    "label": "Command palette",
+    "open": "Open command palette",
+    "placeholder": "Type a command or search…",
+    "empty": "No results found.",
+    "navigation": "Navigation",
+    "actions": "Actions",
+    "signOut": "Sign out"
+  },
   "common": {
     "notFound": "404 — Not Found",
     "notFoundDesc": "This page does not exist.",

--- a/apps/admin-web/src/shared/i18n/locales/en.json
+++ b/apps/admin-web/src/shared/i18n/locales/en.json
@@ -32,7 +32,8 @@
     "retry": "Retry",
     "noData": "No data available",
     "prev": "Prev",
-    "next": "Next"
+    "next": "Next",
+    "close": "Close"
   },
   "scrapers": {
     "stores": {

--- a/apps/admin-web/src/shared/i18n/locales/en.json
+++ b/apps/admin-web/src/shared/i18n/locales/en.json
@@ -28,7 +28,11 @@
     "title": "Notifications",
     "open": "Open notifications",
     "markAllRead": "Mark all as read",
-    "empty": "No notifications"
+    "empty": "No notifications",
+    "mutationFailedTitle": "Operation failed",
+    "serviceDown": "Service {{service}} is down",
+    "serviceRecovered": "Service {{service}} recovered",
+    "jobsFailed": "{{count}} job(s) failed in {{queue}}"
   },
   "common": {
     "notFound": "404 — Not Found",

--- a/apps/admin-web/src/shared/i18n/locales/en.json
+++ b/apps/admin-web/src/shared/i18n/locales/en.json
@@ -36,6 +36,18 @@
     "close": "Close"
   },
   "queues": {
+    "description": "Monitor BullMQ queues: job counts, recent jobs and failures.",
+    "drawer": {
+      "title": "Job detail",
+      "error": "Failed to load job detail",
+      "createdAt": "Created at",
+      "processedAt": "Processed at",
+      "finishedAt": "Finished at",
+      "progress": "Progress",
+      "payload": "Payload",
+      "returnValue": "Return value",
+      "none": "—"
+    },
     "cards": {
       "total": "total",
       "error": "Failed to load queue stats",

--- a/apps/admin-web/src/shared/i18n/locales/en.json
+++ b/apps/admin-web/src/shared/i18n/locales/en.json
@@ -46,6 +46,7 @@
   "common": {
     "notFound": "404 — Not Found",
     "notFoundDesc": "This page does not exist.",
+    "goToDashboard": "Go to dashboard",
     "loading": "Loading…",
     "error": "Something went wrong",
     "retry": "Retry",

--- a/apps/admin-web/src/shared/i18n/locales/es.json
+++ b/apps/admin-web/src/shared/i18n/locales/es.json
@@ -36,6 +36,18 @@
     "close": "Cerrar"
   },
   "queues": {
+    "description": "Monitorea las colas BullMQ: conteos, jobs recientes y fallos.",
+    "drawer": {
+      "title": "Detalle del job",
+      "error": "No se pudo cargar el detalle del job",
+      "createdAt": "Creado",
+      "processedAt": "Procesado",
+      "finishedAt": "Finalizado",
+      "progress": "Progreso",
+      "payload": "Payload",
+      "returnValue": "Valor de retorno",
+      "none": "—"
+    },
     "cards": {
       "total": "total",
       "error": "No se pudieron cargar las estadísticas de colas",

--- a/apps/admin-web/src/shared/i18n/locales/es.json
+++ b/apps/admin-web/src/shared/i18n/locales/es.json
@@ -24,6 +24,12 @@
     "queues": "Colas",
     "settings": "Configuración"
   },
+  "notifications": {
+    "title": "Notificaciones",
+    "open": "Abrir notificaciones",
+    "markAllRead": "Marcar todas como leídas",
+    "empty": "Sin notificaciones"
+  },
   "common": {
     "notFound": "404 — No Encontrado",
     "notFoundDesc": "Esta página no existe.",

--- a/apps/admin-web/src/shared/i18n/locales/es.json
+++ b/apps/admin-web/src/shared/i18n/locales/es.json
@@ -28,7 +28,11 @@
     "title": "Notificaciones",
     "open": "Abrir notificaciones",
     "markAllRead": "Marcar todas como leídas",
-    "empty": "Sin notificaciones"
+    "empty": "Sin notificaciones",
+    "mutationFailedTitle": "Operación fallida",
+    "serviceDown": "El servicio {{service}} está caído",
+    "serviceRecovered": "El servicio {{service}} se recuperó",
+    "jobsFailed": "{{count}} job(s) fallidos en {{queue}}"
   },
   "common": {
     "notFound": "404 — No Encontrado",

--- a/apps/admin-web/src/shared/i18n/locales/es.json
+++ b/apps/admin-web/src/shared/i18n/locales/es.json
@@ -46,6 +46,7 @@
   "common": {
     "notFound": "404 — No Encontrado",
     "notFoundDesc": "Esta página no existe.",
+    "goToDashboard": "Ir al dashboard",
     "loading": "Cargando…",
     "error": "Algo salió mal",
     "retry": "Reintentar",

--- a/apps/admin-web/src/shared/i18n/locales/es.json
+++ b/apps/admin-web/src/shared/i18n/locales/es.json
@@ -32,7 +32,8 @@
     "retry": "Reintentar",
     "noData": "Sin datos disponibles",
     "prev": "Anterior",
-    "next": "Siguiente"
+    "next": "Siguiente",
+    "close": "Cerrar"
   },
   "scrapers": {
     "stores": {

--- a/apps/admin-web/src/shared/i18n/locales/es.json
+++ b/apps/admin-web/src/shared/i18n/locales/es.json
@@ -34,6 +34,15 @@
     "serviceRecovered": "El servicio {{service}} se recuperó",
     "jobsFailed": "{{count}} job(s) fallidos en {{queue}}"
   },
+  "palette": {
+    "label": "Paleta de comandos",
+    "open": "Abrir paleta de comandos",
+    "placeholder": "Escribe un comando o busca…",
+    "empty": "Sin resultados.",
+    "navigation": "Navegación",
+    "actions": "Acciones",
+    "signOut": "Cerrar sesión"
+  },
   "common": {
     "notFound": "404 — No Encontrado",
     "notFoundDesc": "Esta página no existe.",

--- a/apps/admin-web/src/shared/i18n/locales/es.json
+++ b/apps/admin-web/src/shared/i18n/locales/es.json
@@ -35,6 +35,34 @@
     "next": "Siguiente",
     "close": "Cerrar"
   },
+  "queues": {
+    "cards": {
+      "total": "total",
+      "error": "No se pudieron cargar las estadísticas de colas",
+      "empty": {
+        "title": "Sin colas registradas",
+        "description": "Las colas aparecerán aquí cuando el backend las registre."
+      }
+    },
+    "jobs": {
+      "hint": "Selecciona una cola para inspeccionar sus jobs recientes.",
+      "caption": "Jobs recientes de la cola seleccionada",
+      "filterLabel": "Estado",
+      "all": "Todos los estados",
+      "id": "ID del job",
+      "name": "Nombre",
+      "status": "Estado",
+      "attempts": "Intentos",
+      "created": "Creado",
+      "duration": "Duración",
+      "failedReason": "Motivo del fallo",
+      "error": "No se pudieron cargar los jobs",
+      "empty": {
+        "title": "Sin jobs",
+        "description": "Ningún job reciente coincide con el filtro actual."
+      }
+    }
+  },
   "scrapers": {
     "stores": {
       "empty": {

--- a/apps/admin-web/src/shared/notifications/__tests__/notification-provider.test.tsx
+++ b/apps/admin-web/src/shared/notifications/__tests__/notification-provider.test.tsx
@@ -1,0 +1,89 @@
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+
+import { publishNotification } from '../notification-bus';
+import { NotificationProvider } from '../notification-provider';
+import { useNotifications } from '../useNotifications';
+
+function wrapper({ children }: { children: ReactNode }): JSX.Element {
+  return <NotificationProvider>{children}</NotificationProvider>;
+}
+
+describe('NotificationProvider', () => {
+  it('notify() prepends an unread notification with defaults', () => {
+    const { result } = renderHook(() => useNotifications(), { wrapper });
+
+    act(() => {
+      result.current.notify({ title: 'First' });
+      result.current.notify({ title: 'Second', severity: 'error' });
+    });
+
+    expect(result.current.notifications).toHaveLength(2);
+    expect(result.current.notifications[0].title).toBe('Second');
+    expect(result.current.notifications[0].severity).toBe('error');
+    expect(result.current.notifications[1].severity).toBe('info');
+    expect(result.current.unreadCount).toBe(2);
+  });
+
+  it('markRead() and markAllRead() update unreadCount', () => {
+    const { result } = renderHook(() => useNotifications(), { wrapper });
+
+    act(() => {
+      result.current.notify({ title: 'A' });
+      result.current.notify({ title: 'B' });
+    });
+    const firstId = result.current.notifications[0].id;
+
+    act(() => {
+      result.current.markRead(firstId);
+    });
+    expect(result.current.unreadCount).toBe(1);
+
+    act(() => {
+      result.current.markAllRead();
+    });
+    expect(result.current.unreadCount).toBe(0);
+    expect(result.current.notifications).toHaveLength(2);
+  });
+
+  it('clearAll() empties the list', () => {
+    const { result } = renderHook(() => useNotifications(), { wrapper });
+
+    act(() => {
+      result.current.notify({ title: 'A' });
+      result.current.clearAll();
+    });
+    expect(result.current.notifications).toHaveLength(0);
+  });
+
+  it('caps the list at 50 notifications', () => {
+    const { result } = renderHook(() => useNotifications(), { wrapper });
+
+    act(() => {
+      for (let i = 0; i < 55; i++) {
+        result.current.notify({ title: `n${String(i)}` });
+      }
+    });
+    expect(result.current.notifications).toHaveLength(50);
+    expect(result.current.notifications[0].title).toBe('n54');
+  });
+
+  it('receives notifications published through the module bus', () => {
+    const { result } = renderHook(() => useNotifications(), { wrapper });
+
+    act(() => {
+      publishNotification({ title: 'From bus', severity: 'warning' });
+    });
+    expect(result.current.notifications[0].title).toBe('From bus');
+    expect(result.current.notifications[0].severity).toBe('warning');
+  });
+
+  it('throws when used outside the provider', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    expect(() => renderHook(() => useNotifications())).toThrow(
+      'useNotifications must be used within NotificationProvider',
+    );
+    spy.mockRestore();
+  });
+});

--- a/apps/admin-web/src/shared/notifications/index.ts
+++ b/apps/admin-web/src/shared/notifications/index.ts
@@ -1,0 +1,9 @@
+export type {
+  AppNotification,
+  NotificationInput,
+  NotificationSeverity,
+} from './notification.types';
+export { publishNotification, subscribeToNotifications } from './notification-bus';
+export type { NotificationContextValue } from './notification-provider';
+export { NotificationProvider } from './notification-provider';
+export { useNotifications } from './useNotifications';

--- a/apps/admin-web/src/shared/notifications/notification-bus.ts
+++ b/apps/admin-web/src/shared/notifications/notification-bus.ts
@@ -1,0 +1,31 @@
+import type { NotificationInput } from './notification.types';
+
+type NotificationListener = (input: NotificationInput) => void;
+
+// Module-level pub/sub so non-React code (e.g. the TanStack MutationCache)
+// can push notifications without access to the React context. This is UI
+// plumbing, not tenant data — module scope is acceptable here.
+const listeners = new Set<NotificationListener>();
+
+/**
+ * Publishes a notification to every subscribed listener.
+ * No-op when no NotificationProvider is mounted.
+ * @param input - Notification content.
+ */
+export function publishNotification(input: NotificationInput): void {
+  listeners.forEach((listener) => {
+    listener(input);
+  });
+}
+
+/**
+ * Subscribes a listener to published notifications.
+ * @param listener - Callback invoked for each published notification.
+ * @returns Unsubscribe function.
+ */
+export function subscribeToNotifications(listener: NotificationListener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}

--- a/apps/admin-web/src/shared/notifications/notification-provider.tsx
+++ b/apps/admin-web/src/shared/notifications/notification-provider.tsx
@@ -1,0 +1,109 @@
+/* eslint-disable react-refresh/only-export-components */
+
+import { createContext, type ReactNode, useCallback, useEffect, useMemo, useReducer } from 'react';
+
+import type { AppNotification, NotificationInput } from './notification.types';
+import { subscribeToNotifications } from './notification-bus';
+
+const MAX_NOTIFICATIONS = 50;
+
+interface NotificationState {
+  notifications: AppNotification[];
+}
+
+type NotificationAction =
+  | { type: 'add'; notification: AppNotification }
+  | { type: 'markRead'; id: string }
+  | { type: 'markAllRead' }
+  | { type: 'clearAll' };
+
+function notificationReducer(
+  state: NotificationState,
+  action: NotificationAction,
+): NotificationState {
+  switch (action.type) {
+    case 'add':
+      return {
+        notifications: [action.notification, ...state.notifications].slice(0, MAX_NOTIFICATIONS),
+      };
+    case 'markRead':
+      return {
+        notifications: state.notifications.map((n) =>
+          n.id === action.id ? { ...n, read: true } : n,
+        ),
+      };
+    case 'markAllRead':
+      return { notifications: state.notifications.map((n) => (n.read ? n : { ...n, read: true })) };
+    case 'clearAll':
+      return { notifications: [] };
+  }
+}
+
+export interface NotificationContextValue {
+  notifications: AppNotification[];
+  unreadCount: number;
+  notify: (input: NotificationInput) => void;
+  markRead: (id: string) => void;
+  markAllRead: () => void;
+  clearAll: () => void;
+}
+
+export const NotificationContext = createContext<NotificationContextValue | null>(null);
+
+/**
+ * In-memory Notification Center state. Session-scoped by design: tokens are
+ * in-memory too, so a page refresh already forces a re-login — persisting
+ * read-state would outlive the session it belongs to.
+ */
+export function NotificationProvider({ children }: { children: ReactNode }): JSX.Element {
+  const [state, dispatch] = useReducer(notificationReducer, { notifications: [] });
+
+  const notify = useCallback((input: NotificationInput) => {
+    dispatch({
+      type: 'add',
+      notification: {
+        id: crypto.randomUUID(),
+        title: input.title,
+        description: input.description,
+        severity: input.severity ?? 'info',
+        createdAt: new Date(),
+        read: false,
+        link: input.link,
+      },
+    });
+  }, []);
+
+  const markRead = useCallback((id: string) => {
+    dispatch({ type: 'markRead', id });
+  }, []);
+
+  const markAllRead = useCallback(() => {
+    dispatch({ type: 'markAllRead' });
+  }, []);
+
+  const clearAll = useCallback(() => {
+    dispatch({ type: 'clearAll' });
+  }, []);
+
+  // Bridge: anything published on the module bus lands in this provider
+  useEffect(() => subscribeToNotifications(notify), [notify]);
+
+  const unreadCount = useMemo(
+    () => state.notifications.filter((n) => !n.read).length,
+    [state.notifications],
+  );
+
+  const value = useMemo(
+    () => ({
+      notifications: state.notifications,
+      unreadCount,
+      notify,
+      markRead,
+      markAllRead,
+      clearAll,
+    }),
+    [state.notifications, unreadCount, notify, markRead, markAllRead, clearAll],
+  );
+
+  return <NotificationContext.Provider value={value}>{children}</NotificationContext.Provider>;
+}

--- a/apps/admin-web/src/shared/notifications/notification.types.ts
+++ b/apps/admin-web/src/shared/notifications/notification.types.ts
@@ -1,0 +1,21 @@
+export type NotificationSeverity = 'info' | 'success' | 'warning' | 'error';
+
+/** A notification stored in the Notification Center. */
+export interface AppNotification {
+  id: string;
+  title: string;
+  description?: string;
+  severity: NotificationSeverity;
+  createdAt: Date;
+  read: boolean;
+  /** Optional in-app route the notification navigates to on click. */
+  link?: string;
+}
+
+/** Input accepted by notify()/publishNotification(). */
+export interface NotificationInput {
+  title: string;
+  description?: string;
+  severity?: NotificationSeverity;
+  link?: string;
+}

--- a/apps/admin-web/src/shared/notifications/useNotifications.ts
+++ b/apps/admin-web/src/shared/notifications/useNotifications.ts
@@ -1,0 +1,16 @@
+import { useContext } from 'react';
+
+import { NotificationContext, type NotificationContextValue } from './notification-provider';
+
+/**
+ * Access the Notification Center state and actions.
+ * @returns Context value with notifications, unreadCount and actions.
+ * @throws Error when rendered outside a NotificationProvider.
+ */
+export function useNotifications(): NotificationContextValue {
+  const ctx = useContext(NotificationContext);
+  if (!ctx) {
+    throw new Error('useNotifications must be used within NotificationProvider');
+  }
+  return ctx;
+}

--- a/apps/admin-web/src/shared/ui/__tests__/drawer.test.tsx
+++ b/apps/admin-web/src/shared/ui/__tests__/drawer.test.tsx
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { Drawer } from '../drawer';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, defaultVal?: string | Record<string, unknown>): string => {
+      if (typeof defaultVal === 'string') return defaultVal;
+      return key;
+    },
+  }),
+}));
+
+describe('Drawer', () => {
+  it('renders title and children when open', () => {
+    const onClose = vi.fn();
+    render(
+      <Drawer open title="Detail" onClose={onClose}>
+        <p>Body</p>
+      </Drawer>,
+    );
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText('Detail')).toBeInTheDocument();
+    expect(screen.getByText('Body')).toBeInTheDocument();
+  });
+
+  it('is hidden from the accessibility tree when closed', () => {
+    const onClose = vi.fn();
+    render(
+      <Drawer open={false} title="Detail" onClose={onClose}>
+        <p>Body</p>
+      </Drawer>,
+    );
+    // aria-hidden panel is excluded from role queries
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('calls onClose when Escape is pressed inside the panel', () => {
+    const onClose = vi.fn();
+    render(
+      <Drawer open title="Detail" onClose={onClose}>
+        <p>Body</p>
+      </Drawer>,
+    );
+    fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose when the backdrop is clicked', () => {
+    const onClose = vi.fn();
+    const { container } = render(
+      <Drawer open title="Detail" onClose={onClose}>
+        <p>Body</p>
+      </Drawer>,
+    );
+    const backdrop = container.querySelector('[role="presentation"]');
+    expect(backdrop).not.toBeNull();
+    // eslint-disable-next-line @typescript-eslint/non-nullable-type-assertion-style
+    fireEvent.click(backdrop as Element);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose from the close button (with aria-label)', () => {
+    const onClose = vi.fn();
+    render(
+      <Drawer open title="Detail" onClose={onClose}>
+        <p>Body</p>
+      </Drawer>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/admin-web/src/shared/ui/drawer.stories.tsx
+++ b/apps/admin-web/src/shared/ui/drawer.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import '@shared/i18n/i18n';
+
+import { Drawer } from './drawer';
+
+const meta: Meta<typeof Drawer> = {
+  title: 'Shared/Drawer',
+  component: Drawer,
+  parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+type Story = StoryObj<typeof Drawer>;
+
+function noop(): void {
+  // storybook static story — close is a no-op
+}
+
+export const Open: Story = {
+  args: {
+    open: true,
+    title: 'Detail panel',
+    onClose: noop,
+    children: (
+      <dl className="space-y-md">
+        <div>
+          <dt className="text-label-xs font-mono text-on-surface-variant">Field</dt>
+          <dd className="mt-xs text-body-md text-on-surface">Value</dd>
+        </div>
+      </dl>
+    ),
+  },
+};
+
+export const Closed: Story = {
+  args: { ...Open.args, open: false },
+};

--- a/apps/admin-web/src/shared/ui/drawer.tsx
+++ b/apps/admin-web/src/shared/ui/drawer.tsx
@@ -1,0 +1,94 @@
+import { type KeyboardEvent, type ReactNode, useCallback, useEffect, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import { X } from 'lucide-react';
+
+interface DrawerProps {
+  /** Whether the drawer is open */
+  open: boolean;
+  /** Drawer title (sets aria-labelledby) */
+  title: string;
+  /** Drawer content */
+  children: ReactNode;
+  /** Called when the drawer should close (Esc, backdrop click, close button) */
+  onClose: () => void;
+  /** Optional width class (default w-96) */
+  widthClass?: string;
+}
+
+/**
+ * Global right drawer — reusable slide-in detail panel shared across features.
+ *
+ * - `role="dialog"`, `aria-modal="true"`, `aria-labelledby`.
+ * - Esc, backdrop click and the close button all call `onClose`.
+ * - Focuses the close button on open and restores focus on close.
+ * - Content stays mounted so the slide transition can play; while closed the
+ *   panel is `aria-hidden` and `pointer-events-none`.
+ */
+export function Drawer({
+  open,
+  title,
+  children,
+  onClose,
+  widthClass = 'w-96',
+}: DrawerProps): JSX.Element {
+  const { t } = useTranslation();
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  // Focus management: close button on open, restore trigger on close
+  useEffect(() => {
+    if (open) {
+      previousFocusRef.current = document.activeElement as HTMLElement;
+      closeButtonRef.current?.focus();
+    } else if (previousFocusRef.current) {
+      previousFocusRef.current.focus();
+      previousFocusRef.current = null;
+    }
+  }, [open]);
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLDivElement>) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        onClose();
+      }
+    },
+    [onClose],
+  );
+
+  return (
+    <>
+      {/* Backdrop */}
+      {open && (
+        <div className="fixed inset-0 z-40 bg-black/30" role="presentation" onClick={onClose} />
+      )}
+
+      {/* Panel */}
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="drawer-title"
+        aria-hidden={!open}
+        onKeyDown={handleKeyDown}
+        className={`fixed right-0 top-0 z-50 h-full ${widthClass} transform overflow-y-auto border-l border-outline-variant bg-surface-container-high p-lg shadow-lg transition-transform duration-200 ${
+          open ? 'translate-x-0' : 'pointer-events-none translate-x-full'
+        }`}
+      >
+        <div className="mb-lg flex items-center justify-between">
+          <h2 id="drawer-title" className="text-lg font-semibold text-on-surface">
+            {title}
+          </h2>
+          <button
+            ref={closeButtonRef}
+            onClick={onClose}
+            className="rounded-sm p-xs text-on-surface-variant hover:bg-surface-container-highest"
+            aria-label={t('common.close', 'Close')}
+          >
+            <X size={18} />
+          </button>
+        </div>
+        {children}
+      </div>
+    </>
+  );
+}

--- a/apps/admin-web/src/shared/ui/layout/app-layout.tsx
+++ b/apps/admin-web/src/shared/ui/layout/app-layout.tsx
@@ -1,6 +1,7 @@
 import { Outlet } from 'react-router-dom';
 // Deliberate shell → feature import (same rationale as TopBar's bell).
 import { SystemAlertsWatcher } from '@features/notifications';
+import { CommandPalette } from '@shared/command-palette';
 
 import { ContentArea } from './content-area';
 import { SideNav } from './sidenav';
@@ -11,6 +12,7 @@ export function AppLayout(): JSX.Element {
     <div className="flex min-h-screen flex-col bg-surface">
       <TopBar />
       <SystemAlertsWatcher />
+      <CommandPalette />
       <div className="flex flex-1">
         <SideNav />
         <ContentArea>

--- a/apps/admin-web/src/shared/ui/layout/app-layout.tsx
+++ b/apps/admin-web/src/shared/ui/layout/app-layout.tsx
@@ -1,4 +1,6 @@
 import { Outlet } from 'react-router-dom';
+// Deliberate shell → feature import (same rationale as TopBar's bell).
+import { SystemAlertsWatcher } from '@features/notifications';
 
 import { ContentArea } from './content-area';
 import { SideNav } from './sidenav';
@@ -8,6 +10,7 @@ export function AppLayout(): JSX.Element {
   return (
     <div className="flex min-h-screen flex-col bg-surface">
       <TopBar />
+      <SystemAlertsWatcher />
       <div className="flex flex-1">
         <SideNav />
         <ContentArea>

--- a/apps/admin-web/src/shared/ui/layout/sidenav.tsx
+++ b/apps/admin-web/src/shared/ui/layout/sidenav.tsx
@@ -1,58 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { NavLink } from 'react-router-dom';
-import { ROUTES } from '@shared/config/routes';
-import { Permission, useHasPermission } from '@shared/permissions';
-import type { LucideIcon } from 'lucide-react';
-import { BarChart3, Bell, Cog, Database, Layers, Search, Shield, Users } from 'lucide-react';
-
-interface NavItem {
-  labelKey: string;
-  path: string;
-  icon: LucideIcon;
-  permissions: Permission[];
-}
-
-const NAV_ITEMS: readonly NavItem[] = [
-  {
-    labelKey: 'nav.dashboard',
-    path: ROUTES.DASHBOARD,
-    icon: BarChart3,
-    permissions: [Permission.VIEW_DASHBOARD],
-  },
-  {
-    labelKey: 'nav.accounts',
-    path: ROUTES.ACCOUNTS,
-    icon: Database,
-    permissions: [Permission.VIEW_ACCOUNTS],
-  },
-  { labelKey: 'nav.users', path: ROUTES.USERS, icon: Users, permissions: [Permission.VIEW_USERS] },
-  { labelKey: 'nav.roles', path: ROUTES.ROLES, icon: Shield, permissions: [Permission.VIEW_ROLES] },
-  {
-    labelKey: 'nav.products',
-    path: ROUTES.PRODUCTS,
-    icon: Search,
-    permissions: [Permission.VIEW_PRODUCTS],
-  },
-  {
-    labelKey: 'nav.scrapers',
-    path: ROUTES.SCRAPERS,
-    icon: Bell,
-    permissions: [Permission.VIEW_SCRAPERS],
-  },
-  { labelKey: 'nav.rules', path: ROUTES.RULES, icon: Layers, permissions: [Permission.VIEW_RULES] },
-  {
-    labelKey: 'nav.queues',
-    path: ROUTES.QUEUES,
-    icon: BarChart3,
-    permissions: [Permission.VIEW_QUEUES],
-  },
-  {
-    labelKey: 'nav.settings',
-    path: ROUTES.SETTINGS,
-    icon: Cog,
-    permissions: [Permission.VIEW_SETTINGS],
-  },
-];
+import { NAV_ITEMS } from '@shared/config/nav-items';
+import { useHasPermission } from '@shared/permissions';
 
 function navLinkClassName({ isActive }: { isActive: boolean }): string {
   return `flex items-center gap-md px-md py-sm rounded-l border-r-2 transition-colors duration-150 ease-in-out font-label-md text-label-md ${

--- a/apps/admin-web/src/shared/ui/layout/topbar.tsx
+++ b/apps/admin-web/src/shared/ui/layout/topbar.tsx
@@ -47,7 +47,7 @@ export function TopBar(): JSX.Element {
         className="flex items-center gap-xs rounded-md border border-outline-variant px-sm py-xs text-body-sm text-on-surface-variant transition-colors hover:bg-surface-container-high"
       >
         <Search size={14} aria-hidden="true" />
-        <kbd className="rounded-sm bg-surface-container-high px-xs text-label-xs font-mono">K</kbd>
+        <kbd className="rounded-sm bg-surface-container-high px-xs text-label-xs font-mono">⌘K</kbd>
       </button>
 
       {/* User */}

--- a/apps/admin-web/src/shared/ui/layout/topbar.tsx
+++ b/apps/admin-web/src/shared/ui/layout/topbar.tsx
@@ -1,20 +1,27 @@
+import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 // Deliberate shell -> feature import: the app shell hosts the Notification
 // Center trigger. No cycle: features/notifications never imports the layout.
 import { NotificationBell } from '@features/notifications';
 import { useCurrentUser, useLogout } from '@shared/auth';
+import { useCommandPalette } from '@shared/command-palette';
 import { ROUTES } from '@shared/config/routes';
-import { Shield } from 'lucide-react';
+import { Search, Shield } from 'lucide-react';
 
 export function TopBar(): JSX.Element {
   const { t } = useTranslation();
   const user = useCurrentUser();
   const logout = useLogout();
+  const { setOpen } = useCommandPalette();
 
   const handleLogout = (): void => {
     logout();
     window.location.href = ROUTES.LOGIN;
   };
+
+  const handleOpenPalette = useCallback(() => {
+    setOpen(true);
+  }, [setOpen]);
 
   return (
     <header className="sticky top-0 z-50 flex h-12 items-center justify-between border-b border-outline-variant bg-surface px-md">
@@ -32,6 +39,16 @@ export function TopBar(): JSX.Element {
           </a>
         </div>
       </div>
+
+      {/* Command palette trigger */}
+      <button
+        onClick={handleOpenPalette}
+        aria-label={t('palette.open', 'Open command palette')}
+        className="flex items-center gap-xs rounded-md border border-outline-variant px-sm py-xs text-body-sm text-on-surface-variant transition-colors hover:bg-surface-container-high"
+      >
+        <Search size={14} aria-hidden="true" />
+        <kbd className="rounded-sm bg-surface-container-high px-xs text-label-xs font-mono">K</kbd>
+      </button>
 
       {/* User */}
       <div className="flex items-center gap-sm">

--- a/apps/admin-web/src/shared/ui/layout/topbar.tsx
+++ b/apps/admin-web/src/shared/ui/layout/topbar.tsx
@@ -1,4 +1,7 @@
 import { useTranslation } from 'react-i18next';
+// Deliberate shell -> feature import: the app shell hosts the Notification
+// Center trigger. No cycle: features/notifications never imports the layout.
+import { NotificationBell } from '@features/notifications';
 import { useCurrentUser, useLogout } from '@shared/auth';
 import { ROUTES } from '@shared/config/routes';
 import { Shield } from 'lucide-react';
@@ -21,7 +24,10 @@ export function TopBar(): JSX.Element {
           <Shield size={18} />
         </div>
         <div>
-          <a href={ROUTES.DASHBOARD} className="font-headline-lg-mobile text-headline-lg-mobile leading-none tracking-tighter text-primary">
+          <a
+            href={ROUTES.DASHBOARD}
+            className="font-headline-lg-mobile text-headline-lg-mobile leading-none tracking-tighter text-primary"
+          >
             BazaarSentinel
           </a>
         </div>
@@ -29,6 +35,7 @@ export function TopBar(): JSX.Element {
 
       {/* User */}
       <div className="flex items-center gap-sm">
+        <NotificationBell />
         {user && (
           <>
             <span className="text-body-sm font-medium text-on-surface">{user.username}</span>

--- a/apps/admin-web/src/shared/ui/layout/topbar.tsx
+++ b/apps/admin-web/src/shared/ui/layout/topbar.tsx
@@ -40,14 +40,19 @@ export function TopBar(): JSX.Element {
         </div>
       </div>
 
-      {/* Command palette trigger */}
+      {/* Command palette trigger — search bar on md+, icon-only on mobile */}
       <button
         onClick={handleOpenPalette}
+        className="flex items-center gap-xs rounded-md border border-outline-variant px-sm py-xs text-body-sm text-on-surface-variant transition-colors hover:bg-surface-container-high min-w-0 flex-shrink"
         aria-label={t('palette.open', 'Open command palette')}
-        className="flex items-center gap-xs rounded-md border border-outline-variant px-sm py-xs text-body-sm text-on-surface-variant transition-colors hover:bg-surface-container-high"
       >
-        <Search size={14} aria-hidden="true" />
-        <kbd className="rounded-sm bg-surface-container-high px-xs text-label-xs font-mono">⌘K</kbd>
+        <Search size={14} className="shrink-0" aria-hidden="true" />
+        <span className="hidden md:inline truncate">
+          {t('palette.placeholder', 'Type a command or search…')}
+        </span>
+        <kbd className="hidden rounded-sm bg-surface-container-high px-xs text-label-xs font-mono sm:inline">
+          ⌘K
+        </kbd>
       </button>
 
       {/* User */}


### PR DESCRIPTION
## Fase 7 — Features Complementarias

### Entregado

| Módulo | Descripción |
|---|---|
| **Queues Dashboard** | Stats cards, jobs table con filtro de estado, job detail drawer (payload, attempts, timestamps). Consume 4 endpoints `/api/admin/queues/*`. |
| **Notification Center** | Campana con badge en TopBar, panel desplegable, mark-all-read. Alimentado por MutationCache errors + SystemAlertsWatcher (health/queue transitions). 100% client-side. |
| **Global Right Drawer** | Primitivo compartido en `shared/ui/drawer.tsx`. Reutilizado en accounts, users y queues (3 consumidores). |
| **Command Palette** | `⌘K` global con cmdk. Navegación filtrada por permisos + sign out. Trigger responsive (icono en móvil, search bar en desktop). |
| **404 / 403** | NotFoundPage con SearchX + CTA al dashboard. ForbiddenView ya existía en RequirePermission (verificado). |

### Quality Gates

- **Tests:** 40 archivos, 326 tests ✅
- **Lint:** 0 errores, 0 warnings ✅
- **Typecheck:** limpio ✅
- **Build:** exitoso ✅

### Commits

15 conventional commits, un cambio lógico por commit.

### Out of scope (acordado)

Logs (sin endpoint backend), Settings (sin API), búsqueda de recursos en palette, migración a lazy loading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude <noreply@anthropic.com>