### PR TITLE
fix: deliver refresh tokens in register and provider auth flows

### DIFF
--- a/src/__tests__/unit/user.service.registerLocal.test.ts
+++ b/src/__tests__/unit/user.service.registerLocal.test.ts
@@ -33,6 +33,7 @@ describe('UserService.registerLocal', () => {
   let userMapper: jest.Mocked<UserMapper>;
   let passwordHasher: jest.Mocked<PasswordHasher>;
   let accountRepo: jest.Mocked<AccountRepository>;
+  let tokenMgmt: { issueRefreshToken: jest.Mock };
   const loggerMock = { debug: jest.fn(), warn: jest.fn(), error: jest.fn(), context: '' } as any;
 
   const sampleDTO = (overrides = {}): UserRegisterDTO => {
@@ -81,6 +82,8 @@ describe('UserService.registerLocal', () => {
       toDTOs: jest.fn(),
     } as unknown as jest.Mocked<UserMapper>;
 
+    tokenMgmt = { issueRefreshToken: jest.fn().mockResolvedValue('fake-refresh-token') };
+
     userService = new UserService(
       loggerMock,
       userRepo as any,
@@ -91,6 +94,8 @@ describe('UserService.registerLocal', () => {
       {} as any, // providerVerifier (not used in registerLocal)
       accountRepo as any,
       { role: { findFirst: jest.fn().mockResolvedValue({ id: 'role-admin', name: 'ACCOUNT_OWNER' }) } } as any, // prisma
+      undefined, // emailVerify — not exercised here
+      tokenMgmt as any,
     );
   });
 
@@ -120,6 +125,7 @@ describe('UserService.registerLocal', () => {
       expect(result).toEqual({
         user: userDTO,
         token: 'fake-jwt-token',
+        refreshToken: 'fake-refresh-token',
       });
 
       expect(accountRepo.exists).toHaveBeenCalledWith('acc-1');
@@ -127,7 +133,7 @@ describe('UserService.registerLocal', () => {
       expect(userRepo.findByUsername).toHaveBeenCalledWith('john_doe');
       expect(passwordHasher.hash).toHaveBeenCalledWith('SecurePass123');
       expect(userRepo.create).toHaveBeenCalled();
-      expect(tokenService.generateToken).toHaveBeenCalledWith('user-123', 'acc-1', ['USER']);
+      expect(tokenService.generateToken).toHaveBeenCalledWith('user-123', 'acc-1', ['USER'], undefined, undefined);
       expect(loggerMock.debug).toHaveBeenCalledWith('User registered successfully', { userId: 'user-123', email: 'john@example.com' });
     });
 
@@ -197,6 +203,26 @@ describe('UserService.registerLocal', () => {
           accountId: 'acc-1',
         }),
       );
+    });
+
+    it('should include the issued refresh token in the auth response', async () => {
+      const dto = sampleDTO();
+      const createdUser = {
+        id: 'user-123',
+        email: 'john@example.com',
+        username: 'john_doe',
+        accountId: 'acc-1',
+        roles: [{ id: 'r1', name: 'USER' }],
+      } as any;
+      userRepo.findByEmail.mockResolvedValue(null);
+      userRepo.findByUsername.mockResolvedValue(null);
+      userRepo.create.mockResolvedValue(createdUser);
+      userMapper.toDTO.mockReturnValue({ id: 'user-123' } as any);
+
+      const result = await userService.registerLocal(dto, 'acc-1');
+
+      expect(tokenMgmt.issueRefreshToken).toHaveBeenCalledWith('user-123');
+      expect(result.refreshToken).toBe('fake-refresh-token');
     });
   });
 
@@ -315,7 +341,7 @@ describe('UserService.registerLocal', () => {
 
       await userService.registerLocal(dto, 'acc-1');
 
-      expect(tokenService.generateToken).toHaveBeenCalledWith('user-123', 'acc-1', ['USER', 'ADMIN']);
+      expect(tokenService.generateToken).toHaveBeenCalledWith('user-123', 'acc-1', ['USER', 'ADMIN'], undefined, undefined);
     });
   });
 });

--- a/src/__tests__/unit/userRegisterWithProvider.test.ts
+++ b/src/__tests__/unit/userRegisterWithProvider.test.ts
@@ -28,6 +28,7 @@ describe('UserService.registerWithProvider', () => {
   let passwordHasher: any;
   let providerVerifier: any;
   let accountRepo: any;
+  let tokenMgmt: { issueRefreshToken: jest.Mock };
   const loggerMock = { debug: jest.fn(), error: jest.fn(), context: '' } as any;
 
   const sampleDTO = (overrides = {}): ProviderRegistrationDTO => {
@@ -66,6 +67,7 @@ describe('UserService.registerWithProvider', () => {
       verifyProvider: jest.fn().mockResolvedValue({ providerId: 'prov-1', email: 'alice@example.com', email_verified: true }),
     };
     accountRepo = { exists: jest.fn().mockResolvedValue(true) };
+    tokenMgmt = { issueRefreshToken: jest.fn().mockResolvedValue('fake-refresh-token') };
 
     userMapper = {
       toDTO: jest.fn(),
@@ -91,6 +93,8 @@ describe('UserService.registerWithProvider', () => {
       providerVerifier as any,
       accountRepo as any,
       mockPrisma,
+      undefined, // emailVerify — not exercised here
+      tokenMgmt as any,
     );
   });
 
@@ -109,7 +113,8 @@ describe('UserService.registerWithProvider', () => {
     expect(userIdentityRepo.findByProvider).toHaveBeenCalledWith(dto.provider, dto.providerId);
     expect(userRepo.findByIdWithRoles).toHaveBeenCalledWith(existingIdentity.userId);
     expect(tokenService.generateToken).toHaveBeenCalled();
-    expect(result).toEqual({ user: userDTO, token: 'fake-token' });
+    expect(result).toEqual({ user: userDTO, token: 'fake-token', refreshToken: 'fake-refresh-token' });
+    expect(tokenMgmt.issueRefreshToken).toHaveBeenCalledWith('u1');
   });
 
   it('should link identity when user exists by email (happy path)', async () => {
@@ -129,7 +134,7 @@ describe('UserService.registerWithProvider', () => {
     expect(userRepo.findByEmail).toHaveBeenCalledWith(dto.email.trim().toLowerCase());
     expect(userIdentityRepo.create).toHaveBeenCalledWith(userByEmail.id, dto.provider, dto.providerId);
     expect(tokenService.generateToken).toHaveBeenCalled();
-    expect(result).toEqual({ user: userDTO, token: 'fake-token' });
+    expect(result).toEqual({ user: userDTO, token: 'fake-token', refreshToken: 'fake-refresh-token' });
   });
 
   it('should handle race when linking identity: create throws unique constraint -> load created identity and login', async () => {
@@ -154,6 +159,8 @@ describe('UserService.registerWithProvider', () => {
     expect(userRepo.findByIdWithRoles).toHaveBeenCalledWith(identityNow.userId);
     expect(tokenService.generateToken).toHaveBeenCalled();
     expect(result.token).toBe('fake-token');
+    expect(tokenMgmt.issueRefreshToken).toHaveBeenCalledTimes(1);
+    expect(result.refreshToken).toBe('fake-refresh-token');
   });
 
   it('should create user + identity when neither exists (transactional create)', async () => {
@@ -170,7 +177,38 @@ describe('UserService.registerWithProvider', () => {
 
     expect(userRepo.createWithIdentity).toHaveBeenCalled();
     expect(tokenService.generateToken).toHaveBeenCalled();
-    expect(result).toEqual({ user: userDTO, token: 'fake-token' });
+    expect(result).toEqual({ user: userDTO, token: 'fake-token', refreshToken: 'fake-refresh-token' });
+  });
+
+  it('should return undefined refreshToken when TokenManagementService is unavailable', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { UserService: UserServiceClass } = require('@users/services/user.service');
+    const mockPrisma = {
+      role: { findFirst: jest.fn().mockResolvedValue({ id: 'role-admin', name: 'ACCOUNT_OWNER' }) },
+    } as any;
+    const serviceWithoutTokenMgmt = new UserServiceClass(
+      loggerMock,
+      userRepo as any,
+      userMapper as any,
+      tokenService as any,
+      userIdentityRepo as any,
+      passwordHasher as any,
+      providerVerifier as any,
+      accountRepo as any,
+      mockPrisma,
+    );
+
+    const dto = sampleDTO();
+    const existingIdentity = { id: 'id-1', userId: 'u1', provider: dto.provider, providerId: dto.providerId } as any;
+    const dbUser = { id: 'u1', accountId: 'a1', roles: [{ id: 'r1', name: 'ADMIN' }] } as any;
+    userIdentityRepo.findByProvider.mockResolvedValue(existingIdentity as any);
+    userRepo.findByIdWithRoles.mockResolvedValue(dbUser);
+    userMapper.toDTO.mockReturnValue({ id: 'u1' } as any);
+
+    const result = await serviceWithoutTokenMgmt.registerWithProvider(dto, 'a1');
+
+    expect(result.refreshToken).toBeUndefined();
+    expect(result.token).toBe('fake-token');
   });
 
   it('should reject linking when provider email is unverified', async () => {

--- a/src/__tests__/unit/users/account.controller.register.test.ts
+++ b/src/__tests__/unit/users/account.controller.register.test.ts
@@ -1,0 +1,96 @@
+import 'reflect-metadata';
+import { Request, Response } from 'express';
+
+const userServiceMock = {
+  registerLocal: jest.fn(),
+  registerWithProvider: jest.fn(),
+};
+
+jest.mock('@users/services/user.service', () => ({
+  UserService: jest.fn().mockImplementation(() => userServiceMock),
+}));
+
+jest.mock('@users/services/account.service', () => ({
+  AccountService: jest.fn().mockImplementation(() => ({})),
+}));
+
+import { AccountController } from '@users/controllers/account.controller';
+import { ResponseHandler } from '@shared/response-handler';
+import { ILogger } from '@shared/logger.interface';
+import { UserService } from '@users/services/user.service';
+import { AccountService } from '@users/services/account.service';
+
+describe('AccountController register endpoints', () => {
+  let controller: AccountController;
+  let mockRes: Response;
+
+  const loggerMock = {
+    context: '',
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  } as unknown as ILogger;
+
+  const authResponse = {
+    user: { id: 'user-1', email: 'john@example.com' },
+    token: 'jwt-token',
+    refreshToken: 'refresh-token',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockRes = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    } as unknown as Response;
+
+    const userServiceInstance = new (UserService as jest.Mock)() as UserService;
+    const accountServiceInstance = new (AccountService as jest.Mock)() as AccountService;
+    controller = new AccountController(loggerMock, userServiceInstance, accountServiceInstance);
+
+    jest.spyOn(ResponseHandler, 'created');
+  });
+
+  it('registerLocal responds with user, token, and refreshToken', async () => {
+    userServiceMock.registerLocal.mockResolvedValue(authResponse);
+    const req = {
+      body: {
+        accountId: '123e4567-e89b-42d3-a456-426614174000',
+        email: 'john@example.com',
+        username: 'john_doe',
+        password: 'Password123',
+      },
+    } as Request;
+
+    await controller.registerLocal(req, mockRes);
+
+    expect(ResponseHandler.created).toHaveBeenCalledWith(mockRes, 'http:created', {
+      user: authResponse.user,
+      token: authResponse.token,
+      refreshToken: authResponse.refreshToken,
+    });
+  });
+
+  it('registerWithProvider responds with user, token, and refreshToken', async () => {
+    userServiceMock.registerWithProvider.mockResolvedValue(authResponse);
+    const req = {
+      body: {
+        accountId: '123e4567-e89b-42d3-a456-426614174000',
+        email: 'alice@example.com',
+        username: 'alice',
+        provider: 'google',
+        providerId: 'prov-1',
+      },
+    } as Request;
+
+    await controller.registerWithProvider(req, mockRes);
+
+    expect(ResponseHandler.created).toHaveBeenCalledWith(mockRes, 'http:created', {
+      user: authResponse.user,
+      token: authResponse.token,
+      refreshToken: authResponse.refreshToken,
+    });
+  });
+});

--- a/src/main/docs/modules/accounts.paths.ts
+++ b/src/main/docs/modules/accounts.paths.ts
@@ -4,11 +4,6 @@ import { endpoint } from '../helpers/path-builder';
 import { TAG } from '../tags';
 import { Schemas } from '../schema-registry';
 
-const TokenResponse = z.object({
-  user: z.unknown(),
-  token: z.string(),
-});
-
 export function registerAccountsPaths(registry: OpenAPIRegistry): void {
   endpoint('post', '/api/accounts')
     .tag(TAG.ACCOUNTS)
@@ -65,7 +60,7 @@ export function registerAccountsPaths(registry: OpenAPIRegistry): void {
     .description('Creates a user account with email/password authentication within an existing account.')
     .operationId('registerLocal')
     .requestBody(Schemas.UserRegisterDTO)
-    .response(200, 'User registered successfully', TokenResponse)
+    .response(201, 'User registered successfully', Schemas.AuthResponseWithRefreshDTO)
     .errors(400)
     .register(registry);
 
@@ -75,7 +70,7 @@ export function registerAccountsPaths(registry: OpenAPIRegistry): void {
     .description('Authenticates a user via OAuth provider (google, facebook). Creates the user if they do not exist.')
     .operationId('registerProvider')
     .requestBody(Schemas.ProviderRegistrationDTO)
-    .response(200, 'User authenticated via provider', TokenResponse)
+    .response(201, 'User authenticated via provider', Schemas.AuthResponseWithRefreshDTO)
     .errors(400, 401)
     .register(registry);
 }

--- a/src/main/docs/modules/auth.paths.ts
+++ b/src/main/docs/modules/auth.paths.ts
@@ -1,23 +1,15 @@
 import { OpenAPIRegistry } from '@asteasolutions/zod-to-openapi';
-import { z } from 'zod';
 import { endpoint } from '../helpers/path-builder';
 import { TAG } from '../tags';
 import { Schemas } from '../schema-registry';
 
-const AuthResponseSchema = z.object({
-  user: z.unknown().openapi({ description: 'Authenticated user object' }),
-  token: z.string().openapi({ description: 'JWT access token', example: 'eyJhbGciOiJIUzI1NiIs...' }),
-});
-
 export function registerAuthPaths(registry: OpenAPIRegistry): void {
-  const AuthResponse = registry.register('AuthResponseDTO', AuthResponseSchema);
-
   endpoint('post', '/api/auth/login')
     .tag(TAG.AUTH)
     .summary('Login with username and password')
     .operationId('login')
     .requestBody(Schemas.UserLoginDTO)
-    .response(200, 'Successful login with JWT token', AuthResponse)
+    .response(200, 'Successful login with JWT and refresh tokens', Schemas.AuthResponseWithRefreshDTO)
     .errors(400, 401)
     .register(registry);
 }

--- a/src/main/users/controllers/account.controller.ts
+++ b/src/main/users/controllers/account.controller.ts
@@ -74,6 +74,7 @@ export class AccountController {
       ResponseHandler.created(res, 'http:created', {
         user: authResponse.user,
         token: authResponse.token,
+        refreshToken: authResponse.refreshToken,
       });
     } catch (err: unknown) {
       const errorName = err instanceof Error ? err.name : 'Unknown';
@@ -109,6 +110,7 @@ export class AccountController {
       ResponseHandler.created(res, 'http:created', {
         user: authResponse.user,
         token: authResponse.token,
+        refreshToken: authResponse.refreshToken,
       });
     } catch (err: unknown) {
       const errorName = err instanceof Error ? err.name : 'Unknown';

--- a/src/main/users/services/user.service.ts
+++ b/src/main/users/services/user.service.ts
@@ -278,18 +278,6 @@ export class UserService {
 
       this._log.debug('User registered successfully', { userId: createdUser.id, email });
 
-      const token = this._tokenService.generateToken(
-        createdUser.id,
-        createdUser.accountId,
-        (createdUser.roles || []).map((r: any) => r.name),
-      );
-
-      // Issue refresh token
-      let refreshToken: string | undefined;
-      if (this._tokenMgmt) {
-        refreshToken = await this._tokenMgmt.issueRefreshToken(createdUser.id);
-      }
-
       // Enqueue email verification
       if (this._emailVerify) {
         try {
@@ -299,7 +287,7 @@ export class UserService {
         }
       }
 
-      return { user: this._userMapper.toDTO(createdUser)!, token, refreshToken };
+      return this.buildAuthResponse(createdUser);
     } catch (err: any) {
       if (isPrismaUniqueConstraintError(err)) {
         // Handle race condition: email/username created concurrently

--- a/src/main/users/services/user.service.ts
+++ b/src/main/users/services/user.service.ts
@@ -6,7 +6,7 @@ import { ConflictError } from '@users/errors/conflict.error';
 import { UserNotFoundError } from '@users/errors/user-not-found.error';
 import { UserMapper } from '@users/mappers';
 import { isPrismaUniqueConstraintError } from '@users/custom-prisma-client';
-import { UserRepository } from '@users/repositories';
+import { UserRepository, UserWithRoles } from '@users/repositories';
 import { UserIdentityRepository } from '@users/repositories/user-identity.repository';
 import { inject, injectable } from 'inversify';
 import { PasswordHasher } from '@shared/security/password-hasher.serice';
@@ -49,6 +49,28 @@ export class UserService {
     });
 
     return defaultRole ? [defaultRole.id] : [];
+  }
+
+  /**
+   * Builds the auth response for a successfully authenticated user: generates
+   * the JWT access token and, when TokenManagementService is available, issues
+   * an opaque refresh token (30-day expiry).
+   *
+   * @param user - User with roles, as returned by the repository.
+   * @param provider - Optional OAuth provider name embedded in the JWT.
+   * @param providerId - Optional provider-specific user id embedded in the JWT.
+   * @returns Auth response with user DTO, JWT, and refresh token (if issued).
+   */
+  private async buildAuthResponse(user: UserWithRoles, provider?: string, providerId?: string): Promise<AuthResponseDTO> {
+    const token = this._tokenService.generateToken(
+      user.id,
+      user.accountId,
+      (user.roles || []).map(r => r.name),
+      provider,
+      providerId,
+    );
+    const refreshToken = this._tokenMgmt ? await this._tokenMgmt.issueRefreshToken(user.id) : undefined;
+    return { user: this._userMapper.toDTO(user)!, token, refreshToken };
   }
 
   /**
@@ -100,14 +122,7 @@ export class UserService {
     if (existingIdentity) {
       const user = await this._userRepository.findByIdWithRoles(existingIdentity.userId);
       if (!user) throw new UserNotFoundError('Linked user not found');
-      const token = this._tokenService.generateToken(
-        user.id,
-        user.accountId,
-        (user.roles || []).map(r => r.name),
-        data.provider,
-        providerId,
-      );
-      return { user: this._userMapper.toDTO(user)!, token };
+      return this.buildAuthResponse(user, data.provider, providerId);
     }
 
     // 2) Try to find user by email (link identity if exists)
@@ -129,14 +144,7 @@ export class UserService {
           if (identityNow) {
             const user = await this._userRepository.findByIdWithRoles(identityNow.userId);
             if (!user) throw new UserNotFoundError('Linked user not found');
-            const token = this._tokenService.generateToken(
-              user.id,
-              user.accountId,
-              (user.roles || []).map(r => r.name),
-              data.provider,
-              providerId,
-            );
-            return { user: this._userMapper.toDTO(user)!, token };
+            return this.buildAuthResponse(user, data.provider, providerId);
           }
         }
         throw err;
@@ -154,14 +162,7 @@ export class UserService {
 
       const user = await this._userRepository.findByIdWithRoles(userByEmail.id);
       if (!user) throw new UserNotFoundError('Linked user not found');
-      const token = this._tokenService.generateToken(
-        user.id,
-        user.accountId,
-        (user.roles || []).map(r => r.name),
-        data.provider,
-        providerId,
-      );
-      return { user: this._userMapper.toDTO(user)!, token };
+      return this.buildAuthResponse(user, data.provider, providerId);
     }
 
     // 3) No user by email -> create user + identity atomically
@@ -186,16 +187,7 @@ export class UserService {
       }
 
       // Optionally persist profile fields (displayName, picture) if your mapper/repo supports it.
-      const userDTO = this._userMapper.toDTO(createdUser)!;
-      const token = this._tokenService.generateToken(
-        createdUser.id,
-        createdUser.accountId,
-        (createdUser.roles || []).map(r => r.name),
-        data.provider,
-        providerId,
-      );
-
-      return { user: userDTO, token };
+      return this.buildAuthResponse(createdUser, data.provider, providerId);
     } catch (err: any) {
       if (isPrismaUniqueConstraintError(err)) {
         // Could be username/email concurrently created. Translate to Conflict for controller.

--- a/swagger.json
+++ b/swagger.json
@@ -2286,23 +2286,6 @@
           "userId"
         ]
       },
-      "AuthResponseDTO": {
-        "type": "object",
-        "properties": {
-          "user": {
-            "nullable": true,
-            "description": "Authenticated user object"
-          },
-          "token": {
-            "type": "string",
-            "description": "JWT access token",
-            "example": "eyJhbGciOiJIUzI1NiIs..."
-          }
-        },
-        "required": [
-          "token"
-        ]
-      },
       "BotsOkResponse": {
         "type": "object",
         "properties": {
@@ -2348,11 +2331,11 @@
         },
         "responses": {
           "200": {
-            "description": "Successful login with JWT token",
+            "description": "Successful login with JWT and refresh tokens",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AuthResponseDTO"
+                  "$ref": "#/components/schemas/AuthResponseWithRefresh"
                 }
               }
             }
@@ -3188,23 +3171,12 @@
           }
         },
         "responses": {
-          "200": {
+          "201": {
             "description": "User registered successfully",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "user": {
-                      "nullable": true
-                    },
-                    "token": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "token"
-                  ]
+                  "$ref": "#/components/schemas/AuthResponseWithRefresh"
                 }
               }
             }
@@ -3282,23 +3254,12 @@
           }
         },
         "responses": {
-          "200": {
+          "201": {
             "description": "User authenticated via provider",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "user": {
-                      "nullable": true
-                    },
-                    "token": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "token"
-                  ]
+                  "$ref": "#/components/schemas/AuthResponseWithRefresh"
                 }
               }
             }


### PR DESCRIPTION
## Summary
- `registerWithProvider` now issues a refresh token on all four auth paths (existing identity, concurrent race, email link, new user) via a new private `buildAuthResponse()` helper in `UserService`
- Both register endpoints (`/api/accounts/register/local`, `/api/accounts/register/provider`) return `refreshToken` — provider-created users (no password) previously had no way to obtain one, and local registration persisted an orphaned token it never returned
- OpenAPI: login + register responses now reference `AuthResponseWithRefresh`; register status corrected to 201; `swagger.json` regenerated

## Test plan
- [ ] `npm run test` (unit: provider 4 paths + no-tokenMgmt fallback, registerLocal refresh assertion, new controller shaping tests)
- [ ] `npm run docs:validate`
- [ ] CI `Lint, test, build` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)