### PR TITLE
fix(admin-web): unwrap subscriptions response envelope

### DIFF
--- a/apps/admin-web/src/features/accounts/__tests__/subscription-section.test.tsx
+++ b/apps/admin-web/src/features/accounts/__tests__/subscription-section.test.tsx
@@ -101,7 +101,7 @@ describe('SubscriptionSection', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockListByAccount.mockResolvedValue({
-      data: [activeSubscription],
+      data: { subscriptions: [activeSubscription] },
       status: 200,
       statusText: 'OK',
       headers: {},
@@ -157,7 +157,7 @@ describe('SubscriptionSection', () => {
   describe('no active subscription', () => {
     it('renders empty state with Assign Plan button', async () => {
       mockListByAccount.mockResolvedValue({
-        data: [],
+        data: { subscriptions: [] },
         status: 200,
         statusText: 'OK',
         headers: {},

--- a/apps/admin-web/src/features/accounts/hooks/useGetAccountSubscriptions.ts
+++ b/apps/admin-web/src/features/accounts/hooks/useGetAccountSubscriptions.ts
@@ -10,7 +10,7 @@ export function useGetAccountSubscriptions(accountId: string | null) {
         throw new Error('useGetAccountSubscriptions called with null accountId');
       }
       const { data } = await accountSubscriptionsService.listByAccount(accountId);
-      return data;
+      return data.subscriptions;
     },
     enabled: accountId !== null,
     staleTime: 5 * 60 * 1000,

--- a/apps/admin-web/src/features/accounts/services/account-subscriptions-service.ts
+++ b/apps/admin-web/src/features/accounts/services/account-subscriptions-service.ts
@@ -16,12 +16,20 @@ export interface AssignSubscriptionDTO {
   planId: string;
 }
 
+export interface SubscriptionListResponseDTO {
+  subscriptions: SubscriptionDTO[];
+}
+
+export interface SubscriptionResponseDTO {
+  subscription: SubscriptionDTO;
+}
+
 export const accountSubscriptionsService = {
   listByAccount(accountId: string) {
-    return apiClient.get<SubscriptionDTO[]>(`/accounts/${accountId}/subscriptions`);
+    return apiClient.get<SubscriptionListResponseDTO>(`/accounts/${accountId}/subscriptions`);
   },
   assign(data: AssignSubscriptionDTO) {
-    return apiClient.post<SubscriptionDTO>('/subscriptions', data);
+    return apiClient.post<SubscriptionResponseDTO>('/subscriptions', data);
   },
   cancel(subscriptionId: string) {
     return apiClient.delete(`/subscriptions/${subscriptionId}`);


### PR DESCRIPTION
## Summary

Fixes the runtime crash `Uncaught TypeError: subscriptions?.find is not a function` in `SubscriptionSection` (`subscription-section.tsx:35`).

## Root cause

`GET /api/accounts/:id/subscriptions` responds with `ResponseHandler.ok(res, { subscriptions })`, i.e. `{ status, message, data: { subscriptions: [...] } }`. The API client interceptor unwraps one envelope level, so the hook received the object `{ subscriptions: [...] }` — but `accountSubscriptionsService.listByAccount` typed the payload as a bare `SubscriptionDTO[]`. The component then called `.find` on an object and crashed. Test mocks mirrored the same wrong shape, so the suite stayed green while production broke.

## Changes

- `account-subscriptions-service.ts` — new `SubscriptionListResponseDTO` / `SubscriptionResponseDTO` types matching the envelope's inner shape (same pattern as `plansService`); also fixes the latent mismatch on `assign`.
- `useGetAccountSubscriptions.ts` — returns `data.subscriptions`, so the component keeps receiving an array.
- `subscription-section.test.tsx` — mocks now reproduce the real response shape (with the old service code they fail with the exact reported TypeError).

## Verification

- Full admin-web suite: 375 tests in 49 files, all green
- `npm run typecheck -w apps/admin-web` clean
- `npm run lint -w apps/admin-web` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)