### PR TITLE
docs: update CLAUDE.md, skills, and READMEs post Phase 1 stabilization

### DIFF
--- a/.claude/skills/bots/SKILL.md
+++ b/.claude/skills/bots/SKILL.md
@@ -25,7 +25,23 @@ BOT_ENABLED=both → getEnabledBotTypes() → for each botType:
 - **Provider registry** (`providers/provider-registry.ts`) — single source of truth. Adding a provider = adding an entry to `REGISTRY`, NOT a new DI class.
 - **Provider adapters** (`adapters/`) — `TelegramAdapter`, `WhatsAppAdapter` implement `IProviderAdapter`. Flows consume `methods.extensions.providerAdapter`, never branch on provider name.
 - **`BotMenuService`** — wraps raw Telegraf API for reply keyboards (`sendWithKeyboard`) and command menus (`applyCommands`). Needed because builderbot strips `reply_markup`. Singleton, injected into `TelegramAdapter` and `LinkCodeService`.
-- **Extensions** — `BotService.start()` injects `tenantResolver`, `providerAdapter`, `providerName`, `verifyAndLink`, `linkCodeService` into `extensions`. Flows access them via `methods.extensions.*`. To add one: service method → wire in `BotService.start()` → consume in flow.
+- **Extensions** — `BotService.start()` injects `tenantResolver`, `providerAdapter`, `providerName`, `verifyAndLink`, `linkCodeService`, `subscriptionProvider`, `alarmProvider`, `profileProvider`, and `aiHandler` into `extensions`. Flows access them via `methods.extensions.*`. To add one: service method → wire in `BotService.start()` → consume in flow.
+
+### Extension Providers Reference
+
+| Provider | Returns | Used by |
+|---|---|---|
+| `tenantResolver` | `IBotContext` (with `accountId`, `userId`, `preferredLang`) | All flows (via `resolveTenant`) |
+| `providerAdapter` | `IProviderAdapter` | Flows that send rich messages |
+| `providerName` | `'telegram' \| 'whatsapp'` | Flows that branch on provider |
+| `verifyAndLink` | `Promise<boolean>` | `linkAccountFlow` |
+| `linkCodeService` | `LinkCodeService` instance | `linkAccountFlow`, `confirmLinkFlow` |
+| `subscriptionProvider` | `{ planName?, expiresAt? } \| null` | `/subscription` flow |
+| `alarmProvider` | `Array<{ productName?, currentPrice? }>` | `/alarms` flow |
+| `profileProvider` | `{ displayName?, email? } \| null` | `/profile` flow |
+| `aiHandler` | `string` (graceful degradation message) | `fallbackFlow` |
+
+All providers are fail-safe — they catch errors internally and return safe defaults (`null`, `[]`, or a fixed message) rather than throwing.
 
 ## Adding a new flow
 

--- a/apps/admin-web/CLAUDE.md
+++ b/apps/admin-web/CLAUDE.md
@@ -8,9 +8,11 @@ Read these before any UI work — they form a hierarchy:
 
 1. `@./DESIGN.md` — visual identity (brand book: palette, typography, depth, shape, component recipes)
 2. `@../../.claude/rules/admin-web-ui.md` — behavioral & code conventions (layout, tables, charts, async states, toasts, destructive actions)
-3. `@../../.claude/plans/oye-comenzamos-con-otra-wobbly-snowflake.md` — development plan (7 phases, architectural decisions, DoD per phase)
-4. `@../../.plans/super-admin-dashboard-plan.md` — mirror copy of the development plan
-5. This file — architectural constraints, patterns, and how the SPA is wired together
+3. `@../../.claude/rules/admin-web-feature-scaffold.md` — step-by-step recipe for adding a new feature module
+4. This file — architectural constraints, patterns, and how the SPA is wired together
+5. `@../../src/main/CLAUDE.md` — backend code patterns and domain model (Plan/Subscription/Alarm system)
+6. `@../../src/main/users/README.md` — Plans & Subscriptions conceptual docs
+7. `@../../src/main/alarms/README.md` — Alarm system conceptual docs
 
 ## Stack
 
@@ -208,6 +210,10 @@ enum Permission {
   VIEW_QUEUES = 'queues:view',
   VIEW_ROLES = 'roles:view',
   MANAGE_ROLES = 'roles:manage',
+  VIEW_PLANS = 'plans:view',
+  MANAGE_PLANS = 'plans:manage',
+  VIEW_SUBSCRIPTIONS = 'subscriptions:view',
+  MANAGE_SUBSCRIPTIONS = 'subscriptions:manage',
   VIEW_LOGS = 'logs:view',
   VIEW_SETTINGS = 'settings:view',
 }
@@ -291,10 +297,49 @@ npm run typecheck     # tsc --noEmit clean
 npm run build         # Compiles without errors
 ```
 
+## Backend Domain Context (Phase 1)
+
+The backend now has a full Plan → Subscription → Alarm enforcement chain. When building admin-web features for plans, subscriptions, or alarms, these backend capabilities exist:
+
+### Plans & Subscriptions API
+
+| Endpoint | Method | Purpose | Auth |
+|---|---|---|---|
+| `/api/plans` | GET | List all plans | SUPER_ADMIN |
+| `/api/plans` | POST | Create a plan | SUPER_ADMIN |
+| `/api/plans/:id` | PUT | Update a plan | SUPER_ADMIN |
+| `/api/plans/:id` | DELETE | Delete a plan | SUPER_ADMIN |
+| `/api/plans/:id/subscribers` | GET | List accounts subscribed to a plan | SUPER_ADMIN |
+| `/api/subscriptions` | POST | Assign a plan to an account | SUPER_ADMIN |
+| `/api/accounts/:id/subscriptions` | GET | List subscriptions for an account | Auth required |
+| `/api/subscriptions/:id` | DELETE | Cancel a subscription | SUPER_ADMIN |
+
+### Plan Features (JSONB)
+
+Plans carry a `features` JSONB column with these keys:
+- `maxAlarms` — max alarms per account. `-1` = unlimited
+- `allowedConditions` — array of condition type strings the plan permits
+- `aiAlarms` — boolean gating AI-powered conditions
+- `notificationChannels` — array of channel strings (`in-app`, `email`, `telegram`, `whatsapp`)
+
+### Enforcement (server-side, already implemented)
+
+- `PlanEnforcementService` gates alarm create/update. Returns 403 if limits exceeded or condition not allowed.
+- Auto-trial: new accounts get a 7-day TRIAL subscription automatically (fail-open).
+
+### Three Default Plans
+
+| Plan | Max Alarms | Conditions | AI | Channels |
+|---|---|---|---|---|
+| Trial | 3 | Price Drops, Price Rises, Price Change % | No | In-app |
+| Standard | 20 | All 6 | No | In-app, Email |
+| Unlimited | -1 | All 6 | Yes | All |
+
 ## Related
 
 - API spec: `swagger.json` at the repo root (documentation only — not a code-generation source).
 - Backend patterns: `src/main/CLAUDE.md`.
-- Design system audit & dev plan: `~/.claude/plans/oye-comenzamos-con-otra-wobbly-snowflake.md`.
+- Backend domain docs: `src/main/users/README.md`, `src/main/alarms/README.md`.
 - Project-wide compliance: `../../.claude/rules/compliance-checklist.md`.
+- Git workflow: `../../.claude/rules/git-workflow.md`.
 - Git workflow: `../../.claude/rules/git-workflow.md`.

--- a/src/main/CLAUDE.md
+++ b/src/main/CLAUDE.md
@@ -182,4 +182,51 @@ SMTP env vars: `SMTP_HOST`, `SMTP_PORT`, `SMTP_SECURE`, `SMTP_USER`, `SMTP_PASS`
 `AccountDeactivationService` at `src/main/users/services/account-deactivation.service.ts`:
 - Sets `User.deletedAt`, pauses all alarms (`enabled = false`), revokes all refresh tokens, blacklists current JWT
 - Reversible within 30 days by `SUPER_ADMIN` via `POST /api/auth/reactivate`
+- **Reactivation** re-enables all alarms that were paused during deactivation
 - `purgeExpiredAccounts()` hard-deletes personal data after 30 days (run as daily cron). Alarm/account data is preserved.
+
+### Plan & Subscription System
+
+Three plans are seeded idempotently via `prisma/seed.ts`:
+
+| Plan | Price | Max Alarms | Conditions | AI | Channels |
+|---|---|---|---|---|---|
+| Trial | $0 | 3 | Price Drops, Price Rises, Price Change % | No | In-app |
+| Standard | $9.99 | 20 | All 6 | No | In-app, Email |
+| Unlimited | $29.99 | -1 (unlimited) | All 6 | Yes | All |
+
+**Plan.features (JSONB)** — the runtime enforcement layer reads these keys:
+- `maxAlarms` — max alarms per account. `-1` = unlimited.
+- `allowedConditions` — array of `AlarmConditionType` strings the plan permits. Empty/missing = all allowed.
+- `aiAlarms` — boolean gate for AI-powered conditions.
+- `notificationChannels` — which delivery channels the plan includes.
+
+**Auto-trial**: `AccountService.register()` auto-assigns a 7-day TRIAL subscription. Fail-open — never blocks registration if the TRIAL plan is missing or creation fails.
+
+**PlanEnforcementService** — gates `AlarmService.create()` and `update()`:
+1. Counts existing alarms vs `maxAlarms`. Throws `PlanLimitReachedError` (403) if limit reached.
+2. Validates condition type against `allowedConditions`. Throws `ConditionNotAllowedError` (403) if not permitted.
+3. Injects `SubscriptionsRepository` directly (not `SubscriptionsService`) — needs raw Prisma models with nested `plan.features` JSONB that the DTO/mapper layer strips.
+
+**Subscription lifecycle**: `TRIALING` → `ACTIVE` → `PAST_DUE` / `CANCELED`. Only ACTIVE and TRIALING are considered active for enforcement.
+
+**Cascade deletes**: Account deletion cascades to Users, Subscriptions, Alarms (→ AlarmHistory), Notifications, BotLinkCodes, BotLinkAudits, BotConversations. User deletion cascades to UserIdentities, RefreshTokens, PasswordResetTokens, EmailVerificationTokens.
+
+See `src/main/users/README.md` and `src/main/alarms/README.md` for full conceptual documentation.
+
+### DI: Always Use TYPES Symbols
+
+Every `@inject()` MUST use `TYPES.SymbolName`, never a class reference. The container binds Symbols — Inversify treats class constructors and Symbols as distinct identifiers:
+
+```typescript
+// Correct — matches container.bind(TYPES.SubscriptionsService).to(SubscriptionsService)
+@inject(TYPES.SubscriptionsService) private readonly _subs: SubscriptionsService
+
+// Wrong — no matching binding (container has Symbol, not class)
+@inject(SubscriptionsService) private readonly _subs: SubscriptionsService
+
+// Exception: repositories use .toSelf() pattern, so inject by class
+@inject(UserRepository) private readonly _userRepo: UserRepository
+```
+
+The repo has a mix: **services are bound by Symbol** (`container.bind(TYPES.X).to(X)`), **repositories are bound by class** (`container.bind(RepoName).toSelf()`). Match the binding: services → `@inject(TYPES.X)`, repositories → `@inject(ClassName)`.


### PR DESCRIPTION
## Summary

Updates agent documentation files to reflect the Phase 1 stabilization changes merged in #48.

## Changes

- **`src/main/CLAUDE.md`**: Added Plan/Subscription system, PlanEnforcementService, cascade deletes, and DI rule (always use TYPES Symbols)
- **`apps/admin-web/CLAUDE.md`**: Removed stale plan references, added Plan/Subscription permissions (`VIEW_PLANS`, `MANAGE_PLANS`, `VIEW_SUBSCRIPTIONS`, `MANAGE_SUBSCRIPTIONS`), added Backend Domain Context section with API endpoints and the three default plans
- **`.claude/skills/bots/SKILL.md`**: Documented all 9 extension providers with return types

🤖 Generated with [Claude Code](https://claude.com/claude-code)