### PR TITLE
fix(users): trigger family revocation on refresh token reuse

### DIFF
--- a/src/__tests__/integration/refresh-token.test.ts
+++ b/src/__tests__/integration/refresh-token.test.ts
@@ -134,4 +134,30 @@ describe('POST /api/auth/refresh', () => {
     const secondUse = await request(app).post('/api/auth/refresh').send({ refreshToken: freshToken });
     expect(secondUse.status).toBe(400);
   });
+
+  it('should revoke the entire family when a consumed token is replayed (theft detection)', async () => {
+    const freshToken = await tokenMgmt.issueRefreshToken(testUserId);
+
+    // Rotate: freshToken is consumed, rotatedToken is the active descendant
+    const firstUse = await request(app).post('/api/auth/refresh').send({ refreshToken: freshToken });
+    expect(firstUse.status).toBe(200);
+    const rotatedToken = firstUse.body.data.refreshToken as string;
+
+    // Replay the consumed token — theft detected
+    const replay = await request(app).post('/api/auth/refresh').send({ refreshToken: freshToken });
+    expect(replay.status).toBe(400);
+
+    // The whole family must be dead: the rotated descendant is rejected too
+    const useDescendant = await request(app).post('/api/auth/refresh').send({ refreshToken: rotatedToken });
+    expect(useDescendant.status).toBe(400);
+  });
+
+  it('should return 400 when reusing a token revoked by revokeRefreshToken (logout)', async () => {
+    const freshToken = await tokenMgmt.issueRefreshToken(testUserId);
+
+    await tokenMgmt.revokeRefreshToken(freshToken);
+
+    const res = await request(app).post('/api/auth/refresh').send({ refreshToken: freshToken });
+    expect(res.status).toBe(400);
+  });
 });

--- a/src/__tests__/unit/token-management.service.test.ts
+++ b/src/__tests__/unit/token-management.service.test.ts
@@ -78,6 +78,7 @@ describe('TokenManagementService', () => {
       tokenRepo.findRefreshTokenByHash.mockResolvedValue({
         ...storedToken,
         replacedBy: 'token-2',
+        revokedAt: now,
       });
       tokenRepo.revokeRefreshTokenFamily.mockResolvedValue();
 
@@ -85,6 +86,31 @@ describe('TokenManagementService', () => {
 
       expect(result).toBeNull();
       expect(tokenRepo.revokeRefreshTokenFamily).toHaveBeenCalledWith('family-1');
+    });
+
+    it('should return null without revoking the family when token is revoked but not replaced', async () => {
+      tokenRepo.findRefreshTokenByHash.mockResolvedValue({
+        ...storedToken,
+        revokedAt: now,
+      });
+
+      const result = await svc.rotateRefreshToken('revoked-token');
+
+      expect(result).toBeNull();
+      expect(tokenRepo.revokeRefreshTokenFamily).not.toHaveBeenCalled();
+      expect(tokenRepo.createRefreshToken).not.toHaveBeenCalled();
+    });
+
+    it('should return null when token is expired', async () => {
+      tokenRepo.findRefreshTokenByHash.mockResolvedValue({
+        ...storedToken,
+        expiresAt: new Date(now.getTime() - 1000),
+      });
+
+      const result = await svc.rotateRefreshToken('expired-token');
+
+      expect(result).toBeNull();
+      expect(tokenRepo.createRefreshToken).not.toHaveBeenCalled();
     });
 
     it('should return user context alongside the new token on success', async () => {
@@ -161,6 +187,53 @@ describe('TokenManagementService', () => {
       const r = result as IRefreshTokenResult;
       expect(r.roles).toContain('ACCOUNT_OWNER');
       expect(r.roles).toContain('SUPER_ADMIN');
+    });
+  });
+
+  describe('revokeRefreshToken', () => {
+    const now = new Date();
+    const future = new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000);
+
+    it('should revoke an active token by its raw value', async () => {
+      tokenRepo.findRefreshTokenByHash.mockResolvedValue({
+        id: 'token-1',
+        userId: 'user-1',
+        tokenHash: 'hash-1',
+        family: 'family-1',
+        replacedBy: null,
+        revokedAt: null,
+        expiresAt: future,
+        createdAt: now,
+      });
+
+      await svc.revokeRefreshToken('active-token');
+
+      expect(tokenRepo.revokeRefreshToken).toHaveBeenCalledWith('token-1');
+    });
+
+    it('should not re-revoke an already-revoked token', async () => {
+      tokenRepo.findRefreshTokenByHash.mockResolvedValue({
+        id: 'token-1',
+        userId: 'user-1',
+        tokenHash: 'hash-1',
+        family: 'family-1',
+        replacedBy: null,
+        revokedAt: now,
+        expiresAt: future,
+        createdAt: now,
+      });
+
+      await svc.revokeRefreshToken('already-revoked-token');
+
+      expect(tokenRepo.revokeRefreshToken).not.toHaveBeenCalled();
+    });
+
+    it('should do nothing when the token does not exist', async () => {
+      tokenRepo.findRefreshTokenByHash.mockResolvedValue(null);
+
+      await svc.revokeRefreshToken('unknown-token');
+
+      expect(tokenRepo.revokeRefreshToken).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/main/users/repositories/token.repository.ts
+++ b/src/main/users/repositories/token.repository.ts
@@ -70,9 +70,14 @@ export class TokenRepository {
     return this._prisma.refreshToken.create({ data });
   }
 
+  /**
+   * Finds a refresh token by hash regardless of state (revoked, replaced, expired).
+   * State interpretation belongs to the caller — theft detection needs to see
+   * already-replaced tokens, which a `revokedAt: null` filter would hide.
+   */
   public async findRefreshTokenByHash(tokenHash: string): Promise<RefreshToken | null> {
     return this._prisma.refreshToken.findFirst({
-      where: { tokenHash, revokedAt: null, expiresAt: { gt: new Date() } },
+      where: { tokenHash },
     });
   }
 

--- a/src/main/users/services/token-management.service.ts
+++ b/src/main/users/services/token-management.service.ts
@@ -63,11 +63,13 @@ export class TokenManagementService {
     const stored = await this._tokenRepo.findRefreshTokenByHash(tokenHash);
 
     if (!stored) {
-      this._log.warn('Refresh token not found or expired');
+      this._log.warn('Refresh token not found');
       return null;
     }
 
-    // Theft detection: if this token was already replaced, revoke the whole family
+    // Theft detection: if this token was already replaced, revoke the whole family.
+    // Checked before the revoked/expired guards — a replaced token is also revoked,
+    // and reuse must trigger family revocation, not a generic rejection.
     if (stored.replacedBy) {
       this._log.warn('Refresh token reuse detected — revoking entire family', {
         userId: stored.userId,
@@ -77,6 +79,16 @@ export class TokenManagementService {
       if (stored.family) {
         await this._tokenRepo.revokeRefreshTokenFamily(stored.family);
       }
+      return null;
+    }
+
+    if (stored.revokedAt) {
+      this._log.warn('Refresh token is revoked', { userId: stored.userId, tokenId: stored.id });
+      return null;
+    }
+
+    if (stored.expiresAt <= new Date()) {
+      this._log.warn('Refresh token is expired', { userId: stored.userId, tokenId: stored.id });
       return null;
     }
 
@@ -129,7 +141,7 @@ export class TokenManagementService {
   public async revokeRefreshToken(rawToken: string): Promise<void> {
     const tokenHash = this._hashToken(rawToken);
     const stored = await this._tokenRepo.findRefreshTokenByHash(tokenHash);
-    if (stored) {
+    if (stored && !stored.revokedAt) {
       await this._tokenRepo.revokeRefreshToken(stored.id);
     }
   }


### PR DESCRIPTION
## Problem

The refresh-token theft detection documented in `TokenManagementService` was **dead code**. Replaying an already-rotated token returned a generic 400 but never revoked the token family — the stolen chain stayed alive.

**Root cause:** `replaceRefreshToken` sets `revokedAt` on the consumed token, while `findRefreshTokenByHash` filtered `revokedAt: null`. A replayed token was therefore never *found*, so the `stored.replacedBy` branch could never execute. The existing unit test passed only because it mocked the repository returning a state the real query could never produce.

Discovered during live testing of #55 (reuse of a rotated token → 400, but the rotated descendant kept working).

## Fix

- `TokenRepository.findRefreshTokenByHash` is now a pure hash lookup (no state filter) — state interpretation belongs to the service.
- `TokenManagementService.rotateRefreshToken` checks in order: `replacedBy` (theft → revoke entire family) → `revokedAt` (reject) → expired (reject) → rotate.
- `revokeRefreshToken` no longer re-revokes an already-revoked token (would overwrite the original `revokedAt` timestamp).

## Tests

- Integration (`refresh-token.test.ts`): replaying a consumed token now kills the whole family — the rotated descendant is rejected too (this test fails on `develop`); reuse after logout-revocation rejected.
- Unit (`token-management.service.test.ts`): revoked-not-replaced → reject without family revocation; expired → reject; re-revoke guard.
- Full suite: 88 suites / 938 tests green. Lint, prettier, build clean. No API-surface change (`swagger.json` regenerates identically).

🤖 Generated with [Claude Code](https://claude.com/claude-code)